### PR TITLE
Add AbstractDateAssert.isBetween for Instant bounds

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -30,6 +30,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;
@@ -1241,6 +1242,25 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
+   * Same assertion as {@link #isBetween(Date, Date)} but given date is represented as {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * assertThat(new Date()).isBetween(Instant.now().minusSeconds(5), Instant.now().plusSeconds(5));</code></pre>
+   *
+   * @param start the period start (inclusive), expected not to be null.
+   * @param end the period end (exclusive), expected not to be null.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code Date} is {@code null}.
+   * @throws NullPointerException if start Instant as String is {@code null}.
+   * @throws NullPointerException if end Instant as String is {@code null}.
+   * @throws AssertionError if the actual {@code Date} is not in [start, end[ period.
+   */
+  public SELF isBetween(Instant start, Instant end) {
+    return isBetween(Date.from(start), Date.from(end));
+  }
+
+  /**
    * Verifies that the actual {@code Date} is in the given period defined by start and end dates.<br>
    * To include start
    * in the period set inclusiveStart parameter to <code>true</code>.<br>
@@ -1327,6 +1347,29 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    */
   public SELF isBetween(String start, String end, boolean inclusiveStart, boolean inclusiveEnd) {
     dates.assertIsBetween(info, actual, parse(start), parse(end), inclusiveStart, inclusiveEnd);
+    return myself;
+  }
+
+  /**
+   * Same assertion as {@link #isBetween(Date, Date, boolean, boolean)} but given date is represented as
+   * {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * assertThat(new Date()).isBetween(Instant.now().minusSeconds(5), Instant.now().plusSeconds(5), true, true);</code></pre>
+   *
+   * @param start the period start, expected not to be null.
+   * @param end the period end, expected not to be null.
+   * @param inclusiveStart whether to include start date in period.
+   * @param inclusiveEnd whether to include end date in period.
+   * @return this assertion object.
+   * @throws AssertionError if {@code actual} is {@code null}.
+   * @throws NullPointerException if start Date as Instant is {@code null}.
+   * @throws NullPointerException if end Date as Instant is {@code null}.
+   * @throws AssertionError if the actual {@code Date} is not in (start, end) period.
+   */
+  public SELF isBetween(Instant start, Instant end, boolean inclusiveStart, boolean inclusiveEnd) {
+    dates.assertIsBetween(info, actual, Date.from(start), Date.from(end), inclusiveStart, inclusiveEnd);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -1242,11 +1242,10 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
-   * Same assertion as {@link #isBetween(Date, Date)} but given date is represented as {@code java.time.Instant}.
+   * Same assertion as {@link #isBetween(Date, Date)} but given period is represented as {@code java.time.Instant}.
    * <p>
    * Example:
-   * <pre><code class='java'>
-   * assertThat(new Date()).isBetween(Instant.now().minusSeconds(5), Instant.now().plusSeconds(5));</code></pre>
+   * <pre><code class='java'>assertThat(new Date()).isBetween(Instant.now().minusSeconds(5), Instant.now().plusSeconds(5));</code></pre>
    *
    * @param start the period start (inclusive), expected not to be null.
    * @param end the period end (exclusive), expected not to be null.
@@ -1294,7 +1293,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
-   * Same assertion as {@link #isBetween(Date, Date, boolean, boolean)}but given date is represented as String either
+   * Same assertion as {@link #isBetween(Date, Date, boolean, boolean)} but given date is represented as String either
    * with one of the supported defaults date format or a user custom date format (set with method
    * {@link #withDateFormat(DateFormat)}).
    * <p>
@@ -1351,7 +1350,7 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
-   * Same assertion as {@link #isBetween(Date, Date, boolean, boolean)} but given date is represented as
+   * Same assertion as {@link #isBetween(Date, Date, boolean, boolean)} but given period is represented as
    * {@code java.time.Instant}.
    * <p>
    * Example:

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isBetweenSpecifyingBoundariesInclusion_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isBetweenSpecifyingBoundariesInclusion_Test.java
@@ -14,10 +14,12 @@ package org.assertj.core.api.date;
 
 import static org.mockito.Mockito.verify;
 
+import java.time.Instant;
 import java.util.Date;
 
 import org.assertj.core.api.DateAssert;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link DateAssert#isBetween(Date, Date, boolean, boolean)} and
@@ -48,9 +50,19 @@ class DateAssert_isBetweenSpecifyingBoundariesInclusion_Test extends AbstractDat
     return assertions.isBetween(dateAsString, dateAsString, inclusiveStart, inclusiveEnd);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isBetween(instant, instant, inclusiveStart, inclusiveEnd);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(dates).assertIsBetween(getInfo(assertions), getActual(assertions), date, date, inclusiveStart, inclusiveEnd);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isBetween_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isBetween_Test.java
@@ -14,13 +14,16 @@ package org.assertj.core.api.date;
 
 import static org.mockito.Mockito.verify;
 
+import java.time.Instant;
 import java.util.Date;
 
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
 
 
 /**
- * Tests for {@link DateAssert#isBetween(Date, Date)} and {@link DateAssert#isBetween(String, String)}.
+ * Tests for {@link DateAssert#isBetween(Date, Date)}, {@link DateAssert#isBetween(String, String)} and
+ *  {@link DateAssert#isBetween(Instant, Instant)}.
  * 
  * @author Joel Costigliola
  */
@@ -36,9 +39,19 @@ class DateAssert_isBetween_Test extends AbstractDateAssertWithDateArg_Test {
     return assertions.isBetween(dateAsString, dateAsString);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isBetween(instant, instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(dates).assertIsBetween(getInfo(assertions), getActual(assertions), date, date, true, false);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2032
* Unit tests : YES
* Javadoc with a code example (on API only) : YES

Because it's not possible to add assertionInvocationWithInstantArg to base class and don't override it in other derived classes (then I must add other methods for Instant) I had added it in the derived classes. At the next step, when there will be Instant methods for all derived classes it can be pulled up to the base class.


