### PR TITLE
Add assertion factory methods to AbstractAssert.

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -49,6 +49,7 @@ import org.assertj.core.presentation.PredicateDescription;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * Base class for all assertions.
@@ -116,7 +117,28 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
   }
 
   /**
-   * Utility method to ease writing custom assertions classes using {@link String#format(String, Object...)} specifiers
+   * Throw an assertion error based on information in this assertion. Equivalent to:
+   * <pre><code class='java'>throw failure(errorMessage, arguments);</code></pre>
+   * <p>
+   * This method is a thin wrapper around {@link #failure(String, Object...) failure()} -
+   * see that method for a more detailed description. Note that generally speaking, using
+   * {@link #failure(String, Object...) failure()} directly is
+   * preferable to using this wrapper method, as the compiler and other code analysis tools will be able to tell that the
+   * statement will never return normally and respond appropriately.
+   *
+   * @param errorMessage the error message to format
+   * @param arguments the arguments referenced by the format specifiers in the errorMessage string.
+   * @see #failWithActualExpectedAndMessage(Object, Object, String, Object...)
+   * @see #failure(String, Object...)
+   */
+  protected void failWithMessage(String errorMessage, Object... arguments) {
+    throw failure(errorMessage, arguments);
+  }
+
+  /**
+   * Generate a custom assertion error using the information in this assertion.
+   * <p>
+   * This is a utility method to ease writing custom assertions classes using {@link String#format(String, Object...)} specifiers
    * in error message.
    * <p>
    * Moreover, this method honors any description set with {@link #as(String, Object...)} or overridden error message
@@ -138,9 +160,11 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    *
    * @param errorMessage the error message to format
    * @param arguments the arguments referenced by the format specifiers in the errorMessage string.
-   * @see #failWithActualExpectedAndMessage(Object, Object, String, Object...)
+   * @see #failureWithActualExpected(Object, Object, String, Object...)
+   * @see #failWithMessage(String, Object...)
+   * @return The generated assertion error.
    */
-  protected void failWithMessage(String errorMessage, Object... arguments) {
+  protected AssertionError failure(String errorMessage, Object... arguments) {
     AssertionError assertionError = Failures.instance().failureIfErrorMessageIsOverridden(info);
     if (assertionError == null) {
       // error message was not overridden, build it.
@@ -149,11 +173,35 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
     }
     Failures.instance().removeAssertJRelatedElementsFromStackTraceIfNeeded(assertionError);
     removeCustomAssertRelatedElementsFromStackTraceIfNeeded(assertionError);
-    throw assertionError;
+    return assertionError;
   }
 
   /**
-   * Utility method to ease writing custom assertions classes using {@link String#format(String, Object...)} specifiers
+   * Throw an assertion error based on information in this assertion. Equivalent to:
+   * <pre><code class='java'>throw failureWithActualExpected(actual, expected, errorMessageFormat, arguments);</code></pre>
+   * <p>
+   * This method is a thin wrapper around {@link #failureWithActualExpected(Object, Object, String, Object...) failureWithActualExpected()} -
+   * see that method for a more detailed description. Note that generally speaking, using
+   * {@link #failureWithActualExpected(Object, Object, String, Object...) failureWithActualExpected()} directly is
+   * preferable to using this wrapper method, as the compiler and other code analysis tools will be able to tell that the
+   * statement will never return normally and respond appropriately.
+   *
+   * @param actual the actual object that was found during the test
+   * @param expected the object that was expected
+   * @param errorMessageFormat the error message to format
+   * @param arguments the arguments referenced by the format specifiers in the errorMessage string.
+   * @see #failWithMessage(String, Object...)
+   * @see #failureWithActualExpected(Object, Object, String, Object...)
+   */
+  protected void failWithActualExpectedAndMessage(Object actual, Object expected, String errorMessageFormat,
+                                                  Object... arguments) {
+    throw failureWithActualExpected(actual, expected, errorMessageFormat, arguments);
+  }
+
+  /**
+   * Generate a custom assertion error using the information in this assertion, using the given actual and expected values.
+   * <p>
+   * This is a utility method to ease writing custom assertions classes using {@link String#format(String, Object...)} specifiers
    * in error message with actual and expected values.
    * <p>
    * Moreover, this method honors any description set with {@link #as(String, Object...)} or overridden error message
@@ -169,7 +217,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    *
    *   // check condition
    *   if (!actual.getName().equals(name)) {
-   *     failWithActualExpectedAndMessage(actual.getName(), name, &quot;Expected character's name to be &lt;%s&gt; but was &lt;%s&gt;&quot;, name, actual.getName());
+   *     throw failureWithActualExpected(actual.getName(), name, &quot;Expected character's name to be &lt;%s&gt; but was &lt;%s&gt;&quot;, name, actual.getName());
    *   }
    *
    *   // return the current assertion for method chaining
@@ -180,17 +228,19 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
    * @param expected the object that was expected
    * @param errorMessageFormat the error message to format
    * @param arguments the arguments referenced by the format specifiers in the errorMessage string.
-   * @see #failWithMessage(String, Object...)
+   * @return The generated assertion error.
+   * @see #failure(String, Object...)
+   * @see #failWithActualExpectedAndMessage(Object, Object, String, Object...)
    */
-  protected void failWithActualExpectedAndMessage(Object actual, Object expected, String errorMessageFormat,
-                                                  Object... arguments) {
+  protected AssertionError failureWithActualExpected(Object actual, Object expected, String errorMessageFormat,
+                                                     Object... arguments) {
     String errorMessage = Optional.ofNullable(info.overridingErrorMessage())
                                   .orElse(format(errorMessageFormat, arguments));
     String description = MessageFormatter.instance().format(info.description(), info.representation(), errorMessage);
     AssertionError assertionError = assertionErrorCreator.assertionError(description, actual, expected);
     Failures.instance().removeAssertJRelatedElementsFromStackTraceIfNeeded(assertionError);
     removeCustomAssertRelatedElementsFromStackTraceIfNeeded(assertionError);
-    throw assertionError;
+    return assertionError;
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/ConcreteAssert.java
+++ b/src/test/java/org/assertj/core/api/ConcreteAssert.java
@@ -14,6 +14,7 @@ package org.assertj.core.api;
 
 import org.assertj.core.internal.Objects;
 import org.assertj.core.util.VisibleForTesting;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * @author Alex Ruiz
@@ -59,4 +60,15 @@ public class ConcreteAssert extends AbstractAssert<ConcreteAssert, Object> {
     super.failWithActualExpectedAndMessage(actual, expected, errorMessage, arguments);
   }
 
+  @VisibleForTesting
+  @Override
+  public AssertionError failure(String errorMessage, Object... arguments) {
+    return super.failure(errorMessage, arguments);
+  }
+
+  @VisibleForTesting
+  @Override
+  public AssertionFailedError failureWithActualExpected(Object actual, Object expected, String errorMessage, Object... arguments) {
+    return (AssertionFailedError)super.failureWithActualExpected(actual, expected, errorMessage, arguments);
+  }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_failureWithActualExpected_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_failureWithActualExpected_Test.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.assertj.core.api.ConcreteAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+/**
+ * Tests for <code>AbstractAssert#failureWithActualExpected(Object, Object, String, Object...)</code>.
+ *
+ * @author Joel Costigliola
+ * @author Fr Jeremy Krieg
+ */
+class AbstractAssert_failureWithActualExpected_Test {
+
+  private ConcreteAssert assertion;
+
+  private Object actual = "Actual";
+  private Object expected = "Expected";
+
+  @BeforeEach
+  void setup() {
+    assertion = new ConcreteAssert("foo");
+  }
+
+  @Test
+  void should_create_failure_with_simple_message() {
+    // WHEN
+    AssertionFailedError afe = assertion.failureWithActualExpected(actual, expected, "fail");
+
+    // THEN
+    then(afe).hasMessage("fail");
+    then(afe.getActual().getEphemeralValue()).isSameAs(actual);
+    then(afe.getExpected().getEphemeralValue()).isSameAs(expected);
+  }
+
+  @Test
+  void should_create_failure_with_message_having_args() {
+    // WHEN
+    AssertionFailedError afe = assertion.failureWithActualExpected(actual, expected, "fail %d %s %%s", 5, "times");
+
+    // THEN
+    then(afe).hasMessage("fail 5 times %s");
+    then(afe.getActual().getEphemeralValue()).isSameAs(actual);
+    then(afe.getExpected().getEphemeralValue()).isSameAs(expected);
+  }
+
+  @Test
+  void should_keep_description_set_by_user() {
+    // WHEN
+    AssertionFailedError afe = assertion.as("user description")
+                                        .failureWithActualExpected(actual, expected,
+                                                                   "fail %d %s", 5,
+                                                                   "times");
+    // THEN
+    then(afe).hasMessage("[user description] fail 5 times");
+    then(afe.getActual().getEphemeralValue()).isSameAs(actual);
+    then(afe.getExpected().getEphemeralValue()).isSameAs(expected);
+  }
+
+  @Test
+  void should_keep_specific_error_message_and_description_set_by_user() {
+    // WHEN
+    AssertionFailedError afe = assertion.as("test context")
+                                        .overridingErrorMessage("my %d errors %s", 5, "!")
+                                        .failureWithActualExpected(actual, expected,
+                                                                   "%d %s", 5,
+                                                                   "time");
+    // THEN
+    then(afe).hasMessage("[test context] my 5 errors !");
+    then(afe.getActual().getEphemeralValue()).isSameAs(actual);
+    then(afe.getExpected().getEphemeralValue()).isSameAs(expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_failure_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_failure_Test.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+import org.assertj.core.api.ConcreteAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>AbstractAssert#failure(String, Object...)</code>.
+ *
+ * @author Joel Costigliola
+ */
+class AbstractAssert_failure_Test {
+
+  private ConcreteAssert assertion;
+
+  @BeforeEach
+  void setup() {
+    assertion = new ConcreteAssert("foo");
+  }
+
+  @Test
+  void should_create_failure_with_simple_message() {
+    // WHEN
+    AssertionError error = assertion.failure("fail");
+    // THEN
+    then(error).hasMessage("fail");
+  }
+
+  @Test
+  void should_create_failure_with_message_having_args() {
+    // WHEN
+    AssertionError error = assertion.failure("fail %d %s", 5, "times");
+    // THEN
+    then(error).hasMessage("fail 5 times");
+  }
+
+  @Test
+  void should_keep_description_set_by_user() {
+    // WHEN
+    AssertionError error = assertion.as("user description").failure("fail %d %s", 5, "times");
+    // THEN
+    then(error).hasMessage("[user description] fail 5 times");
+  }
+
+  @Test
+  void should_keep_specific_error_message_and_description_set_by_user() {
+    // WHEN
+    AssertionError error = assertion.as("test context")
+                                    .overridingErrorMessage("my %d errors %s %%s", 5, "!")
+                                    .failure("%d %s", 5, "time");
+    // THEN
+    then(error).hasMessage("[test context] my 5 errors ! %s");
+  }
+
+}


### PR DESCRIPTION
Fixes #2001.

I couldn't use the same name (`failure()`) for both methods because the arguments are too similar for common use cases and lead to ambiguities that the compiler can't resolve. So I went with `failure()` and `failureWithActualExpected`. I'm open to alternatives.