### PR TITLE
Fix error mesage of ShouldNotHaveSameClass and test naming convention of same class assertions

### DIFF
--- a/src/main/java/org/assertj/core/error/ShouldNotHaveSameClass.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotHaveSameClass.java
@@ -30,6 +30,6 @@ public class ShouldNotHaveSameClass extends BasicErrorMessageFactory {
   }
 
   private ShouldNotHaveSameClass(Object actual, Object other) {
-    super("%nExpecting:%n <%s>%nnot to have not the same class as:%n <%s> (%s)", actual, other, actual.getClass());
+    super("%nExpecting:%n <%s>%nnot to have the same class as:%n <%s> (%s)", actual, other, actual.getClass());
   }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_doesNotHaveSameClassAs_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_doesNotHaveSameClassAs_Test.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
  * 
  * @author Nicolas François
  */
-class AbstractAssert_doesNotHaveTheSameClassAs_Test extends AbstractAssertBaseTest {
+class AbstractAssert_doesNotHaveSameClassAs_Test extends AbstractAssertBaseTest {
 
   @Override
   protected ConcreteAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_hasSameClassAs_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_hasSameClassAs_Test.java
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
  * 
  * @author Nicolas François
  */
-class AbstractAssert_hasTheSameClassAs_Test extends AbstractAssertBaseTest {
+class AbstractAssert_hasSameClassAs_Test extends AbstractAssertBaseTest {
 
   @Override
   protected ConcreteAssert invoke_api_method() {

--- a/src/test/java/org/assertj/core/error/ShouldNotHaveSameClass_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotHaveSameClass_create_Test.java
@@ -34,6 +34,6 @@ class ShouldNotHaveSameClass_create_Test {
     // WHEN
     String message = factory.create(new TestDescription("Test"), new StandardRepresentation());
     // THEN
-    then(message).isEqualTo(format("[Test] %nExpecting:%n <\"Yoda\">%nnot to have not the same class as:%n <\"Luke\"> (java.lang.String)"));
+    then(message).isEqualTo(format("[Test] %nExpecting:%n <\"Yoda\">%nnot to have the same class as:%n <\"Luke\"> (java.lang.String)"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveSameClassAs_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveSameClassAs_Test.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
  * @author Nicolas François
  * @author Joel Costigliola
  */
-class Objects_assertDoesNotHaveNotSameClassAs_Test extends ObjectsBaseTest {
+class Objects_assertDoesNotHaveSameClassAs_Test extends ObjectsBaseTest {
 
   private static Person actual;
 


### PR DESCRIPTION
#### Check List:
* Fixes NA
* Unit tests : NA
* Javadoc with a code example (on API only) : NA

The error message of `ShouldNotHaveSameClass` is fixed because it was double negative.

Some inconsistencies were also found for the test naming convention of same class assertions while I was working on https://github.com/assertj/assertj-core/issues/2028.

