### PR TITLE
Use dedicated executorservice for every testcase

### DIFF
--- a/src/test/java/org/assertj/core/api/future/AbstractFutureTest.java
+++ b/src/test/java/org/assertj/core/api/future/AbstractFutureTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.future;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+abstract class AbstractFutureTest {
+
+  protected ExecutorService executorService;
+
+  @BeforeEach
+  void beforeEach() {
+    executorService = Executors.newSingleThreadExecutor();
+  }
+
+  @AfterEach
+  void afterEach() {
+    executorService.shutdownNow();
+  }
+}

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_failsWithin_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_failsWithin_Test.java
@@ -17,26 +17,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.junit.jupiter.api.condition.OS.MAC;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 
 @DisplayName("FutureAssert failsWithin")
-class CompletableFutureAssert_failsWithin_Test {
+class CompletableFutureAssert_failsWithin_Test extends AbstractFutureTest{
 
   private static final Duration ONE_SECOND = Duration.ofSeconds(1);
 
   @Test
   void should_pass_when_future_does_not_complete_within_timeout_Duration() {
     // GIVEN
-    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND);
+    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(Duration.ofMillis(50));
   }
@@ -44,7 +43,7 @@ class CompletableFutureAssert_failsWithin_Test {
   @Test
   void should_pass_when_future_does_not_complete_within_timeout() {
     // GIVEN
-    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND);
+    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(50, MILLISECONDS);
   }
@@ -52,7 +51,7 @@ class CompletableFutureAssert_failsWithin_Test {
   @Test
   void should_allow_assertion_on_future_exception_when_future_did_not_complete_within_timeout_Duration() {
     // GIVEN
-    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND);
+    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND,executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(Duration.ofMillis(50))
                       .withThrowableOfType(TimeoutException.class)
@@ -62,29 +61,27 @@ class CompletableFutureAssert_failsWithin_Test {
   @Test
   void should_allow_assertion_on_future_exception_when_future_did_not_complete_within_timeout() {
     // GIVEN
-    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND);
+    CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(50, MILLISECONDS)
                       .withThrowableOfType(TimeoutException.class)
                       .withMessage(null);
   }
 
-  @DisabledOnOs(MAC) // Fails only on the Mac runner of GitHub Actions, but succeeds locally
   @Test
   void should_fail_if_future_completes_within_given_timeout() {
     // GIVEN
-    CompletableFuture<Void> future = futureCompletingAfter(Duration.ofMillis(10));
+    CompletableFuture<Void> future = futureCompletingAfter(Duration.ofMillis(10), executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).failsWithin(500, MILLISECONDS));
     // THEN
     then(assertionError).hasMessageContainingAll("Completed", "to have failed within 500L MILLISECONDS.");
   }
 
-  @DisabledOnOs(MAC) // Fails only on the Mac runner of GitHub Actions, but succeeds locally
   @Test
   void should_fail_if_future_completes_within_given_timeout_Duration() {
     // GIVEN
-    CompletableFuture<Void> future = futureCompletingAfter(Duration.ofMillis(10));
+    CompletableFuture<Void> future = futureCompletingAfter(Duration.ofMillis(10), executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).failsWithin(Duration.ofMillis(500)));
     // THEN
@@ -126,8 +123,8 @@ class CompletableFutureAssert_failsWithin_Test {
     then(assertionError).hasMessage(actualIsNull());
   }
 
-  private static CompletableFuture<Void> futureCompletingAfter(Duration duration) {
-    return CompletableFuture.runAsync(() -> sleep(duration));
+  private static CompletableFuture<Void> futureCompletingAfter(Duration duration, Executor executor) {
+    return CompletableFuture.runAsync(() -> sleep(duration), executor);
   }
 
   private static void sleep(Duration duration) {

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_Test.java
@@ -23,13 +23,13 @@ import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("CompletableFutureAssert succeedsWithin")
-class CompletableFutureAssert_succeedsWithin_Test {
+class CompletableFutureAssert_succeedsWithin_Test extends AbstractFutureTest {
 
   @Test
   void should_allow_assertion_on_future_result_when_completed_normally() {
@@ -46,7 +46,7 @@ class CompletableFutureAssert_succeedsWithin_Test {
     // GIVEN
     String value = "done";
     int sleepDuration = 10;
-    CompletableFuture<String> future = completedFutureAfter(value, sleepDuration);
+    CompletableFuture<String> future = completedFutureAfter(value, sleepDuration, executorService);
     // WHEN/THEN
     // using the same duration would fail depending on when the thread executing the future is started
     assertThat(future).succeedsWithin(sleepDuration + 100, MILLISECONDS)
@@ -67,7 +67,7 @@ class CompletableFutureAssert_succeedsWithin_Test {
   void should_fail_if_completable_future_does_not_succeed_within_given_timeout() {
     // GIVEN
     int sleepDuration = 100000;
-    CompletableFuture<String> future = completedFutureAfter("ook!", sleepDuration);
+    CompletableFuture<String> future = completedFutureAfter("ook!", sleepDuration, executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).succeedsWithin(10, MILLISECONDS));
     // THEN
@@ -113,9 +113,9 @@ class CompletableFutureAssert_succeedsWithin_Test {
                         .hasMessageContaining("to be completed within 1L Millis.");
   }
 
-  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration) {
+  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration, ExecutorService service) {
     CompletableFuture<U> completableFuture = new CompletableFuture<>();
-    Executors.newSingleThreadExecutor().submit(() -> {
+    service.submit(() -> {
       Thread.sleep(sleepDuration);
       completableFuture.complete(value);
       return null;

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_duration_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_succeedsWithin_duration_Test.java
@@ -24,13 +24,13 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("CompletableFutureAssert succeedsWithin(Duration)")
-class CompletableFutureAssert_succeedsWithin_duration_Test {
+class CompletableFutureAssert_succeedsWithin_duration_Test extends AbstractFutureTest {
 
   @Test
   void should_allow_assertion_on_future_result_when_completed_normally() {
@@ -47,7 +47,7 @@ class CompletableFutureAssert_succeedsWithin_duration_Test {
     // GIVEN
     String value = "done";
     int sleepDuration = 10;
-    CompletableFuture<String> future = completedFutureAfter(value, sleepDuration);
+    CompletableFuture<String> future = completedFutureAfter(value, sleepDuration, executorService);
     // WHEN/THEN
     // using the same duration would fail depending on when the thread executing the future is started
     assertThat(future).succeedsWithin(Duration.ofMillis(sleepDuration + 500))
@@ -68,7 +68,7 @@ class CompletableFutureAssert_succeedsWithin_duration_Test {
   void should_fail_if_completable_future_does_not_succeed_within_given_timeout() {
     // GIVEN
     int sleepDuration = 100000;
-    CompletableFuture<String> future = completedFutureAfter("ook!", sleepDuration);
+    CompletableFuture<String> future = completedFutureAfter("ook!", sleepDuration, executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).succeedsWithin(Duration.ofMillis(10)));
     // THEN
@@ -114,9 +114,9 @@ class CompletableFutureAssert_succeedsWithin_duration_Test {
                         .hasMessageContaining("to be completed within 0.001S.");
   }
 
-  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration) {
+  private static <U> CompletableFuture<U> completedFutureAfter(U value, long sleepDuration, ExecutorService service) {
     CompletableFuture<U> completableFuture = new CompletableFuture<>();
-    Executors.newSingleThreadExecutor().submit(() -> {
+    service.submit(() -> {
       Thread.sleep(sleepDuration);
       completableFuture.complete(value);
       return null;

--- a/src/test/java/org/assertj/core/api/future/FutureAssert_failsWithin_Test.java
+++ b/src/test/java/org/assertj/core/api/future/FutureAssert_failsWithin_Test.java
@@ -17,29 +17,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.junit.jupiter.api.condition.OS.MAC;
-import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
 
 @DisplayName("FutureAssert failsWithin")
-class FutureAssert_failsWithin_Test {
+class FutureAssert_failsWithin_Test extends AbstractFutureTest {
 
   private static final Duration ONE_SECOND = Duration.ofSeconds(1);
 
   @Test
   void should_pass_when_future_does_not_complete_within_timeout_Duration() {
     // GIVEN
-    Future<String> future = futureCompletingAfter(ONE_SECOND);
+    Future<String> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(Duration.ofMillis(50));
   }
@@ -47,7 +44,7 @@ class FutureAssert_failsWithin_Test {
   @Test
   void should_pass_when_future_does_not_complete_within_timeout() {
     // GIVEN
-    Future<String> future = futureCompletingAfter(ONE_SECOND);
+    Future<String> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(50, MILLISECONDS);
   }
@@ -55,7 +52,7 @@ class FutureAssert_failsWithin_Test {
   @Test
   void should_allow_assertion_on_future_exception_when_future_did_not_complete_within_timeout_Duration() {
     // GIVEN
-    Future<String> future = futureCompletingAfter(ONE_SECOND);
+    Future<String> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(Duration.ofMillis(50))
                       .withThrowableOfType(TimeoutException.class)
@@ -65,7 +62,7 @@ class FutureAssert_failsWithin_Test {
   @Test
   void should_allow_assertion_on_future_exception_when_future_did_not_complete_within_timeout() {
     // GIVEN
-    Future<String> future = futureCompletingAfter(ONE_SECOND);
+    Future<String> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(50, MILLISECONDS)
                       .withThrowableOfType(TimeoutException.class)
@@ -73,10 +70,9 @@ class FutureAssert_failsWithin_Test {
   }
 
   @Test
-  @DisabledOnOs({ MAC, WINDOWS })
   void should_fail_if_future_completes_within_given_timeout() {
     // GIVEN
-    Future<String> future = futureCompletingAfter(Duration.ofMillis(10));
+    Future<String> future = futureCompletingAfter(Duration.ofMillis(10), executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).failsWithin(50, MILLISECONDS));
     // THEN
@@ -84,10 +80,9 @@ class FutureAssert_failsWithin_Test {
   }
 
   @Test
-  @DisabledOnOs({ MAC, WINDOWS })
   void should_fail_if_future_completes_within_given_timeout_Duration() {
     // GIVEN
-    Future<String> future = futureCompletingAfter(Duration.ofMillis(10));
+    Future<String> future = futureCompletingAfter(Duration.ofMillis(10), executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).failsWithin(Duration.ofMillis(50)));
     // THEN
@@ -129,8 +124,8 @@ class FutureAssert_failsWithin_Test {
     then(assertionError).hasMessage(actualIsNull());
   }
 
-  private static Future<String> futureCompletingAfter(Duration duration) {
-    return Executors.newSingleThreadExecutor().submit(() -> {
+  private static Future<String> futureCompletingAfter(Duration duration, ExecutorService service) {
+    return service.submit(() -> {
       Thread.sleep(duration.toMillis());
       return "ook!";
     });

--- a/src/test/java/org/assertj/core/api/future/FutureAssert_succeedsWithin_duration_Test.java
+++ b/src/test/java/org/assertj/core/api/future/FutureAssert_succeedsWithin_duration_Test.java
@@ -14,7 +14,6 @@ package org.assertj.core.api.future;
 
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.completedFuture;
-import static java.util.concurrent.Executors.newSingleThreadExecutor;
 import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -24,13 +23,14 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 @DisplayName("FutureAssert succeedsWithin(Duration)")
-class FutureAssert_succeedsWithin_duration_Test {
+class FutureAssert_succeedsWithin_duration_Test extends AbstractFutureTest {
 
   @Test
   void should_allow_assertion_on_future_result_when_completed_normally() {
@@ -47,7 +47,7 @@ class FutureAssert_succeedsWithin_duration_Test {
     // GIVEN
     String value = "done";
     int sleepDuration = 10;
-    Future<String> future = futureAfter(value, sleepDuration);
+    Future<String> future = futureAfter(value, sleepDuration, executorService);
     // WHEN/THEN
     // using the same duration would fail depending on when the thread executing the future is started
     assertThat(future).succeedsWithin(Duration.ofMillis(sleepDuration + 100))
@@ -68,7 +68,7 @@ class FutureAssert_succeedsWithin_duration_Test {
   void should_fail_if_future_does_not_succeed_within_given_timeout() {
     // GIVEN
     int sleepDuration = 100_000;
-    Future<String> future = futureAfter("ook!", sleepDuration);
+    Future<String> future = futureAfter("ook!", sleepDuration, executorService);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(future).succeedsWithin(Duration.ofMillis(10)));
     // THEN
@@ -102,8 +102,8 @@ class FutureAssert_succeedsWithin_duration_Test {
     then(assertionError).hasMessage(actualIsNull());
   }
 
-  private static <U> Future<U> futureAfter(U value, long sleepDuration) {
-    return newSingleThreadExecutor().submit(() -> {
+  private static <U> Future<U> futureAfter(U value, long sleepDuration, ExecutorService service) {
+    return service.submit(() -> {
       Thread.sleep(sleepDuration);
       return value;
     });


### PR DESCRIPTION
fixes #2030

Basically, this pr creates a separate [executorservice](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ExecutorService.html) for every test case and additionally a [shutdown now](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/concurrent/ExecutorService.html#shutdownNow()) is performed.
This will make our future tests more stable (especially on nodes with low number of cores).

Previously, in some cases tasks from other test cases were still running.

We might go for a junit jupiter parameterresolver based solution in the future.


