### PR TITLE
CharSequenceAssert: add support for checking pattern matchers to e.g verify groups

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.io.LineNumberReader;
 import java.text.Normalizer;
 import java.util.Comparator;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
@@ -1220,6 +1222,29 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} matches the given regular expression pattern.
+   * Accepts a {@code Consumer<Matcher>} to do further verification of the match.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(&quot;Frodo&quot;).matchesSatisfying(&quot;..(o.o)&quot;, match -&gt; assertThat(match).isEqualTo(&quot;odo&quot;));
+   * </code></pre>
+   *
+   * @param regex the regular expression to which the actual {@code CharSequence} is to be matched.
+   * @param matchSatisfies a consumer of the Matcher to do further verification
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not match the given regular expression.
+   */
+  public SELF matchesSatisfying(CharSequence regex, Consumer<Matcher> matchSatisfies) {
+    Matcher matcher = Pattern.compile(regex.toString()).matcher(actual);
+    strings.assertMatches(info, actual, matcher);
+    matchSatisfies.accept(matcher);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} does not match the given regular expression.
    * <p>
    * Example:
@@ -1259,6 +1284,24 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    */
   public SELF matches(Pattern pattern) {
     strings.assertMatches(info, actual, pattern);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} matches the given regular expression pattern.
+   * Accepts a {@code Consumer<Matcher>} to do further verification of the match.
+   *
+   * @param pattern the regular expression to which the actual {@code CharSequence} is to be matched.
+   * @param matchSatisfies a consumer of the Matcher to do further verification
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not match the given regular expression.
+   */
+  public SELF matchesSatisfying(Pattern pattern, Consumer<Matcher> matchSatisfies) {
+    Matcher matcher = pattern.matcher(actual);
+    strings.assertMatches(info, actual, matcher);
+    matchSatisfies.accept(matcher);
     return myself;
   }
 
@@ -1649,6 +1692,31 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} contains the given regular expression.
+   * Accepts a {@code Consumer<Matcher>} for further verification of the found match.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(&quot;Frodo&quot;).containsPatternSatisfying(&quot;.o(.o)&quot;,
+   *   match -&gt; assertThat(match).isEqualTo(&quot;do&quot;));
+   * </code></pre>
+   *
+   * @param regex the regular expression to find in the actual {@code CharSequence}.
+   * @param matchSatisfies a consumer for further verifying the Matcher.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws PatternSyntaxException if the regular expression's syntax is invalid.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given regular expression cannot be found in the actual {@code CharSequence}.
+   */
+  public SELF containsPatternSatisfying(CharSequence regex, Consumer<Matcher> matchSatisfies) {
+    Matcher matcher = Pattern.compile(regex.toString()).matcher(actual);
+    strings.assertContainsPattern(info, actual, matcher);
+    matchSatisfies.accept(matcher);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} contains the given regular expression pattern.
    * <p>
    * Example:
@@ -1666,6 +1734,30 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    */
   public SELF containsPattern(Pattern pattern) {
     strings.assertContainsPattern(info, actual, pattern);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} contains the given regular expression pattern.
+   * Accepts a {@code Consumer<Matcher>} for further verification of the found match.
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(&quot;Frodo&quot;).containsPatternSatisfying(Pattern.compile(&quot;.o(.o)&quot;),
+   *   match -&gt; assertThat(match).isEqualTo(&quot;do&quot;));
+   * </code></pre>
+   *
+   * @param pattern the regular expression to find in the actual {@code CharSequence}.
+   * @param matchSatisfies a consumer for further verifying the Matcher.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given regular expression cannot be found in the actual {@code CharSequence}.
+   */
+  public SELF containsPatternSatisfying(Pattern pattern, Consumer<Matcher> matchSatisfies) {
+    Matcher matcher = pattern.matcher(actual);
+    strings.assertContainsPattern(info, actual, matcher);
+    matchSatisfies.accept(matcher);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -1068,7 +1068,23 @@ public class Strings {
   public void assertMatches(AssertionInfo info, CharSequence actual, Pattern pattern) {
     checkIsNotNull(pattern);
     assertNotNull(info, actual);
-    if (!pattern.matcher(actual).matches()) throw failures.failure(info, shouldMatch(actual, pattern.pattern()));
+    assertMatches(info, actual, pattern.matcher(actual));
+  }
+
+  /**
+   * Verifies that the given {@code CharSequence} matches the given regular expression.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @param matcher the matcher to check for matching.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} does not match the given regular expression.
+   */
+  public void assertMatches(AssertionInfo info, CharSequence actual, Matcher matcher) {
+    checkIsNotNull(matcher);
+    assertNotNull(info, actual);
+    if (!matcher.matches()) throw failures.failure(info, shouldMatch(actual, matcher.pattern().pattern()));
   }
 
   /**
@@ -1092,6 +1108,14 @@ public class Strings {
 
   private NullPointerException patternToMatchIsNull() {
     return new NullPointerException("The regular expression pattern to match should not be null");
+  }
+
+  private void checkIsNotNull(Matcher matcher) {
+    if (matcher == null) throw matcherIsNull();
+  }
+
+  private NullPointerException matcherIsNull() {
+    return new NullPointerException("The matcher should not be null");
   }
 
   private void assertNotNull(AssertionInfo info, CharSequence actual) {
@@ -1227,10 +1251,24 @@ public class Strings {
    */
   public void assertContainsPattern(AssertionInfo info, CharSequence actual, CharSequence regex) {
     checkRegexIsNotNull(regex);
+    assertContainsPattern(info, actual, Pattern.compile(regex.toString()));
+  }
+
+  /**
+   * Verifies that the given {@code CharSequence} contains the given regular expression.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given {@code CharSequence}.
+   * @param matcher the matcher for finding in the actual {@code CharSequence}.
+   * @throws NullPointerException if the given pattern is {@code null}.
+   * @throws PatternSyntaxException if the regular expression's syntax is invalid.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not contain the given regular expression.
+   */
+  public void assertContainsPattern(AssertionInfo info, CharSequence actual, Matcher matcher) {
     assertNotNull(info, actual);
-    Pattern pattern = Pattern.compile(regex.toString());
-    Matcher matcher = pattern.matcher(actual);
-    if (!matcher.find()) throw failures.failure(info, shouldContainPattern(actual, pattern.pattern()));
+    checkIsNotNull(matcher);
+    if (!matcher.find()) throw failures.failure(info, shouldContainPattern(actual, matcher.pattern().pattern()));
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsPatternSatisfying_Pattern_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsPatternSatisfying_Pattern_Test.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsPatternSatisfying(Pattern, Consumer)}</code>.
+ */
+public class CharSequenceAssert_containsPatternSatisfying_Pattern_Test {
+  @Test
+  public void containsPatternSatisfying() {
+    assertThat("Yoda").containsPatternSatisfying(
+            Pattern.compile("o(da)"),
+            matcher -> assertThat(matcher.group(1)).isEqualTo("da"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsPatternSatisfying_String_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsPatternSatisfying_String_Test.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsPatternSatisfying(CharSequence, Consumer)}</code>.
+ */
+public class CharSequenceAssert_containsPatternSatisfying_String_Test {
+  @Test
+  public void containsPatternSatisfying() {
+    assertThat("Yoda").containsPatternSatisfying(
+            "o(da)",
+            matcher -> assertThat(matcher.group(1)).isEqualTo("da"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_matchesSatisfying_Pattern_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_matchesSatisfying_Pattern_Test.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsPatternSatisfying(Pattern, Consumer)}</code>.
+ */
+public class CharSequenceAssert_matchesSatisfying_Pattern_Test {
+  @Test
+  public void matchesSatisfying() {
+    assertThat("Yoda").matchesSatisfying(
+            Pattern.compile("(Yo)da"),
+            matcher -> assertThat(matcher.group(1)).isEqualTo("Yo"));
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_matchesSatisfying_String_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_matchesSatisfying_String_Test.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#containsPatternSatisfying(CharSequence, Consumer)}</code>.
+ */
+public class CharSequenceAssert_matchesSatisfying_String_Test {
+  @Test
+  public void matchesSatisfying() {
+    assertThat("Yoda").matchesSatisfying(
+            "(Yo)da",
+            matcher -> assertThat(matcher.group(1)).isEqualTo("Yo"));
+  }
+}


### PR DESCRIPTION
We recently wanted to use a pattern to extract part of a string, and then do further assertions on the matching groups.  This simple new api makes doing so easy!


#### Check List:
* Fixes NA - New Feature Request
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


