### PR TITLE
Improve describe error readability of ElementsShouldSatisfy

### DIFF
--- a/src/main/java/org/assertj/core/error/ElementsShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/ElementsShouldSatisfy.java
@@ -68,7 +68,7 @@ public class ElementsShouldSatisfy extends BasicErrorMessageFactory {
     }
 
     public String describe(AssertionInfo info) {
-      return format("  <%s> error: %s", info.representation().toStringOf(elementNotSatisfyingRequirements), errorMessage);
+      return format("  <%s>%nerror: %s", info.representation().toStringOf(elementNotSatisfyingRequirements), errorMessage);
     }
 
     @Override

--- a/src/main/java/org/assertj/core/error/ZippedElementsShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/ZippedElementsShouldSatisfy.java
@@ -60,7 +60,7 @@ public class ZippedElementsShouldSatisfy extends BasicErrorMessageFactory {
     }
 
     public static String describe(AssertionInfo info, ZipSatisfyError satisfyError) {
-      return String.format("(%s, %s) error: %s",
+      return String.format("(%s, %s)%nerror: %s",
                            info.representation().toStringOf(satisfyError.actualElement),
                            info.representation().toStringOf(satisfyError.otherElement),
                            satisfyError.error);
@@ -68,7 +68,7 @@ public class ZippedElementsShouldSatisfy extends BasicErrorMessageFactory {
 
     @Override
     public String toString() {
-      return String.format("(%s, %s) error: %s", actualElement, otherElement, error);
+      return String.format("(%s, %s)%nerror: %s", actualElement, otherElement, error);
     }
 
   }

--- a/src/test/java/org/assertj/core/error/ElementsShouldSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ElementsShouldSatisfy_create_Test.java
@@ -50,8 +50,10 @@ class ElementsShouldSatisfy_create_Test {
                                    "Expecting all elements of:%n" +
                                    "  <[\"Leia\", \"Luke\", \"Yoda\"]>%n" +
                                    "to satisfy given requirements, but these elements did not:%n%n" +
-                                   "  <\"Leia\"> error: Leia mistake.%n%n" +
-                                   "  <\"Luke\"> error: Luke mistake."));
+                                   "  <\"Leia\">%n" +
+                                   "error: Leia mistake.%n%n" +
+                                   "  <\"Luke\">%n" +
+                                   "error: Luke mistake."));
   }
 
   @Test
@@ -67,8 +69,10 @@ class ElementsShouldSatisfy_create_Test {
                                    "Expecting all elements of:%n" +
                                    "  <[\"Leia%%s\", \"Luke\", \"Yoda\"]>%n" +
                                    "to satisfy given requirements, but these elements did not:%n%n" +
-                                   "  <\"Leia%%s\"> error: Leia mistake.%n%n" +
-                                   "  <\"Luke\"> error: Luke mistake."));
+                                   "  <\"Leia%%s\">%n" +
+                                   "error: Leia mistake.%n%n" +
+                                   "  <\"Luke\">%n" +
+                                   "error: Luke mistake."));
   }
 
   @Test
@@ -84,8 +88,10 @@ class ElementsShouldSatisfy_create_Test {
                                    "Expecting any element of:%n" +
                                    "  <[\"Luke\", \"Yoda\"]>%n" +
                                    "to satisfy the given assertions requirements but none did:%n%n" +
-                                   "  <\"Leia\"> error: Leia mistake.%n%n" +
-                                   "  <\"Luke\"> error: Luke mistake."));
+                                   "  <\"Leia\">%n" +
+                                   "error: Leia mistake.%n%n" +
+                                   "  <\"Luke\">%n" +
+                                   "error: Luke mistake."));
   }
 
   @Test
@@ -101,7 +107,9 @@ class ElementsShouldSatisfy_create_Test {
                                    "Expecting any element of:%n" +
                                    "  <[\"Lu%%dke\", \"Yoda\"]>%n" +
                                    "to satisfy the given assertions requirements but none did:%n%n" +
-                                   "  <\"Leia\"> error: Leia mistake.%n%n" +
-                                   "  <\"Luke\"> error: Luke mistake."));
+                                   "  <\"Leia\">%n" +
+                                   "error: Leia mistake.%n%n" +
+                                   "  <\"Luke\">%n" +
+                                   "error: Luke mistake."));
   }
 }

--- a/src/test/java/org/assertj/core/error/ElementsShouldZipSatisfy_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ElementsShouldZipSatisfy_create_Test.java
@@ -53,8 +53,10 @@ class ElementsShouldZipSatisfy_create_Test {
                                    "and:%n" +
                                    "  <[\"LUKE\", \"YODA\"]>%n" +
                                    "to satisfy given requirements but these zipped elements did not:" +
-                                   "%n%n- (\"Luke\", \"LUKE\") error: error luke" +
-                                   "%n%n- (\"Yo-da\", \"YODA\") error: error yoda"));
+                                   "%n%n- (\"Luke\", \"LUKE\")%n" +
+                                   "error: error luke" +
+                                   "%n%n- (\"Yo-da\", \"YODA\")%n" +
+                                   "error: error yoda"));
   }
 
   @Test
@@ -75,7 +77,9 @@ class ElementsShouldZipSatisfy_create_Test {
                                    "and:%n" +
                                    "  <[\"LU%%dKE\", \"YODA\"]>%n" +
                                    "to satisfy given requirements but these zipped elements did not:" +
-                                   "%n%n- (\"Luke\", \"LU%%dKE\") error: error luke" +
-                                   "%n%n- (\"Yo-da\", \"YODA\") error: error yoda"));
+                                   "%n%n- (\"Luke\", \"LU%%dKE\")%n" +
+                                   "error: error luke" +
+                                   "%n%n- (\"Yo-da\", \"YODA\")%n" +
+                                   "error: error yoda"));
   }
 }


### PR DESCRIPTION
Previously, the error was appended after the `toString` of the element that did not satisfy the requirements. This was problematic for objects with a lengthy `toString` because it made the describe error difficult to identify. Now, the describe error is on a new line allowing for quick identification.

#### Check List:
* Fixes #2010
* Unit tests : YES
* Javadoc with a code example (on API only) : NA

I think I updated all the areas needed for this change, otherwise let me know!

