### PR TITLE
#2005 Adds assertions for infinities.

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -42,6 +42,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  * @author Nicolas François
+ * @author Jin Kwon
  */
 public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SELF>> extends
     AbstractComparableAssert<SELF, Double> implements FloatingPointNumberAssert<SELF, Double> {
@@ -855,4 +856,45 @@ public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SEL
     return doubles.getComparator() == null;
   }
 
+  /** {@inheritDoc} */
+  @Override
+  public SELF isFinite() {
+    doubles.assertIsFinite(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isInfinite() {
+    doubles.assertIsInfinite(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isNegativeInfinity() {
+    doubles.assertIsNegativeInfinity(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isNotNegativeInfinity() {
+    doubles.assertIsNotNegativeInfinity(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isPositiveInfinity() {
+    doubles.assertIsPositiveInfinity(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isNotPositiveInfinity() {
+    doubles.assertIsNotPositiveInfinity(info, actual);
+    return myself;
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFloatAssert.java
@@ -40,6 +40,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Ansgar Konermann
  * @author Mikhail Mazursky
  * @author Nicolas François
+ * @author Jin Kwon
  */
 public abstract class AbstractFloatAssert<SELF extends AbstractFloatAssert<SELF>> extends AbstractComparableAssert<SELF, Float>
     implements FloatingPointNumberAssert<SELF, Float> {
@@ -870,5 +871,47 @@ public abstract class AbstractFloatAssert<SELF extends AbstractFloatAssert<SELF>
 
   private boolean noCustomComparatorSet() {
     return floats.getComparator() == null;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isFinite() {
+    floats.assertIsFinite(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isInfinite() {
+    floats.assertIsInfinite(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isNegativeInfinity() {
+    floats.assertIsNegativeInfinity(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isNotNegativeInfinity() {
+    floats.assertIsNotNegativeInfinity(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isPositiveInfinity() {
+    floats.assertIsPositiveInfinity(info, actual);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public SELF isNotPositiveInfinity() {
+    floats.assertIsNotPositiveInfinity(info, actual);
+    return myself;
   }
 }

--- a/src/main/java/org/assertj/core/api/FloatingPointNumberAssert.java
+++ b/src/main/java/org/assertj/core/api/FloatingPointNumberAssert.java
@@ -23,8 +23,10 @@ import org.assertj.core.data.Offset;
  * @author Alex Ruiz
  * @author Yvonne Wang
  * @author Mikhail Mazursky
+ * @author Jin Kwon
  */
-public interface FloatingPointNumberAssert<SELF extends  FloatingPointNumberAssert<SELF, ACTUAL>, ACTUAL extends Number> extends NumberAssert<SELF, ACTUAL> {
+public interface FloatingPointNumberAssert<SELF extends FloatingPointNumberAssert<SELF, ACTUAL>, ACTUAL extends Number>
+    extends NumberAssert<SELF, ACTUAL> {
 
   /**
    * Verifies that the actual number is close to the given one within the given offset value.
@@ -150,4 +152,148 @@ public interface FloatingPointNumberAssert<SELF extends  FloatingPointNumberAsse
    * @throws AssertionError if the actual value is equal to {@code NaN}.
    */
   SELF isNotNaN();
+
+  /**
+   * Verifies that the actual value is a finite floating-point value.
+   * <p>
+   * Example:
+   * <blockquote><pre>{@code
+   * // assertions will pass
+   * assertThat(+1.0f).isFinite();
+   * assertThat(-1.0d).isFinite();
+   *
+   * // assertions will fail
+   * assertThat(Float.NaN).isFinite();
+   * assertThat(Float.NEGATIVE_INFINITY).isFinite();
+   * assertThat(Float.POSITIVE_INFINITY).isFinite();
+   * assertThat(Double.NaN).isFinite();
+   * assertThat(Double.NEGATIVE_INFINITY).isFinite();
+   * assertThat(Double.POSITIVE_INFINITY).isFinite();
+   * }</pre></blockquote>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is not a finite floating-point value.
+   * @see #isInfinite()
+   */
+  SELF isFinite();
+
+  /**
+   * Verifies that the actual value represents positive infinity or negative infinity.
+   * <p>
+   * Example:
+   * <blockquote><pre>{@code
+   * // assertions will pass
+   * assertThat(Float.NEGATIVE_INFINITY).isInfinite();
+   * assertThat(Float.POSITIVE_INFINITY).isInfinite();
+   * assertThat(Double.NEGATIVE_INFINITY).isInfinite();
+   * assertThat(Double.POSITIVE_INFINITY).isInfinite();
+   *
+   * // assertions will fail
+   * assertThat(+1.0f).isInfinite();
+   * assertThat(Float.NaN).isInfinite();
+   * assertThat(-1.0d).isInfinite();
+   * assertThat(Double.NaN).isInfinite();
+   * }</pre></blockquote>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value doesn't represent the positive infinity nor negative infinity.
+   * @see #isFinite()
+   */
+  SELF isInfinite();
+
+  /**
+   * Verifies that the actual value is equal to {@code NEGATIVE_INFINITY}.
+   * <p>
+   * Example:
+   * <blockquote><pre>{@code
+   * // assertions will pass
+   * assertThat(Float.NEGATIVE_INFINITY).isNegativeInfinity();
+   * assertThat(Double.NEGATIVE_INFINITY).isNegativeInfinity();
+   *
+   * // assertions will fail
+   * assertThat(+1.0f).isNegativeInfinity();
+   * assertThat(Float.NaN).isNegativeInfinity();
+   * assertThat(Float.POSITIVE_INFINITY).isNegativeInfinity();
+   * assertThat(-1.0d).isNegativeInfinity();
+   * assertThat(Double.NaN).isNegativeInfinity();
+   * assertThat(Double.POSITIVE_INFINITY).isNegativeInfinity();
+   * }</pre></blockquote>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is not equal to {@code NEGATIVE_INFINITY}.
+   * @see #isNotNegativeInfinity()
+   */
+  SELF isNegativeInfinity();
+
+  /**
+   * Verifies that the actual value is not equal to {@code NEGATIVE_INFINITY}.
+   * <p>
+   * Example:
+   * <blockquote><pre>{@code
+   * // assertions will pass
+   * assertThat(+1.0f).isNotNegativeInfinity();
+   * assertThat(Float.NaN).isNotNegativeInfinity();
+   * assertThat(Float.POSITIVE_INFINITY).isNotNegativeInfinity();
+   * assertThat(-1.0d).isNotNegativeInfinity();
+   * assertThat(Double.NaN).isNegativeInfinity();
+   * assertThat(Double.POSITIVE_INFINITY).isNotNegativeInfinity();
+   *
+   * // assertions will fail
+   * assertThat(Float.NEGATIVE_INFINITY).isNotNegativeInfinity();
+   * assertThat(Double.NEGATIVE_INFINITY).isNotNegativeInfinity();
+   * }</pre></blockquote>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is equal to {@code NEGATIVE_INFINITY}.
+   * @see #isNegativeInfinity()
+   */
+  SELF isNotNegativeInfinity();
+
+  /**
+   * Verifies that the actual value is equal to {@code POSITIVE_INFINITY}.
+   * <p>
+   * Example:
+   * <blockquote><pre>{@code
+   * // assertions will pass
+   * assertThat(Float.POSITIVE_INFINITY).isPositiveInfinity();
+   * assertThat(Double.POSITIVE_INFINITY).isPositiveInfinity();
+   *
+   * // assertions will fail
+   * assertThat(+1.0f).isPositiveInfinity();
+   * assertThat(Float.NaN).isPositiveInfinity();
+   * assertThat(Float.NEGATIVE_INFINITY).isPositiveInfinity();
+   * assertThat(-1.0d).isPositiveInfinity();
+   * assertThat(Double.NaN).isPositiveInfinity();
+   * assertThat(Double.NEGATIVE_INFINITY).isPositiveInfinity();
+   * }</pre></blockquote>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is not equal to {@code POSITIVE_INFINITY}.
+   * @see #isNotPositiveInfinity()
+   */
+  SELF isPositiveInfinity();
+
+  /**
+   * Verifies that the actual value is not equal to {@code POSITIVE_INFINITY}.
+   * <p>
+   * Example:
+   * <blockquote><pre>{@code
+   * // assertions will pass
+   * assertThat(+1.0f).isNotPositiveInfinity();
+   * assertThat(Float.NaN).isNotPositiveInfinity();
+   * assertThat(Float.NEGATIVE_INFINITY).isNotPositiveInfinity();
+   * assertThat(-1.0d).isNotPositiveInfinity();
+   * assertThat(Double.NaN).isNotPositiveInfinity();
+   * assertThat(Double.NEGATIVE_INFINITY).isNotPositiveInfinity();
+   *
+   * // assertions will fail
+   * assertThat(Float.POSITIVE_INFINITY).isNotPositiveInfinity();
+   * assertThat(Double.POSITIVE_INFINITY).isNotPositiveInfinity();
+   * }</pre></blockquote>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if the actual value is equal to {@code POSITIVE_INFINITY}.
+   * @see #isPositiveInfinity()
+   */
+  SELF isNotPositiveInfinity();
 }

--- a/src/main/java/org/assertj/core/internal/Doubles.java
+++ b/src/main/java/org/assertj/core/internal/Doubles.java
@@ -22,6 +22,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Drummond Dawson
  * @author Alex Ruiz
  * @author Joel Costigliola
+ * @author Jin Kwon
  */
 public class Doubles extends RealNumbers<Double> {
 
@@ -65,4 +66,43 @@ public class Doubles extends RealNumbers<Double> {
     return abs(other.doubleValue() - actual.doubleValue());
   }
 
+  /**
+   * {@inheritDoc}
+   * @param value {@inheritDoc}
+   * @return {@inheritDoc}
+   * @see Double#isFinite(double)
+   */
+  @Override
+  protected boolean isFinite(Double value) {
+    return Double.isFinite(value);
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param value {@inheritDoc}
+   * @return {@inheritDoc}
+   * @see Double#isInfinite(double)
+   */
+  @Override
+  protected boolean isInfinite(Double value) {
+    return Double.isInfinite(value);
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return {@link Double#NEGATIVE_INFINITY}.
+   */
+  @Override
+  protected Double NEGATIVE_INFINITY() {
+    return Double.NEGATIVE_INFINITY;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return {@link Double#POSITIVE_INFINITY}.
+   */
+  @Override
+  protected Double POSITIVE_INFINITY() {
+    return Double.POSITIVE_INFINITY;
+  }
 }

--- a/src/main/java/org/assertj/core/internal/Floats.java
+++ b/src/main/java/org/assertj/core/internal/Floats.java
@@ -23,6 +23,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Alex Ruiz
  * @author Joel Costigliola
  * @author Mikhail Mazursky
+ * @author Jin Kwon
  */
 public class Floats extends RealNumbers<Float> {
 
@@ -65,4 +66,45 @@ public class Floats extends RealNumbers<Float> {
   protected Float absDiff(Float actual, Float other) {
     return abs(other.floatValue() - actual.floatValue());
   }
+
+  /**
+   * {@inheritDoc}
+   * @param value {@inheritDoc}
+   * @return {@inheritDoc}
+   * @see Float#isFinite(float)
+   */
+  @Override
+  protected boolean isFinite(Float value) {
+    return Float.isFinite(value);
+  }
+
+  /**
+   * {@inheritDoc}
+   * @param value {@inheritDoc}
+   * @return {@inheritDoc}
+   * @see Float#isInfinite(float)
+   */
+  @Override
+  protected boolean isInfinite(Float value) {
+    return Float.isInfinite(value);
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return {@link Float#NEGATIVE_INFINITY}.
+   */
+  @Override
+  protected Float NEGATIVE_INFINITY() {
+    return Float.NEGATIVE_INFINITY;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @return {@link Float#POSITIVE_INFINITY}.
+   */
+  @Override
+  protected Float POSITIVE_INFINITY() {
+    return Float.POSITIVE_INFINITY;
+  }
+
 }

--- a/src/main/java/org/assertj/core/internal/RealNumbers.java
+++ b/src/main/java/org/assertj/core/internal/RealNumbers.java
@@ -12,12 +12,15 @@
  */
 package org.assertj.core.internal;
 
+import static org.assertj.core.error.ShouldBeTrue.shouldBeTrue;
+
 import org.assertj.core.api.AssertionInfo;
 
 /**
  * Base class of reusable assertions for real numbers (float and double).
  * 
  * @author Joel Costigliola
+ * @author Jin Kwon
  */
 public abstract class RealNumbers<NUMBER extends Number & Comparable<NUMBER>> extends Numbers<NUMBER> {
 
@@ -58,4 +61,100 @@ public abstract class RealNumbers<NUMBER extends Number & Comparable<NUMBER>> ex
     return value.compareTo(other) > 0;
   }
 
+  /**
+   * Checks whether specified value is a finite floating-point value.
+   * @param value the value to check.
+   * @return {@code true} if the value is a finite floating-point value; {@code false} otherwise.
+   */
+  protected abstract boolean isFinite(NUMBER value);
+
+  /**
+   * Verifies that the actual value is a finite floating-point value.
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is not a finite floating-point value.
+   */
+  public void assertIsFinite(AssertionInfo info, NUMBER actual) {
+    assertNotNull(info, actual);
+    final boolean result = isFinite(actual);
+    if (result) {
+      return;
+    }
+    throw failures.failure(info, shouldBeTrue(false));
+  }
+
+  /**
+   * Checks whether specified value is infinitely large in magnitude.
+   * @param value the value to check.
+   * @return {@code true} if the {@code value} is positive infinity or negative infinity; {@code false} otherwise.
+   */
+  protected abstract boolean isInfinite(NUMBER value);
+
+  /**
+   * Verifies that the actual value is infinitely large in magnitude.
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is not positive infinity nor negative infinity.
+   */
+  public void assertIsInfinite(AssertionInfo info, NUMBER actual) {
+    assertNotNull(info, actual);
+    final boolean result = isInfinite(actual);
+    if (result)
+      return;
+    throw failures.failure(info, shouldBeTrue(false));
+  }
+
+  /**
+   * Returns a value represents positive infinity.
+   * @return a value represents positive infinity.
+   */
+  protected abstract NUMBER POSITIVE_INFINITY();
+
+  /**
+   * Verifies that the actual value is equal to what {@link #POSITIVE_INFINITY()} returns.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is not equal to {@code POSITIVE_INFINITY}.
+   */
+  public void assertIsPositiveInfinity(AssertionInfo info, NUMBER actual) {
+    assertEqualByComparison(info, actual, POSITIVE_INFINITY());
+  }
+
+  /**
+   * Verifies that the actual value is not equal to what {@link #POSITIVE_INFINITY()} returns.
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is equal to {@code POSITIVE_INFINITY}.
+   */
+  public void assertIsNotPositiveInfinity(AssertionInfo info, NUMBER actual) {
+    assertNotEqualByComparison(info, actual, POSITIVE_INFINITY());
+  }
+
+  /**
+   * Returns a value represents negative infinity.
+   * @return a value represents negative infinity.
+   */
+  protected abstract NUMBER NEGATIVE_INFINITY();
+
+  /**
+   * Verifies that the actual value is equal to what {@link #NEGATIVE_INFINITY()} returns.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is not equal to {@code NEGATIVE_INFINITY}.
+   */
+  public void assertIsNegativeInfinity(AssertionInfo info, NUMBER actual) {
+    assertEqualByComparison(info, actual, NEGATIVE_INFINITY());
+  }
+
+  /**
+   * Verifies that the actual value is not equal to what {@link #NEGATIVE_INFINITY()} returns.
+   * @param info contains information about the assertion.
+   * @param actual the actual value.
+   * @throws AssertionError if the actual value is equal to {@code NEGATIVE_INFINITY}.
+   */
+  public void assertIsNotNegativeInfinity(AssertionInfo info, NUMBER actual) {
+    assertNotEqualByComparison(info, actual, NEGATIVE_INFINITY());
+  }
 }

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssertTestParameters.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssertTestParameters.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.DoubleStream;
+import java.util.stream.LongStream;
+
+import org.assertj.core.api.DoubleAssert;
+
+/**
+ * A class provides shared test parameters for {@link DoubleAssert}-related test classes.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+final class DoubleAssertTestParameters {
+
+  private static LongStream signs() {
+    return LongStream.of(0b0__00000000_000__00000000_00000000_00000000_00000000_00000000_00000000__0000L,
+                         0b1__00000000_000__00000000_00000000_00000000_00000000_00000000_00000000__0000L);
+  }
+
+  static DoubleStream zeros() {
+    return signs()
+      .mapToDouble(Double::longBitsToDouble)
+      .peek(v-> assertThat(v).isZero().isNotNaN().isFinite());
+  }
+
+  static DoubleStream subnormalValues() {
+    return LongStream.range(0, 128)
+      .map(i -> {
+        final long e = 0b0__00000000_000__00000000_00000000_00000000_00000000_00000000_00000000__0000L;
+        final long g = (current().nextLong(Long.MAX_VALUE) + 1L) >>> 12;
+        return e | g;
+      })
+      .flatMap(v -> signs().map(s -> s | v))
+      .mapToDouble(Double::longBitsToDouble)
+      .peek(v -> assertThat(v).isNotZero().isNotNaN().isFinite());
+  }
+
+  static DoubleStream normalValues() {
+    return LongStream.range(0, 128)
+      .map(i -> {
+        final long e = current().nextLong(0x001L, 0x7FFL) << 52;
+        final long g = current().nextInt() >>> 12;
+        return e | g;
+      })
+      .flatMap(v -> signs().map(s -> s | v))
+      .mapToDouble(Double::longBitsToDouble)
+      .peek(v -> assertThat(v).isNotZero().isNotNaN().isFinite());
+  }
+
+  private DoubleAssertTestParameters() {
+    super();
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isFinite_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isFinite_Test.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link DoubleAssert#isFinite()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class DoubleAssert_isFinite_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isInfinite();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsInfinite(getInfo(assertions), getActual(assertions));
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_zero(final double actual) {
+    assertThat(actual).isFinite();
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_subnormal_value(final double actual) {
+    assertThat(actual).isFinite();
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_normal_value(final double actual) {
+    assertThat(actual).isFinite();
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final double actual = Double.NaN;
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isFinite());
+  }
+
+  @Test
+  void should_fail_if_actual_is_NEGATIVE_INFINITY() {
+    final double actual = Double.NEGATIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isFinite());
+  }
+
+  @Test
+  void should_fail_if_actual_is_POSITIVE_INFINITY() {
+    final double actual = Double.POSITIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isFinite());
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isInfinite_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isInfinite_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link DoubleAssert#isInfinite()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class DoubleAssert_isInfinite_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isInfinite();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsInfinite(getInfo(assertions), getActual(assertions));
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_zero(final double actual) {
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_subnormal_value(final double actual) {
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_normal_value(final double actual) {
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    double actual = Double.NaN;
+    assertThatExceptionOfType(AssertionError.class)
+                                                   .isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @Test
+  void should_pass_if_actual_is_NEGATIVE_INFINITY() {
+    double actual = Double.NEGATIVE_INFINITY;
+    assertThat(actual).isInfinite();
+  }
+
+  @Test
+  void should_pass_if_actual_is_POSITIVE_INFINITY() {
+    double actual = Double.POSITIVE_INFINITY;
+    assertThat(actual).isInfinite();
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNegativeInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNegativeInfinity_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for <code>{@link DoubleAssert#isNegativeInfinity()}</code>.
+ * 
+ * @author Jin Kwon
+ */
+class DoubleAssert_isNegativeInfinity_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isNegativeInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsNegativeInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_pass_if_actual_is_NEGATIVE_INFINITY() {
+    final double actual = Float.NEGATIVE_INFINITY;
+    assertThat(actual).isNegativeInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_zero(final double actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.NEGATIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_subnormal_value(final double actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.NEGATIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_normal_value(final double actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.NEGATIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final double actual = Double.NaN;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.NEGATIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_POSITIVE_INFINITY() {
+    final double actual = Double.POSITIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.NEGATIVE_INFINITY);
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotNegativeInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotNegativeInfinity_Test.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for {@link DoubleAssert#isNotNegativeInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class DoubleAssert_isNotNegativeInfinity_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isNotNegativeInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsNotNegativeInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_fail_if_actual_is_NEGATIVE_INFINITY() {
+    final double actual = Float.NEGATIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNotNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.NEGATIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_zero(final double actual) {
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_subnormal_value(final double actual) {
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_normal_value(final double actual) {
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_POSITIVE_INFINITY() {
+    final double actual = Double.POSITIVE_INFINITY;
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_NaN() {
+    final double actual = Double.NaN;
+    assertThat(actual).isNotNegativeInfinity();
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotPositiveInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotPositiveInfinity_Test.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link DoubleAssert#isNotPositiveInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class DoubleAssert_isNotPositiveInfinity_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isNotPositiveInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsNotPositiveInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_fail_if_actual_is_POSITIVE_INFINITY() {
+    final double actual = Double.POSITIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertThat(actual).isNotPositiveInfinity())
+      .withMessageContainingAll("" + actual, "" + Double.POSITIVE_INFINITY);
+  }
+
+  @MethodSource({"org.assertj.core.api.double_.DoubleAssertTestParameters#zeros"})
+  @ParameterizedTest
+  void should_pass_if_actual_is_zero(final double actual) {
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @MethodSource({"org.assertj.core.api.double_.DoubleAssertTestParameters#subnormalValues"})
+  @ParameterizedTest
+  void should_pass_if_actual_is_subnormal_value(final double actual) {
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @MethodSource({"org.assertj.core.api.double_.DoubleAssertTestParameters#normalValues"})
+  @ParameterizedTest
+  void should_pass_if_actual_is_normal_value(final double actual) {
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_NEGATIVE_INFINITY() {
+    final double actual = Double.NEGATIVE_INFINITY;
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_NaN() {
+    final double actual = Double.NaN;
+    assertThat(actual).isNotPositiveInfinity();
+  }
+}

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isPositiveInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isPositiveInfinity_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.double_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link DoubleAssert#isPositiveInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class DoubleAssert_isPositiveInfinity_Test extends DoubleAssertBaseTest {
+
+  @Override
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isPositiveInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(doubles).assertIsPositiveInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_pass_if_actual_is_POSITIVE_INFINITY() {
+    final double actual = Double.POSITIVE_INFINITY;
+    assertThat(actual).isPositiveInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_zero(final double actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.POSITIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_subnormal_value(final double actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.POSITIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.double_.DoubleAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_normal_value(final double actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_NEGATIVE_INFINITY() {
+    final double actual = Double.NEGATIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final double actual = Double.NaN;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Double.POSITIVE_INFINITY);
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssertTestParameters.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssertTestParameters.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static java.util.concurrent.ThreadLocalRandom.current;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.assertj.core.api.FloatAssert;
+
+/**
+ * A class provides shared test parameters for {@link FloatAssert}-related test classes.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+final class FloatAssertTestParameters {
+
+  private static IntStream signs() {
+    return IntStream.of(0b0__00000000__00000000_00000000_0000_000,
+                        0b1__00000000__00000000_00000000_0000_000);
+  }
+
+  static Stream<Float> zeros() {
+    return signs()
+      .mapToObj(Float::intBitsToFloat)
+      .peek(v -> assertThat(v.floatValue()).isZero().isNotNaN().isFinite());
+  }
+
+  static Stream<Float> subnormalValues() {
+    return IntStream.range(0, 128)
+      .map(i -> {
+        final int e = 0b0__00000000__00000000_00000000_0000_000;
+        final int g = (current().nextInt(Integer.MAX_VALUE) + 1) >>> 9;
+        return e | g;
+      })
+      .flatMap(v -> signs().map(s -> s | v))
+      .mapToObj(Float::intBitsToFloat)
+      .peek(v ->        assertThat(v.floatValue()).isNotZero().isNotNaN().isFinite()      );
+  }
+
+  static Stream<Float> normalValues() {
+    return IntStream.range(0, 128)
+      .map(i -> {
+        int e = current().nextInt(0x01, 0xFF) << 23;
+        int g = current().nextInt() >>> 9;
+        return e | g;
+      })
+      .flatMap(v -> signs().map(s -> s | v))
+      .mapToObj(Float::intBitsToFloat)
+      .peek(v ->        assertThat(v.floatValue()).isNotZero().isNotNaN().isFinite());
+  }
+
+  private FloatAssertTestParameters() {
+    super();
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isFinite_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isFinite_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link FloatAssert#isFinite()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class FloatAssert_isFinite_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isFinite();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsFinite(getInfo(assertions), getActual(assertions));
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_zero(final float actual) {
+    assertThat(actual).isFinite();
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_subnormal_value(final float actual) {
+    assertThat(actual).isFinite();
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_normal_value(final float actual) {
+    assertThat(actual).isFinite();
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final float actual = Float.NaN;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isFinite());
+  }
+
+  @Test
+  void should_fail_if_actual_is_NEGATIVE_INFINITY() {
+    final float actual = Float.NEGATIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isFinite());
+  }
+
+  @Test
+  void should_fail_if_actual_is_POSITIVE_INFINITY() {
+    final float actual = Float.POSITIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isFinite());
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isInfinite_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isInfinite_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link FloatAssert#isInfinite()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class FloatAssert_isInfinite_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isInfinite();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsInfinite(getInfo(assertions), getActual(assertions));
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_zero(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_subnormal_value(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_normal_value(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final float actual = Float.NaN;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isInfinite());
+  }
+
+  @Test
+  void should_pass_if_actual_is_NEGATIVE_INFINITY() {
+    float actual = Float.NEGATIVE_INFINITY;
+    assertThat(actual).isInfinite();
+  }
+
+  @Test
+  void should_pass_if_actual_is_POSITIVE_INFINITY() {
+    float actual = Float.POSITIVE_INFINITY;
+    assertThat(actual).isInfinite();
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNegativeInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNegativeInfinity_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link FloatAssert#isNegativeInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class FloatAssert_isNegativeInfinity_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isNegativeInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsNegativeInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_pass_if_actual_is_NEGATIVE_INFINITY() {
+    final float actual = Float.NEGATIVE_INFINITY;
+    assertThat(actual).isNegativeInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_zero(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.NEGATIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_subnormal_value(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.NEGATIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_normal_value(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.NEGATIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final float actual = Float.NaN;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.NEGATIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_POSITIVE_INFINITY() {
+    final float actual = Float.POSITIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.NEGATIVE_INFINITY);
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotNegativeInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotNegativeInfinity_Test.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A cass for testing {@link DoubleAssert#isNotNegativeInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class FloatAssert_isNotNegativeInfinity_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isNotNegativeInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsNotNegativeInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_fail_if_actual_is_NEGATIVE_INFINITY() {
+    final float actual = Float.NEGATIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isNotNegativeInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.NEGATIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_zero(final float actual) {
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_subnormal_value(final float actual) {
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_pass_if_actual_is_normal_value(final float actual) {
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_POSITIVE_INFINITY() {
+    final float actual = Float.POSITIVE_INFINITY;
+    assertThat(actual).isNotNegativeInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_NaN() {
+    final float actual = Float.NaN;
+    assertThat(actual).isNotNegativeInfinity();
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotPositiveInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotPositiveInfinity_Test.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link FloatAssert#isNotPositiveInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class FloatAssert_isNotPositiveInfinity_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isPositiveInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsPositiveInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_fail_if_actual_is_POSITIVE_INFINITY() {
+    final float actual = Float.POSITIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertThat(actual).isNotPositiveInfinity())
+      .withMessageContainingAll("" + actual, "" + Float.POSITIVE_INFINITY);
+  }
+
+  @MethodSource({"org.assertj.core.api.float_.FloatAssertTestParameters#zeros"})
+  @ParameterizedTest
+  void should_pass_if_actual_is_zero(final float actual) {
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @MethodSource({"org.assertj.core.api.float_.FloatAssertTestParameters#subnormalValues"})
+  @ParameterizedTest
+  void should_pass_if_actual_is_subnormal_value(final float actual) {
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @MethodSource({"org.assertj.core.api.float_.FloatAssertTestParameters#normalValues"})
+  @ParameterizedTest
+  void should_pass_if_actual_is_normal_value(final float actual) {
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_NEGATIVE_INFINITY() {
+    final float actual = Float.NEGATIVE_INFINITY;
+    assertThat(actual).isNotPositiveInfinity();
+  }
+
+  @Test
+  void should_pass_if_actual_is_NaN() {
+    final float actual = Float.NaN;
+    assertThat(actual).isNotPositiveInfinity();
+  }
+}

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isPositiveInfinity_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isPositiveInfinity_Test.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.float_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * A class for testing {@link FloatAssert#isPositiveInfinity()} method.
+ * 
+ * @author Jin Kwon &lt;onacit_at_gmail.com&gt;
+ */
+class FloatAssert_isPositiveInfinity_Test extends FloatAssertBaseTest {
+
+  @Override
+  protected FloatAssert invoke_api_method() {
+    return assertions.isPositiveInfinity();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(floats).assertIsPositiveInfinity(getInfo(assertions), getActual(assertions));
+  }
+
+  @Test
+  void should_pass_if_actual_is_POSITIVE_INFINITY() {
+    final float actual = Float.POSITIVE_INFINITY;
+    assertThat(actual).isPositiveInfinity();
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#zeros" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_zero(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.POSITIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#subnormalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_subnormal_value(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.POSITIVE_INFINITY);
+  }
+
+  @MethodSource({ "org.assertj.core.api.float_.FloatAssertTestParameters#normalValues" })
+  @ParameterizedTest
+  void should_fail_if_actual_is_normal_value(final float actual) {
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.POSITIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_NEGATIVE_INFINITY() {
+    final float actual = Float.NEGATIVE_INFINITY;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.POSITIVE_INFINITY);
+  }
+
+  @Test
+  void should_fail_if_actual_is_NaN() {
+    final float actual = Float.NaN;
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(actual).isPositiveInfinity())
+                                                   .withMessageContainingAll("" + actual, "" + Float.POSITIVE_INFINITY);
+  }
+}


### PR DESCRIPTION
* `isFinite()`   // without isNotFinite();
* `isInfinite()` // without isNotInfinite();
* `isNegativeInfinite()`
* `isNotNegativeInfinite()`
* `isPositiveInfinite()`
* `isNotPositiveInfinite()`

#### Check List:
* Fixes #2005
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


