### PR TITLE
Add AbstractDateAssert.isEqualXXX for Instant arg

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -145,6 +145,23 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
+   * Same assertion as {@link AbstractAssert#isEqualTo(Object) isEqualTo(Date date)} but given date is represented as
+   * an {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>
+   * // theTwoTowers release date : 2002-12-18
+   * assertThat(theTwoTowers.getReleaseDate()).isEqualTo(Instant.now());</code></pre>
+   *
+   * @param instant the given Date represented as {@code Instant}.
+   * @return this assertion object.
+   * @throws AssertionError if actual and given Date represented as {@code Instant} are not equal.
+   */
+  public SELF isEqualTo(Instant instant) {
+    return isEqualTo(Date.from(instant));
+  }
+
+  /**
    * Same assertion as {@link AbstractDateAssert#isEqualToIgnoringHours(Date)} but given Date is represented as String
    * either with one of the default supported date format or user custom date format (set with method
    * {@link #withDateFormat(DateFormat)}).
@@ -191,6 +208,22 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    */
   public SELF isEqualToIgnoringHours(String dateAsString) {
     return isEqualToIgnoringHours(parse(dateAsString));
+  }
+
+  /**
+   * Same assertion as {@link AbstractDateAssert#isEqualToIgnoringHours(Date)} but given Date is represented as
+   * an {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThat(new Date()).isEqualToIgnoringHours(Instant.now());</code></pre>
+   *
+   * @param instant the given Date represented as {@code Instant}.
+   * @return this assertion object.
+   * @throws AssertionError if actual and given Date represented as {@code Instant} are not equal ignoring
+   *           hours, minutes, seconds and milliseconds.
+   */
+  public SELF isEqualToIgnoringHours(Instant instant) {
+    return isEqualToIgnoringHours(Date.from(instant));
   }
 
   /**
@@ -275,6 +308,22 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
+   * Same assertion as {@link AbstractDateAssert#isEqualToIgnoringMinutes(Date)} but given Date is represented as
+   * an {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThat(new Date()).isEqualToIgnoringMinutes(Instant.now());</code></pre>
+   *
+   * @param instant the given Date represented as {@code Instant}.
+   * @return this assertion object.
+   * @throws AssertionError if actual and given Date represented as {@code Instant} are not equal ignoring minutes, seconds and
+   *           milliseconds.
+   */
+  public SELF isEqualToIgnoringMinutes(Instant instant) {
+    return isEqualToIgnoringMinutes(Date.from(instant));
+  }
+
+  /**
    * Same assertion as {@link AbstractAssert#isEqualTo(Object)} but given Date should not take care of minutes,
    * seconds and milliseconds precision.
    * <p>
@@ -350,6 +399,22 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    */
   public SELF isEqualToIgnoringSeconds(String dateAsString) {
     return isEqualToIgnoringSeconds(parse(dateAsString));
+  }
+
+  /**
+   * Same assertion as {@link AbstractDateAssert#isEqualToIgnoringSeconds(Date)} but given Date is represented as
+   * an {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThat(new Date()).isEqualToIgnoringSeconds(Instant.now());</code></pre>
+   *
+   * @param instant the given Date represented as {@code Instant}.
+   * @return this assertion object.
+   * @throws AssertionError if actual and given Date represented as {@code Instant} are not equal ignoring seconds and
+   *           milliseconds.
+   */
+  public SELF isEqualToIgnoringSeconds(Instant instant) {
+    return isEqualToIgnoringSeconds(Date.from(instant));
   }
 
   /**
@@ -429,6 +494,21 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
   }
 
   /**
+   * Same assertion as {@link AbstractDateAssert#isEqualToIgnoringMillis(Date)} but given Date is represented as
+   * an {@code java.time.Instant}.
+   * <p>
+   * Example:
+   * <pre><code class='java'>assertThat(new Date()).isEqualToIgnoringMillis(Instant.now());</code></pre>
+   *
+   * @param instant the given Date represented as {@code Instant}.
+   * @return this assertion object.
+   * @throws AssertionError if actual and given Date represented as {@code Instant} are not equal ignoring milliseconds.
+   */
+  public SELF isEqualToIgnoringMillis(Instant instant) {
+    return isEqualToIgnoringMillis(Date.from(instant));
+  }
+
+  /**
    * Same assertion as {@link AbstractAssert#isEqualTo(Object)} but given Date should not take care of milliseconds
    * precision.
    * <p>
@@ -500,6 +580,23 @@ public abstract class AbstractDateAssert<SELF extends AbstractDateAssert<SELF>> 
    */
   public SELF isNotEqualTo(String dateAsString) {
     return isNotEqualTo(parse(dateAsString));
+  }
+
+  /**
+   * Same assertion as {@link AbstractAssert#isNotEqualTo(Object) isNotEqualTo(Date date)} but given date is
+   * represented as an {@code java.time.Instant}.
+   *
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * // theTwoTowers release date : 2002-12-18
+   * assertThat(theTwoTowers.getReleaseDate()).isNotEqualTo(Instant.now());</code></pre>
+   *
+   * @param instant the given Date represented as {@code Instant}.
+   * @return this assertion object.
+   * @throws AssertionError if actual and given Date represented as {@code Instant} are equal.
+   */
+  public SELF isNotEqualTo(Instant instant) {
+    return isNotEqualTo(Date.from(instant));
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDateAssert.java
@@ -30,6 +30,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.Instant;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Comparator;

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringHours_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringHours_Test.java
@@ -12,9 +12,12 @@
  */
 package org.assertj.core.api.date;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
+
 import static org.mockito.Mockito.verify;
 
 
@@ -35,9 +38,19 @@ class DateAssert_isEqualToIgnoringHours_Test extends AbstractDateAssertWithDateA
     return assertions.isEqualToIgnoringHours(date);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isEqualToIgnoringHours(instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(dates).assertIsEqualWithPrecision(getInfo(assertions), getActual(assertions), date, TimeUnit.HOURS);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringMillis_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringMillis_Test.java
@@ -12,9 +12,12 @@
  */
 package org.assertj.core.api.date;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
+
 import static org.mockito.Mockito.verify;
 
 
@@ -35,9 +38,19 @@ class DateAssert_isEqualToIgnoringMillis_Test extends AbstractDateAssertWithDate
     return assertions.isEqualToIgnoringMillis(date);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isEqualToIgnoringMillis(instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(dates).assertIsEqualWithPrecision(getInfo(assertions), getActual(assertions), date, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringMinutes_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringMinutes_Test.java
@@ -12,9 +12,12 @@
  */
 package org.assertj.core.api.date;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
+
 import static org.mockito.Mockito.verify;
 
 
@@ -35,9 +38,19 @@ class DateAssert_isEqualToIgnoringMinutes_Test extends AbstractDateAssertWithDat
     return assertions.isEqualToIgnoringMinutes(date);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isEqualToIgnoringMinutes(instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(dates).assertIsEqualWithPrecision(getInfo(assertions), getActual(assertions), date, TimeUnit.MINUTES);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringSeconds_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isEqualToIgnoringSeconds_Test.java
@@ -12,9 +12,12 @@
  */
 package org.assertj.core.api.date;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
+
 import static org.mockito.Mockito.verify;
 
 
@@ -35,9 +38,19 @@ class DateAssert_isEqualToIgnoringSeconds_Test extends AbstractDateAssertWithDat
     return assertions.isEqualToIgnoringSeconds(date);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isEqualToIgnoringSeconds(instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(dates).assertIsEqualWithPrecision(getInfo(assertions), getActual(assertions), date, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isEqualTo_Test.java
@@ -14,9 +14,11 @@ package org.assertj.core.api.date;
 
 import static org.mockito.Mockito.verify;
 
+import java.time.Instant;
 import java.util.Date;
 
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -36,9 +38,19 @@ class DateAssert_isEqualTo_Test extends AbstractDateAssertWithDateArg_Test {
     return assertions.isEqualTo(dateAsString);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isEqualTo(instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(objects).assertEqual(getInfo(assertions), getActual(assertions), date);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isNotEqualTo_Test.java
@@ -14,9 +14,12 @@ package org.assertj.core.api.date;
 
 import static org.mockito.Mockito.verify;
 
+import java.time.Instant;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.DateAssert;
+import org.junit.jupiter.api.Test;
 
 
 /**
@@ -36,9 +39,19 @@ class DateAssert_isNotEqualTo_Test extends AbstractDateAssertWithDateArg_Test {
     return assertions.isNotEqualTo(dateAsString);
   }
 
+  protected DateAssert assertionInvocationWithInstantArg(Instant instant) {
+    return assertions.isNotEqualTo(instant);
+  }
+
   @Override
   protected void verifyAssertionInvocation(Date date) {
     verify(objects).assertNotEqual(getInfo(assertions), getActual(assertions), date);
+  }
+
+  @Test
+  public void should_verify_assertion_with_instant_arg() {
+    assertionInvocationWithInstantArg(otherDate.toInstant());
+    verifyAssertionInvocation(otherDate);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/date/DateAssert_isNotEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_isNotEqualTo_Test.java
@@ -23,7 +23,8 @@ import org.junit.jupiter.api.Test;
 
 
 /**
- * Tests for {@link DateAssert#isNotEqualTo(Date)} and {@link DateAssert#isNotEqualTo(String)}.
+ * Tests for {@link DateAssert#isNotEqualTo(Date)}, {@link DateAssert#isNotEqualTo(String)} and
+ * {@link DateAssert#isNotEqualTo(Instant)}.
  * 
  * @author Joel Costigliola
  */


### PR DESCRIPTION
#### Check List:
* Fixes #2032
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


