### PR TITLE
 #22: Implement ReaderAssert in a similar way as InputStreamAssert 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in contributing to AssertJ assertions!
 
 We appreciate your effort and to make sure that your pull request is easy to review, we ask you to make note of the following guidelines:
 
+* If you contribute to Java 8 feature, please work in java-8 branch.
 * Use **[AssertJ code Eclipse formatting preferences](src/ide-support/assertj-eclipse-formatter.xml)** (for IntelliJ IDEA users, you can import it)
 * Write complete Javadocs for each assertion method and include a code example.
 * Write one JUnit test class for each assertion method with the following naming convention: `<AssertClass>_<assertion>_Test`.
@@ -39,7 +40,7 @@ A good javadoc example taken from [`AbstractCharSequenceAssert.containsSequence`
  * <p>
  * Example:
  *
- * <pre>
+ * <pre><code class='java'>
  * String book = "{ 'title':'A Game of Thrones', 'author':'George Martin'}";
  *
  * // this assertion succeeds ...
@@ -47,7 +48,7 @@ A good javadoc example taken from [`AbstractCharSequenceAssert.containsSequence`
  *
  * // ... but this one fails as "author" must come after "A Game of Thrones"
  * assertThat(book).containsSequence("{", "author", "A Game of Thrones", "}");
- * </pre>
+ * </code></pre>
  *
  * @param values the Strings to look for, in order.
  * @return {@code this} assertion object.

--- a/src/main/java/org/assertj/core/api/AbstractReaderAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractReaderAssert.java
@@ -1,0 +1,44 @@
+package org.assertj.core.api;
+
+import java.io.Reader;
+
+import org.assertj.core.internal.Readers;
+import org.assertj.core.util.VisibleForTesting;
+
+/**
+ * Base class for all implementations of assertions for {@link java.io.Reader}s.
+ * 
+ * @param <S> the "self" type of this assertion class. Please read &quot;<a href="http://bit.ly/anMa4g"
+ *          target="_blank">Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
+ *          for more details.
+ * @param <A> the type of the "actual" value.
+ *
+ * @author Matthieu Baechler
+ * @author Mikhail Mazursky
+ * @author Bartosz Bierkowski
+ */
+public abstract class AbstractReaderAssert<S extends AbstractReaderAssert<S, A>, A extends Reader> extends
+    AbstractAssert<S, A> {
+
+  @VisibleForTesting
+  Readers readers = Readers.instance();
+
+  protected AbstractReaderAssert(A actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  /**
+   * Verifies that the content of the actual {@code Reader} is equal to the content of the given one.
+   *
+   * @param expected the given {@code Reader} to compare the actual {@code Reader} to.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given {@code Reader} is {@code null}.
+   * @throws AssertionError if the actual {@code Reader} is {@code null}.
+   * @throws AssertionError if the content of the actual {@code Reader} is not equal to the content of the given one.
+   * @throws org.assertj.core.internal.ReadersException if an I/O error occurs.
+   */
+  public S hasContentEqualTo(Reader expected) {
+    readers.assertEqualContent(info, actual, expected);
+    return myself;
+  }
+}

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -17,6 +17,7 @@ package org.assertj.core.api;
 
 import java.io.File;
 import java.io.InputStream;
+import java.io.Reader;
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
@@ -259,6 +260,7 @@ public class Assertions {
     return new InputStreamAssert(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link FloatAssert}</code>.
    *
@@ -357,6 +359,16 @@ public class Assertions {
    */
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return new LongArrayAssert(actual);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ReaderAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractReaderAssert<?, ? extends Reader> assertThat(Reader actual) {
+    return new ReaderAssert(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/ReaderAssert.java
+++ b/src/main/java/org/assertj/core/api/ReaderAssert.java
@@ -1,0 +1,21 @@
+package org.assertj.core.api;
+
+import java.io.Reader;
+
+/**
+ * Assertion methods for {@link java.io.Reader}s.
+ * <p>
+ * To create a new instance of this class, invoke
+ * <code>{@link org.assertj.core.api.Assertions#assertThat(java.io.Reader)}</code>.
+ * </p>
+ * 
+ * @author Matthieu Baechler
+ * @author Mikhail Mazursky
+ * @author Bartosz Bierkowski
+ */
+public class ReaderAssert extends AbstractReaderAssert<ReaderAssert, Reader> {
+
+  public ReaderAssert(Reader actual) {
+    super(actual, ReaderAssert.class);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldHaveEqualContent.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveEqualContent.java
@@ -1,35 +1,50 @@
 /*
  * Created on Jan 28, 2011
  * 
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
- * License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
  * 
  * http://www.apache.org/licenses/LICENSE-2.0
  * 
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
- * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
- * governing permissions and limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
  * 
  * Copyright @2011 the original author or authors.
  */
 package org.assertj.core.error;
 
-
 import java.io.File;
 import java.io.InputStream;
+import java.io.Reader;
 import java.util.List;
 
 /**
- * Creates an error message indicating that an assertion that verifies that two files/inputStreams have equal content failed.
- * 
+ * Creates an error message indicating that an assertion that verifies that two files/inputStreams/readers have equal
+ * content failed.
+ *
  * @author Yvonne Wang
  * @author Matthieu Baechler
  * @author Joel Costigliola
+ * @author Bartosz Bierkowski
  */
 public class ShouldHaveEqualContent extends AbstractShouldHaveTextContent {
 
   /**
    * Creates a new <code>{@link ShouldHaveEqualContent}</code>.
+   * 
+   * @param actual the actual reader in the failed assertion.
+   * @param expected the expected reader in the failed assertion.
+   * @param diffs the differences between {@code actual} and {@code expected}.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldHaveEqualContent(Reader actual, Reader expected, List<String> diffs) {
+    return new ShouldHaveEqualContent(actual, expected, diffsAsString(diffs));
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldHaveEqualContent}</code>.
+   * 
    * @param actual the actual file in the failed assertion.
    * @param expected the expected file in the failed assertion.
    * @param diffs the differences between {@code actual} and {@code expected}.
@@ -41,6 +56,7 @@ public class ShouldHaveEqualContent extends AbstractShouldHaveTextContent {
 
   /**
    * Creates a new <code>{@link ShouldHaveEqualContent}</code>.
+   * 
    * @param actual the actual InputStream in the failed assertion.
    * @param expected the expected Stream in the failed assertion.
    * @param diffs the differences between {@code actual} and {@code expected}.
@@ -57,6 +73,11 @@ public class ShouldHaveEqualContent extends AbstractShouldHaveTextContent {
 
   private ShouldHaveEqualContent(InputStream actual, InputStream expected, String diffs) {
     super("\nInputStreams do not have equal content:", actual, expected);
+    this.diffs = diffs;
+  }
+
+  private ShouldHaveEqualContent(Reader actual, Reader expected, String diffs) {
+    super("\nReaders do not have equal content:", actual, expected);
     this.diffs = diffs;
   }
 }

--- a/src/main/java/org/assertj/core/internal/Readers.java
+++ b/src/main/java/org/assertj/core/internal/Readers.java
@@ -1,0 +1,84 @@
+/*
+ * Created on Jan 26, 2011
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import static java.lang.String.format;
+import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.List;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.util.VisibleForTesting;
+
+/**
+ * Reusable assertions for <code>{@link java.io.Reader}</code>s.
+ *
+ * @author Matthieu Baechler
+ * @author Bartosz Bierkowski
+ */
+public class Readers {
+
+  private static final Readers INSTANCE = new Readers();
+
+  /**
+   * Returns the singleton instance of this class.
+   * 
+   * @return the singleton instance of this class.
+   */
+  public static Readers instance() {
+    return INSTANCE;
+  }
+
+  @VisibleForTesting
+  Diff diff = new Diff();
+  @VisibleForTesting
+  Failures failures = Failures.instance();
+
+  @VisibleForTesting
+  Readers() {
+  }
+
+  /**
+   * Asserts that the given Readers have equal content.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the "actual" Reader.
+   * @param expected the "expected" Reader.
+   * @throws NullPointerException if {@code expected} is {@code null}.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws AssertionError if the given Readers do not have equal content.
+   * @throws org.assertj.core.internal.ReadersException if an I/O error occurs.
+   */
+  public void assertEqualContent(AssertionInfo info, Reader actual, Reader expected) {
+    if (expected == null)
+      throw new NullPointerException("The Reader to compare to should not be null");
+    assertNotNull(info, actual);
+    try {
+      List<String> diffs = diff.diff(actual, expected);
+      if (diffs.isEmpty())
+        return;
+      throw failures.failure(info, shouldHaveEqualContent(actual, expected, diffs));
+    } catch (IOException e) {
+      String msg = format("Unable to compare contents of Readers:\n  <%s>\nand:\n  <%s>", actual, expected);
+      throw new ReadersException(msg, e);
+    }
+  }
+
+  private static void assertNotNull(AssertionInfo info, Reader reader) {
+    Objects.instance().assertNotNull(info, reader);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/ReadersException.java
+++ b/src/main/java/org/assertj/core/internal/ReadersException.java
@@ -1,0 +1,45 @@
+/*
+ * Created on May 16, 2007
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2007-2011 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+/**
+ * Exception thrown by <code>{@link org.assertj.core.internal.Readers}</code>.
+ *
+ * @author Matthieu Baechler
+ * @author Bartosz Bierkowski
+ */
+public class ReadersException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Creates a new <code>{@link org.assertj.core.internal.ReadersException}</code>.
+   * 
+   * @param message the detail message.
+   */
+  public ReadersException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates a new <code>{@link org.assertj.core.internal.ReadersException}</code>.
+   * 
+   * @param message the detail message.
+   * @param cause the cause of the error.
+   */
+  public ReadersException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Reader_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_assertThat_with_Reader_Test.java
@@ -1,0 +1,52 @@
+/*
+ * Created on Jan 28, 2011
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.Assertions#assertThat(java.io.Reader)}</code>.
+ *
+ * @author Matthieu Baechler
+ * @author Bartosz Bierkowski
+ */
+public class Assertions_assertThat_with_Reader_Test {
+
+  private static Reader actual;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    actual = new StringReader("");
+  }
+
+  @Test
+  public void should_create_Assert() {
+    AbstractReaderAssert<?, ? extends Reader> assertions = Assertions.assertThat(actual);
+    assertNotNull(assertions);
+  }
+
+  @Test
+  public void should_pass_actual() {
+    AbstractReaderAssert<?, ? extends Reader> assertions = Assertions.assertThat(actual);
+    assertSame(actual, assertions.actual);
+  }
+}

--- a/src/test/java/org/assertj/core/api/ReaderAssertBaseTest.java
+++ b/src/test/java/org/assertj/core/api/ReaderAssertBaseTest.java
@@ -1,0 +1,49 @@
+/*
+ * Created on Aug 02, 2012
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2010-2011 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.assertj.core.internal.Readers;
+
+/**
+ * Base class for {@link org.assertj.core.api.ReaderAssert} tests.
+ *
+ * @author Joel Costigliola
+ * @author Bartosz Bierkowski
+ */
+public abstract class ReaderAssertBaseTest extends BaseTestTemplate<ReaderAssert, Reader> {
+  protected Readers readers;
+
+  @Override
+  protected ReaderAssert create_assertions() {
+    return new ReaderAssert(new StringReader("a"));
+  }
+
+  @Override
+  protected void inject_internal_objects() {
+    super.inject_internal_objects();
+    readers = mock(Readers.class);
+    assertions.readers = readers;
+  }
+
+  protected Readers getReaders(ReaderAssert someAssertions) {
+    return someAssertions.readers;
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/reader/ReaderAssert_hasContentEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/reader/ReaderAssert_hasContentEqualTo_Test.java
@@ -1,0 +1,52 @@
+/*
+ * Created on Jan 28, 2011
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.assertj.core.api.reader;
+
+import static org.mockito.Mockito.verify;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.assertj.core.api.ReaderAssert;
+import org.assertj.core.api.ReaderAssertBaseTest;
+import org.junit.BeforeClass;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.ReaderAssert#hasContentEqualTo(java.io.Reader)}</code>.
+ *
+ * @author Matthieu Baechler
+ * @author Joel Costigliola
+ * @author Bartosz Bierkowski
+ */
+public class ReaderAssert_hasContentEqualTo_Test extends ReaderAssertBaseTest {
+
+  private static Reader expected;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    expected = new StringReader("b");
+  }
+
+  @Override
+  protected ReaderAssert invoke_api_method() {
+    return assertions.hasContentEqualTo(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(readers).assertEqualContent(getInfo(assertions), getActual(assertions), expected);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/ReadersBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/ReadersBaseTest.java
@@ -1,0 +1,51 @@
+package org.assertj.core.internal;
+
+import static org.assertj.core.test.ExpectedException.none;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.io.Reader;
+import java.io.StringReader;
+
+import org.assertj.core.test.ExpectedException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+
+/**
+ * Base class for {@link org.assertj.core.internal.Readers} unit tests
+ * <p>
+ * Is in <code>org.assertj.core.internal</code> package to be able to set {@link org.assertj.core.internal.Readers}
+ * attributes appropriately.
+ *
+ * @author Joel Costigliola
+ * @author Bartosz Bierkowski
+ *
+ */
+public class ReadersBaseTest {
+
+  @Rule
+  public ExpectedException thrown = none();
+  protected Diff diff;
+  protected Failures failures;
+  protected Readers readers;
+
+  protected static Reader actual;
+  protected static Reader expected;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    actual = new StringReader("");
+    expected = new StringReader("");
+  }
+
+  @Before
+  public void setUp() {
+    diff = mock(Diff.class);
+    failures = spy(new Failures());
+    readers = new Readers();
+    readers.diff = diff;
+    readers.failures = failures;
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/readers/Diff_diff_Reader_Test.java
+++ b/src/test/java/org/assertj/core/internal/readers/Diff_diff_Reader_Test.java
@@ -1,0 +1,91 @@
+/*
+ * Created on Jan 28, 2011
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.assertj.core.internal.readers;
+
+import static junit.framework.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+import org.assertj.core.internal.Diff;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests for <code>{@link org.assertj.core.internal.Diff#diff(java.io.Reader, java.io.Reader)}</code>.
+ * 
+ * @author Matthieu Baechler
+ * @author Bartosz Bierkowski
+ */
+public class Diff_diff_Reader_Test {
+
+  private final static String LINE_SEPARATOR = System.getProperty("line.separator");
+  private static Diff diff;
+
+  @BeforeClass
+  public static void setUpOnce() {
+    diff = new Diff();
+  }
+
+  private Reader actual;
+  private Reader expected;
+
+  private Reader reader(String... lines) throws UnsupportedEncodingException {
+    StringBuilder stringBuilder = new StringBuilder();
+    for (String line : lines) {
+      stringBuilder.append(line).append(LINE_SEPARATOR);
+    }
+    return new StringReader(stringBuilder.toString());
+  }
+
+  @Test
+  public void should_return_empty_diff_list_if_readers_have_equal_content() throws IOException {
+    actual = reader("base", "line0", "line1");
+    expected = reader("base", "line0", "line1");
+    List<String> diffs = diff.diff(actual, expected);
+    assertEquals(0, diffs.size());
+  }
+
+  @Test
+  public void should_return_diffs_if_readers_do_not_have_equal_content() throws IOException {
+    actual = reader("base", "line_0", "line_1");
+    expected = reader("base", "line0", "line1");
+    List<String> diffs = diff.diff(actual, expected);
+    assertEquals(2, diffs.size());
+    assertEquals("line:<2>, expected:<line0> but was:<line_0>", diffs.get(0));
+    assertEquals("line:<3>, expected:<line1> but was:<line_1>", diffs.get(1));
+  }
+
+  @Test
+  public void should_return_diffs_if_content_of_actual_is_shorter_than_content_of_expected() throws IOException {
+    actual = reader("base", "line_0");
+    expected = reader("base", "line_0", "line_1");
+    List<String> diffs = diff.diff(actual, expected);
+    assertEquals(1, diffs.size());
+    assertEquals("line:<3>, expected:<line_1> but was:<EOF>", diffs.get(0));
+  }
+
+  @Test
+  public void should_return_diffs_if_content_of_actual_is_longer_than_content_of_expected() throws IOException {
+    actual = reader("base", "line_0", "line_1");
+    expected = reader("base", "line_0");
+    List<String> diffs = diff.diff(actual, expected);
+    assertEquals(1, diffs.size());
+    assertEquals("line:<3>, expected:<EOF> but was:<line_1>", diffs.get(0));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/readers/Readers_assertEqualContent_Test.java
+++ b/src/test/java/org/assertj/core/internal/readers/Readers_assertEqualContent_Test.java
@@ -1,0 +1,89 @@
+/*
+ * Created on Jan 27, 2011
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ * 
+ * Copyright @2011 the original author or authors.
+ */
+package org.assertj.core.internal.readers;
+
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.fail;
+import static org.assertj.core.error.ShouldHaveEqualContent.shouldHaveEqualContent;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.test.TestFailures.failBecauseExpectedAssertionErrorWasNotThrown;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ReadersBaseTest;
+import org.assertj.core.internal.ReadersException;
+import org.junit.Test;
+
+/**
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Readers#assertEqualContent(org.assertj.core.api.AssertionInfo, java.io.Reader, java.io.Reader)}</code>
+ * .
+ * 
+ * @author Matthieu Baechler
+ * @author Bartosz Bierkowski
+ */
+public class Readers_assertEqualContent_Test extends ReadersBaseTest {
+
+  @Test
+  public void should_throw_error_if_expected_is_null() {
+    thrown.expectNullPointerException("The Reader to compare to should not be null");
+    readers.assertEqualContent(someInfo(), actual, null);
+  }
+
+  @Test
+  public void should_fail_if_actual_is_null() {
+    thrown.expectAssertionError(actualIsNull());
+    readers.assertEqualContent(someInfo(), null, expected);
+  }
+
+  @Test
+  public void should_pass_if_readerss_have_equal_content() throws IOException {
+    when(diff.diff(actual, expected)).thenReturn(new ArrayList<String>());
+    readers.assertEqualContent(someInfo(), actual, expected);
+  }
+
+  @Test
+  public void should_throw_error_wrapping_catched_IOException() throws IOException {
+    IOException cause = new IOException();
+    when(diff.diff(actual, expected)).thenThrow(cause);
+    try {
+      readers.assertEqualContent(someInfo(), actual, expected);
+      fail("Expected a ReadersException to be thrown");
+    } catch (ReadersException e) {
+      assertSame(cause, e.getCause());
+    }
+  }
+
+  @Test
+  public void should_fail_if_inputstreams_do_not_have_equal_content() throws IOException {
+    List<String> diffs = newArrayList("line:1, expected:<line1> but was:<EOF>");
+    when(diff.diff(actual, expected)).thenReturn(diffs);
+    AssertionInfo info = someInfo();
+    try {
+      readers.assertEqualContent(info, actual, expected);
+    } catch (AssertionError e) {
+      verify(failures).failure(info, shouldHaveEqualContent(actual, expected, diffs));
+      return;
+    }
+    failBecauseExpectedAssertionErrorWasNotThrown();
+  }
+}


### PR DESCRIPTION
Copied and renamed the InputStreamAssert to ReaderAssert together with supporting classes. Kept the same structure for Reader\* as for the InputStream*.
