### PR TITLE
Get the current actual

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -1084,4 +1084,20 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
     return (ASSERT) assertFactory.createAssert(extractedValue).withAssertionState(myself);
   }
 
+  /**
+   * Return the actual object under test.
+   * <p>
+   * This allows users to retrieve the current object under test. This method will break assertion chain.
+   * <p>
+   * Example:
+   * <pre><code class='java'> TolkienCharacter smaug = new TolkienCharacter("Smaug", DRAGON);
+   * assertThat(smaug).getActual() // return smaug
+   * assertThat(Optional.of(smaug)).get().getActual() // return smaug
+   *
+   * @return the current object under test.
+   *
+   */
+  public ACTUAL getActual() {
+    return actual;
+  }
 }

--- a/src/main/java/org/assertj/core/api/AbstractTemporalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractTemporalAssert.java
@@ -47,11 +47,6 @@ public abstract class AbstractTemporalAssert<SELF extends AbstractTemporalAssert
     comparables = new Comparables();
   }
 
-  @VisibleForTesting
-  protected TEMPORAL getActual() {
-    return actual;
-  }
-
   /**
    * Verifies that the actual {@link Temporal} is close to the other according to the given {@link TemporalOffset}.
    * <p>

--- a/src/test/java/org/assertj/core/api/abstract_/OptionalAssert_getActual_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/OptionalAssert_getActual_Test.java
@@ -1,0 +1,32 @@
+package org.assertj.core.api.abstract_;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.data.TolkienCharacter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.TolkienCharacter.Race.DRAGON;
+
+class AbstractAssert_getActual_Test {
+
+  @Test
+  void should_pass_if_optional_contains_the_expected_object_reference() {
+    Optional<String> tested = Optional.of("something");
+
+    String innerValue = assertThat(tested).get().getActual();
+
+    assertThat(innerValue).isEqualTo("something");
+  }
+
+  @Test
+  void should_pass_if_optional_contains_the_expected_object_reference2() {
+    TolkienCharacter tested = TolkienCharacter.of("smaug", 1, DRAGON);
+
+    String innerValue = assertThat(tested).extracting("name", as(InstanceOfAssertFactories.STRING)).getActual();
+
+    assertThat(innerValue).isEqualTo("smaug");
+  }
+}


### PR DESCRIPTION
This is the solution proposed in the #1931 to be able to get the current value.

I know it will stop the assertion flow but sometimes it's easier for test readability.

#### Check List:
* Fixes #1931
* Unit tests : YES
* Javadoc with a code example (on API only) : YES

