### PR TITLE
Add containsExactly/containsExactlyInAnyOrder String assertion

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -543,7 +543,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * @param values the charSequences to check.
    * @return {@code this} assertion object.
-   * @throws NullPointerException if the array of values is {@code null}.
+   * @throws NullPointerException if the array or one of its values is {@code null}.
    * @throws IllegalArgumentException if the array of values is empty.
    * @throws AssertionError if the given {@code CharSequence} is {@code null}.
    * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in a sequential order.
@@ -570,7 +570,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * @param values the charSequences to check.
    * @return {@code this} assertion object.
-   * @throws NullPointerException if the Iterable of values is {@code null}.
+   * @throws NullPointerException if the Iterable or one of its values is {@code null}.
    * @throws IllegalArgumentException if the Iterable of values is empty.
    * @throws AssertionError if the given {@code CharSequence} is {@code null}.
    * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in a sequential order.
@@ -597,7 +597,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * @param values the charSequences to check.
    * @return {@code this} assertion object.
-   * @throws NullPointerException if the array of values is {@code null}.
+   * @throws NullPointerException if the array or one of its values is {@code null}.
    * @throws IllegalArgumentException if the array of values is empty.
    * @throws AssertionError if the given {@code CharSequence} is {@code null}.
    * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in any order.
@@ -624,7 +624,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * @param values the charSequences to check.
    * @return {@code this} assertion object.
-   * @throws NullPointerException if the iterable of values is {@code null}.
+   * @throws NullPointerException if the iterable or one of its values is {@code null}.
    * @throws IllegalArgumentException if the iterable of values is empty.
    * @throws AssertionError if the given {@code CharSequence} is {@code null}.
    * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in any order.

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -527,6 +527,60 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given charSequences <b>in a sequential order with no more or less elements</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
+   *
+   * // this assertion succeeds
+   * assertThat(actual).containsExactly(&quot;foo&quot;, &quot;, bar&quot;);
+   *
+   * // this assertion fails because of the wrong order
+   * assertThat(actual).containsExactly(&quot;, bar&quot;, &quot;foo&quot;);
+   *
+   * // this assertion fails because of unmatched elements
+   * assertThat(actual).containsExactly(&quot;foo&quot;);</code></pre>
+   *
+   * @param values the charSequences to check.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the array of values is {@code null}.
+   * @throws IllegalArgumentException if the array of values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in a sequential order.
+   */
+  public SELF containsExactly(CharSequence... values){
+    strings.assertContainsExactly(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given Iterable <b>in a sequential order with no more or less elements</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
+   *
+   * // this assertion succeeds
+   * assertThat(actual).containsExactly(asList(&quot;foo&quot;, &quot;, bar&quot;));
+   *
+   * // this assertion fails because of the wrong order
+   * assertThat(actual).containsExactly(asList(&quot;, bar&quot;, &quot;foo&quot;));
+   *
+   * // this assertion fails because of unmatched elements
+   * assertThat(actual).containsExactly(asList(&quot;foo&quot;));</code></pre>
+   *
+   * @param values the charSequences to check.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the Iterable of values is {@code null}.
+   * @throws IllegalArgumentException if the Iterable of values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in a sequential order.
+   */
+  public SELF containsExactly(Iterable<? extends CharSequence> values) {
+    strings.assertContainsExactly(info, actual, IterableUtil.toArray(values, CharSequence.class));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} contains exactly all the values of the given charSequences <b>in any order with no more or less elements</b>.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -527,6 +527,60 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given charSequences <b>in any order with no more or less elements</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
+   *
+   * // this assertion succeeds
+   * assertThat(actual).containsExactlyInAnyOrder(&quot; bar&quot;, &quot;,&quot;, &quot;foo&quot;);
+   *
+   * // this assertion fails because some elements in {@code actual} are not found
+   * assertThat(actual).containsExactlyInAnyOrder(&quot;foo&quot;);
+   *
+   * // this assertion fails because of some unexpected elements
+   * assertThat(actual).containsExactlyInAnyOrder(&quot;foo, bar&quot;, &quot;element&quot;);</code></pre>
+   *
+   * @param values the charSequences to check.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the array of values is {@code null}.
+   * @throws IllegalArgumentException if the array of values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in any order.
+   */
+  public SELF containsExactlyInAnyOrder(CharSequence... values) {
+    strings.assertContainsExactlyInAnyOrder(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given Iterable <b>in any order with no more or less elements</b>.
+   * <p>
+   * Example:
+   * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
+   *
+   * // this assertion succeeds
+   * assertThat(actual).containsExactlyInAnyOrder(asList(&quot; bar&quot;, &quot;,&quot;, &quot;foo&quot;));
+   *
+   * // this assertion fails because some elements in {@code actual} are not found
+   * assertThat(actual).containsExactlyInAnyOrder(asList(&quot;foo&quot;));
+   *
+   * // this assertion fails because of some unexpected elements
+   * assertThat(actual).containsExactlyInAnyOrder(asList(&quot;foo, bar&quot;, &quot;element&quot;));</code></pre>
+   *
+   * @param values the charSequences to check.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the iterable of values is {@code null}.
+   * @throws IllegalArgumentException if the iterable of values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in any order.
+   */
+  public SELF containsExactlyInAnyOrder(Iterable<? extends CharSequence> values) {
+    strings.assertContainsExactlyInAnyOrder(info, actual, IterableUtil.toArray(values, CharSequence.class));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} contains the given sequence of values <b>in the given order without any other values between them</b>.
    * <p>
    * <b>Breaking change since 2.9.0</b>: in previous versions this assertion behaved like {@link #containsSubsequence(CharSequence...) containsSubsequence} 

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -570,8 +570,8 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    *
    * @param values the charSequences to check.
    * @return {@code this} assertion object.
-   * @throws NullPointerException if the Iterable or one of its values is {@code null}.
-   * @throws IllegalArgumentException if the Iterable of values is empty.
+   * @throws NullPointerException if the iterable or one of its values is {@code null}.
+   * @throws IllegalArgumentException if the iterable of values is empty.
    * @throws AssertionError if the given {@code CharSequence} is {@code null}.
    * @throws AssertionError if the given {@code CharSequence} does not contain exactly the values in a sequential order.
    */

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -527,7 +527,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given charSequences <b>in a sequential order with no more or less elements</b>.
+   * Verifies that the actual {@code CharSequence} contains exactly all the <b>non-null</b> values of the given charSequences <b>in a sequential order with no more or less elements</b>.
    * <p>
    * Example:
    * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
@@ -554,7 +554,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given Iterable <b>in a sequential order with no more or less elements</b>.
+   * Verifies that the actual {@code CharSequence} contains exactly all the <b>non-null</b> values of the given Iterable <b>in a sequential order with no more or less elements</b>.
    * <p>
    * Example:
    * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
@@ -581,7 +581,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given charSequences <b>in any order with no more or less elements</b>.
+   * Verifies that the actual {@code CharSequence} contains exactly all the <b>non-null</b> values of the given charSequences <b>in any order with no more or less elements</b>.
    * <p>
    * Example:
    * <pre><code class='java'> String actual = &quot;foo, bar&quot;;
@@ -608,7 +608,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} contains exactly all the values of the given Iterable <b>in any order with no more or less elements</b>.
+   * Verifies that the actual {@code CharSequence} contains exactly all the <b>non-null</b> values of the given Iterable <b>in any order with no more or less elements</b>.
    * <p>
    * Example:
    * <pre><code class='java'> String actual = &quot;foo, bar&quot;;

--- a/src/main/java/org/assertj/core/internal/Arrays.java
+++ b/src/main/java/org/assertj/core/internal/Arrays.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal;
 
 import static java.lang.reflect.Array.getLength;
+import static java.util.Arrays.asList;
 import static org.assertj.core.error.ConditionAndGroupGenericParameterTypeShouldBeTheSame.shouldBeSameGenericBetweenIterableAndCondition;
 import static org.assertj.core.error.ElementsShouldBe.elementsShouldBe;
 import static org.assertj.core.error.ElementsShouldBeAtLeast.elementsShouldBeAtLeast;
@@ -261,20 +262,14 @@ public class Arrays {
 
   void assertContainsExactlyInAnyOrder(AssertionInfo info, Failures failures, Object actual, Object values) {
     if (commonChecks(info, actual, values)) return;
-    List<Object> notExpected = asList(actual);
-    List<Object> notFound = asList(values);
 
-    for (Object value : asList(values)) {
-      if (iterableContains(notExpected, value)) {
-        iterablesRemoveFirst(notExpected, value);
-        iterablesRemoveFirst(notFound, value);
-      }
-    }
+    List<Object> actualAsList = asList(actual);
+    IterableDiff diff = diff(actualAsList, asList(values), comparisonStrategy);
 
-    if (notExpected.isEmpty() && notFound.isEmpty()) return;
+    if (!diff.differencesFound()) return;
 
     throw failures.failure(info,
-                           shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
+                           shouldContainExactlyInAnyOrder(actual, values, diff.missing, diff.unexpected, comparisonStrategy));
   }
 
   void assertContainsOnlyOnce(AssertionInfo info, Failures failures, Object actual, Object values) {

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -58,6 +58,7 @@ import static org.assertj.core.internal.ErrorMessages.emptySequence;
 import static org.assertj.core.internal.ErrorMessages.emptySubsequence;
 import static org.assertj.core.internal.ErrorMessages.nullSequence;
 import static org.assertj.core.internal.ErrorMessages.nullSubsequence;
+import static org.assertj.core.internal.IterableDiff.*;
 import static org.assertj.core.internal.IterableDiff.diff;
 import static org.assertj.core.util.Arrays.prepend;
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
@@ -997,20 +998,15 @@ public class Iterables {
   public void assertContainsExactlyInAnyOrder(AssertionInfo info, Iterable<?> actual, Object[] values) {
     checkIsNotNull(values);
     assertNotNull(info, actual);
-    List<Object> notExpected = newArrayList(actual);
-    List<Object> notFound = newArrayList(values);
 
-    for (Object value : values) {
-      if (iterableContains(notExpected, value)) {
-        iterablesRemoveFirst(notExpected, value);
-        iterablesRemoveFirst(notFound, value);
-      }
-    }
+    List<Object> actualAsList = newArrayList(actual);
+    IterableDiff diff = diff(actualAsList, asList(values), comparisonStrategy);
 
-    if (notExpected.isEmpty() && notFound.isEmpty()) return;
+    if (!diff.differencesFound()) return;
 
     throw failures.failure(info,
-                           shouldContainExactlyInAnyOrder(actual, values, notFound, notExpected, comparisonStrategy));
+                           shouldContainExactlyInAnyOrder(actual, values, diff.missing, diff.unexpected,
+                                                          comparisonStrategy));
   }
 
   void assertNotNull(AssertionInfo info, Iterable<?> actual) {

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -824,7 +824,7 @@ public class Strings {
     if (!diff.differencesFound()) return;
 
     throw failures
-      .failure(info, shouldContainExactlyInAnyOrder(actual, values, valuesAsList, actualAsList, comparisonStrategy));
+      .failure(info, shouldContainExactlyInAnyOrder(actual, values, diff.missing, diff.unexpected, comparisonStrategy));
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -59,6 +59,7 @@ import static org.assertj.core.internal.CommonValidations.checkSameSizes;
 import static org.assertj.core.internal.CommonValidations.checkSizes;
 import static org.assertj.core.internal.CommonValidations.hasSameSizeAsCheck;
 import static org.assertj.core.internal.IterableDiff.diff;
+import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.assertj.core.util.Preconditions.checkNotNull;
 import static org.assertj.core.util.xml.XmlStringPrettyFormatter.xmlPrettyFormat;
@@ -797,20 +798,12 @@ public class Strings {
     IterableDiff diff = diff(actualAsList, valuesAsList, comparisonStrategy);
 
     if (!diff.differencesFound()) {
-      // actual and values have the same elements but are they in the same order ?
-      for (int i = 0; i < actualAsList.size(); i++) {
-        String elementFromActual = actualAsList.get(i);
-        String elementFromValues = valuesAsList.get(i);
-        if (!comparisonStrategy.areEqual(elementFromActual, elementFromValues)) {
-          throw failures
-            .failure(info, elementsDifferAtIndex(elementFromActual, elementFromValues, i, comparisonStrategy));
-        }
-      }
+      checkIdenticalElementsAreInSameOrder(info, actualAsList, valuesAsList);
       return;
     }
 
     throw failures
-      .failure(info, shouldContainExactly(actual, values, diff.missing, diff.unexpected, comparisonStrategy));
+      .failure(info, shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected, comparisonStrategy));
   }
 
   /**
@@ -1087,5 +1080,17 @@ public class Strings {
     checkIsNotNull(sequence);
     checkIsNotEmpty(sequence);
     checkCharSequenceArrayDoesNotHaveNullElements(sequence);
+  }
+
+  private void checkIdenticalElementsAreInSameOrder(AssertionInfo info, List<String> actualAsList,
+                                                    List<String> valuesAsList) {
+    for (int i = 0; i < actualAsList.size(); i++) {
+      String elementFromActual = actualAsList.get(i);
+      String elementFromValues = valuesAsList.get(i);
+      if (!comparisonStrategy.areEqual(elementFromActual, elementFromValues)) {
+        throw failures
+          .failure(info, elementsDifferAtIndex(elementFromActual, elementFromValues, i, comparisonStrategy));
+      }
+    }
   }
 }

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -791,10 +791,6 @@ public class Strings {
     List<String> actualAsList = splitCharSequencesToListOfElements(actual);
     List<String> valuesAsList = splitCharSequencesToListOfElements(values);
 
-    if (actualAsList.size() != valuesAsList.size()) {
-      throw failures.failure(info, shouldHaveSameSizeAs(actual, actualAsList.size(), valuesAsList.size()));
-    }
-
     IterableDiff diff = diff(actualAsList, valuesAsList, comparisonStrategy);
 
     if (!diff.differencesFound()) {
@@ -822,10 +818,6 @@ public class Strings {
 
     List<String> actualAsList = splitCharSequencesToListOfElements(actual);
     List<String> valuesAsList = splitCharSequencesToListOfElements(values);
-
-    if (actualAsList.size() != valuesAsList.size()) {
-      throw failures.failure(info, shouldHaveSameSizeAs(actual, actualAsList.size(), valuesAsList.size()));
-    }
 
     IterableDiff diff = diff(actualAsList, valuesAsList, comparisonStrategy);
 

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactlyInAnyOrder_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import java.util.Arrays;
+
+import static org.assertj.core.util.Arrays.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsExactlyInAnyOrder(Iterable<CharSequence>)}</code>.
+ *
+ * @author Billy Yuan
+ */
+public class CharSequenceAssert_containsExactlyInAnyOrder_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.containsExactlyInAnyOrder(Arrays.<CharSequence>asList("od", "do"));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertContainsExactlyInAnyOrder(getInfo(assertions), getActual(assertions), array("od", "do"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactlyInAnyOrder_with_var_args_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactlyInAnyOrder_with_var_args_Test.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import java.util.Arrays;
+
+import static org.assertj.core.util.Arrays.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsExactlyInAnyOrder(CharSequence...)}</code>.
+ *
+ * @author Billy Yuan
+ */
+public class CharSequenceAssert_containsExactlyInAnyOrder_with_var_args_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.containsExactlyInAnyOrder("od", "do");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertContainsExactlyInAnyOrder(getInfo(assertions), getActual(assertions), array("od", "do"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_Test.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
 package org.assertj.core.api.charsequence;
 
 import org.assertj.core.api.CharSequenceAssert;

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_Test.java
@@ -1,0 +1,27 @@
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import java.util.Arrays;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsExactly(Iterable<CharSequence>)}</code>.
+ *
+ * @author Billy Yuan
+ */
+public class CharSequenceAssert_containsExactly_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.containsExactly(Arrays.<CharSequence>asList("od", "do"));
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertContainsExactly(getInfo(assertions), getActual(assertions), array("od", "do"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_with_var_args_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_with_var_args_Test.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
 package org.assertj.core.api.charsequence;
 
 import org.assertj.core.api.CharSequenceAssert;

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_with_var_args_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsExactly_with_var_args_Test.java
@@ -1,0 +1,25 @@
+package org.assertj.core.api.charsequence;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+import static org.assertj.core.util.Arrays.array;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsExactly(CharSequence...)}</code>.
+ *
+ * @author Billy Yuan
+ */
+public class CharSequenceAssert_containsExactly_with_var_args_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.containsExactly("od", "do");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertContainsExactly(getInfo(assertions), getActual(assertions), array("od", "do"));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactlyInAnyOrder_Test.java
@@ -22,10 +22,10 @@ import org.junit.Test;
 import java.util.Arrays;
 
 import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
-import static org.assertj.core.error.ShouldHaveSameSizeAs.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.TestData.*;
 import static org.assertj.core.util.FailureMessages.*;
+import static org.assertj.core.util.Lists.newArrayList;
 
 /**
  * Tests for <code>{@link Strings#assertContainsExactlyInAnyOrder(AssertionInfo, CharSequence, CharSequence[])}</code>.
@@ -102,4 +102,25 @@ public class Strings_assertContainsExactlyInAnyOrder_Test extends StringsBaseTes
     stringsWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
   }
 
+  @Test
+  public void should_fail_if_actual_contains_duplicates_and_expected_does_not() {
+    String actual = "LukeLeiaLuke";
+    String[] values = { "Luke", "Leia" };
+    thrown.expectAssertionError(
+      shouldContainExactlyInAnyOrder(actual, values, newArrayList(),
+                                     newArrayList("L", "u", "k", "e"),
+                                     StandardComparisonStrategy.instance()));
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_expected_contains_duplicates_and_actual_does_not() {
+    String actual = "LukeLeia";
+    String[] values = { "Luke", "Leia", "Luke" };
+    thrown.expectAssertionError(
+      shouldContainExactlyInAnyOrder(actual, values, newArrayList("L", "u", "k", "e"),
+                                     newArrayList(),
+                                     StandardComparisonStrategy.instance()));
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactlyInAnyOrder_Test.java
@@ -81,24 +81,6 @@ public class Strings_assertContainsExactlyInAnyOrder_Test extends StringsBaseTes
   }
 
   @Test
-  public void should_fail_if_actual_contains_more_chars_than_values() {
-    String[] values = { "Practice ", "makes ", "!" };
-    int sizeOfCharsOfValues = 16;
-    thrown.expectAssertionError(
-      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
-    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
-  }
-
-  @Test
-  public void should_fail_if_actual_contains_less_chars_than_values() {
-    String[] values = { "Practice makes perfect", "!", "more" };
-    int sizeOfCharsOfValues = 27;
-    thrown.expectAssertionError(
-      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
-    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
-  }
-
-  @Test
   public void should_fail_if_actual_does_not_contain_values() {
     String actual = "Yoda";
     String[] values = { "Lu", "ke" };

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactlyInAnyOrder_Test.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
+package org.assertj.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.error.ShouldContainExactlyInAnyOrder.*;
+import static org.assertj.core.error.ShouldHaveSameSizeAs.*;
+import static org.assertj.core.internal.ErrorMessages.*;
+import static org.assertj.core.test.TestData.*;
+import static org.assertj.core.util.FailureMessages.*;
+
+/**
+ * Tests for <code>{@link Strings#assertContainsExactlyInAnyOrder(AssertionInfo, CharSequence, CharSequence[])}</code>.
+ *
+ * @author Billy Yuan
+ */
+public class Strings_assertContainsExactlyInAnyOrder_Test extends StringsBaseTest {
+  String actual = "Practice makes perfect!";
+
+  @Test
+  public void should_pass_if_actual_exactly_contains_values_in_order() {
+    String[] values = { "Practice ", "makes", " ", "perfect!" };
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_pass_if_actual_exactly_contains_values_without_order() {
+    String[] values = { " makes ", "Practice", "!", "perfect" };
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_pass_if_actual_exactly_contains_values_according_to_custom_comparison_strategy() {
+    String[] values = { "practice ", "MAKES ", "!", "PerFECT" };
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_throw_error_if_actual_is_null() {
+    String[] values = { "hey", "there" };
+    thrown.expectAssertionError(actualIsNull());
+    strings.assertContainsExactlyInAnyOrder(someInfo(), null, values);
+  }
+
+  @Test
+  public void should_throw_exception_if_the_array_of_values_is_null() {
+    thrown.expectNullPointerException(arrayOfValuesToLookForIsNull());
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, null);
+  }
+
+  @Test
+  public void should_throw_exception_if_one_of_values_is_null() {
+    String[] values = { null, "Practice makes perfect", "!" };
+    thrown.expectNullPointerException("Expecting CharSequence elements not to be null but found one at index 0");
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_throw_exception_if_the_array_of_values_is_empty() {
+    String[] values = {};
+    thrown.expectIllegalArgumentException(arrayOfValuesToLookForIsEmpty());
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_more_chars_than_values() {
+    String[] values = { "Practice ", "makes ", "!" };
+    int sizeOfCharsOfValues = 16;
+    thrown.expectAssertionError(
+      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_less_chars_than_values() {
+    String[] values = { "Practice makes perfect", "!", "more" };
+    int sizeOfCharsOfValues = 27;
+    thrown.expectAssertionError(
+      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contain_values() {
+    String actual = "Yoda";
+    String[] values = { "Lu", "ke" };
+    thrown.expectAssertionError(
+      shouldContainExactlyInAnyOrder(actual, values, Arrays.asList("L", "u", "k", "e"),
+                                     Arrays.asList("Y", "o", "d", "a"),
+                                     StandardComparisonStrategy.instance()));
+    strings.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contains_values_according_to_custom_comparison_strategy() {
+    String actual = "YODA";
+    String[] values = { "lu", "ke" };
+    thrown.expectAssertionError(
+      shouldContainExactlyInAnyOrder(actual, values, Arrays.asList("l", "u", "k", "e"),
+                                     Arrays.asList("Y", "O", "D", "A"),
+                                     comparisonStrategy));
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsExactlyInAnyOrder(someInfo(), actual, values);
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2017 the original author or authors.
+ */
+
 package org.assertj.core.internal.strings;
 
 import org.assertj.core.api.AssertionInfo;

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
@@ -1,0 +1,110 @@
+package org.assertj.core.internal.strings;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.error.ShouldContainExactly.*;
+import static org.assertj.core.error.ShouldHaveSameSizeAs.*;
+import static org.assertj.core.internal.ErrorMessages.*;
+import static org.assertj.core.test.TestData.*;
+import static org.assertj.core.util.FailureMessages.*;
+
+/**
+ * Tests for <code>{@link Strings#assertContainsExactly(AssertionInfo, CharSequence, CharSequence[])}</code>.
+ *
+ * @author Billy Yuan
+ */
+public class Strings_assertContainsExactly_Test extends StringsBaseTest {
+  String actual = "Practice makes perfect!";
+
+  @Test
+  public void should_pass_if_actual_exactly_contains_values_in_order() {
+    String[] values = { "Practice ", "makes", " ", "perfect!" };
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_the_same_values_but_without_order() {
+    String[] values = { " makes ", "Practice", "!", "perfect" };
+    thrown.expectAssertionError(elementsDifferAtIndex("P", " ", 0));
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_pass_if_actual_exactly_contains_values_according_to_custom_comparison_strategy() {
+    String[] values = { "practice ", "MAKES ", "PerFECT", "!" };
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_throw_error_if_actual_is_null() {
+    String[] values = { "hey", "there" };
+    thrown.expectAssertionError(actualIsNull());
+    strings.assertContainsExactly(someInfo(), null, values);
+  }
+
+  @Test
+  public void should_throw_exception_if_the_array_of_values_is_null() {
+    thrown.expectNullPointerException(arrayOfValuesToLookForIsNull());
+    strings.assertContainsExactly(someInfo(), actual, null);
+  }
+
+  @Test
+  public void should_throw_exception_if_one_of_values_is_null() {
+    String[] values = { null, "Practice makes perfect", "!" };
+    thrown.expectNullPointerException("Expecting CharSequence elements not to be null but found one at index 0");
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_throw_exception_if_the_array_of_values_is_empty() {
+    String[] values = {};
+    thrown.expectIllegalArgumentException(arrayOfValuesToLookForIsEmpty());
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_more_chars_than_values() {
+    String[] values = { "Practice ", "makes ", "!" };
+    int sizeOfCharsOfValues = 16;
+    thrown.expectAssertionError(
+      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_contains_less_chars_than_values() {
+    String[] values = { "Practice makes perfect", "!", "more" };
+    int sizeOfCharsOfValues = 27;
+    thrown.expectAssertionError(
+      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contain_values() {
+    String actual = "Yoda";
+    String[] values = { "Lu", "ke" };
+    thrown.expectAssertionError(
+      shouldContainExactly(actual, values, Arrays.asList("L", "u", "k", "e"),
+                           Arrays.asList("Y", "o", "d", "a"),
+                           StandardComparisonStrategy.instance()));
+    strings.assertContainsExactly(someInfo(), actual, values);
+  }
+
+  @Test
+  public void should_fail_if_actual_does_not_contains_values_according_to_custom_comparison_strategy() {
+    String actual = "YODA";
+    String[] values = { "lu", "ke" };
+    thrown.expectAssertionError(
+      shouldContainExactly(actual, values, Arrays.asList("l", "u", "k", "e"),
+                           Arrays.asList("Y", "O", "D", "A"),
+                           comparisonStrategy));
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsExactly(someInfo(), actual, values);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
@@ -83,24 +83,6 @@ public class Strings_assertContainsExactly_Test extends StringsBaseTest {
   }
 
   @Test
-  public void should_fail_if_actual_contains_more_chars_than_values() {
-    String[] values = { "Practice ", "makes ", "!" };
-    int sizeOfCharsOfValues = 16;
-    thrown.expectAssertionError(
-      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
-    strings.assertContainsExactly(someInfo(), actual, values);
-  }
-
-  @Test
-  public void should_fail_if_actual_contains_less_chars_than_values() {
-    String[] values = { "Practice makes perfect", "!", "more" };
-    int sizeOfCharsOfValues = 27;
-    thrown.expectAssertionError(
-      shouldHaveSameSizeAs(actual, actual.length(), sizeOfCharsOfValues));
-    strings.assertContainsExactly(someInfo(), actual, values);
-  }
-
-  @Test
   public void should_fail_if_actual_does_not_contain_values() {
     String actual = "Yoda";
     String[] values = { "Lu", "ke" };

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsExactly_Test.java
@@ -25,6 +25,7 @@ import static org.assertj.core.error.ShouldContainExactly.*;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.*;
 import static org.assertj.core.internal.ErrorMessages.*;
 import static org.assertj.core.test.TestData.*;
+import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.*;
 
 /**
@@ -104,7 +105,7 @@ public class Strings_assertContainsExactly_Test extends StringsBaseTest {
     String actual = "Yoda";
     String[] values = { "Lu", "ke" };
     thrown.expectAssertionError(
-      shouldContainExactly(actual, values, Arrays.asList("L", "u", "k", "e"),
+      shouldContainExactly(actual, asList(values), Arrays.asList("L", "u", "k", "e"),
                            Arrays.asList("Y", "o", "d", "a"),
                            StandardComparisonStrategy.instance()));
     strings.assertContainsExactly(someInfo(), actual, values);
@@ -115,7 +116,7 @@ public class Strings_assertContainsExactly_Test extends StringsBaseTest {
     String actual = "YODA";
     String[] values = { "lu", "ke" };
     thrown.expectAssertionError(
-      shouldContainExactly(actual, values, Arrays.asList("l", "u", "k", "e"),
+      shouldContainExactly(actual, asList(values), Arrays.asList("l", "u", "k", "e"),
                            Arrays.asList("Y", "O", "D", "A"),
                            comparisonStrategy));
     stringsWithCaseInsensitiveComparisonStrategy.assertContainsExactly(someInfo(), actual, values);


### PR DESCRIPTION
#### Check List:
* Fixes #1063 
* Unit tests : YES
* Javadoc with a code example (API only) : YES

#### Something needed to be discussed
While I'm implementing the `assertContainsExactly` assertion, I have reused the `IterableDiff` in package `org.assertj.core.internal` like it is done in `Iterables#assertContainsExactly`.

But I find something unexpected, if you write an iterable assertion like this 
```
    List<String> myList = Arrays.asList("$","$","#");
    Assertions.assertThat(myList)
              .containsExactly("#", "#", "$");
```
AssertionError is this
```
java.lang.AssertionError: 
Actual and expected have the same elements but not in the same order, at index 0 actual element was:
  <"$">
whereas expected element was:
  <"#">
```

method `differencesFound()` in `IterableDiff` will return false when calling `IterableDiff.diff(Arrays.asList("#","#","$"),Arrays.asList("$","$","#"),StandardComparisonStrategy.instance()).differencesFound()`

It looks like this may lead to give a **wrong** assertion message 

> Actual and expected have the same elements but not in the same order

in fact they **don't** have the same elements?

For now I'm following the same impl in `containsExactly` Iterable assertion when implementing `containsExactly` String assertion.

So the question is 
shall we change the `IterableDiff` or work this out in some other ways?