### PR TITLE
Add overloaded methods with boxed arrays for contains assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLongArrayAssert.java
@@ -12,6 +12,10 @@
  */
 package org.assertj.core.api;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+
+import java.util.Arrays;
 import java.util.Comparator;
 
 import org.assertj.core.data.Index;
@@ -21,7 +25,7 @@ import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.VisibleForTesting;
 
 public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAssert<SELF>>
-  extends AbstractArrayAssert<SELF, long[], Long> {
+    extends AbstractArrayAssert<SELF, long[], Long> {
 
   @VisibleForTesting
   protected LongArrays arrays = LongArrays.instance();
@@ -199,6 +203,33 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
   }
 
   /**
+   * Verifies that the actual array contains the values of the given array, in any order.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new long[] { 1L, 2L, 3L }).contains(new Long[] { 1L, 2L });
+   * assertThat(new long[] { 1L, 2L, 3L }).contains(new Long[] { 3L, 1L });
+   * assertThat(new long[] { 1L, 2L, 3L }).contains(new Long[] { 1L, 3L, 2L });
+   *
+   * // assertions will fail
+   * assertThat(new long[] { 1L, 2L, 3L }).contains(new Long[] { 1L, 4L });
+   * assertThat(new long[] { 1L, 2L, 3L }).contains(new Long[] { 4L, 7L });</code></pre>
+   *
+   * @param values the given {@code Long} array of values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given values.
+   * @since 3.19.0
+   */
+  public SELF contains(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertContains(info, actual, toPrimitiveLongArray(values));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual array contains only the given values and nothing else, in any order.
    * <p>
    * Example:
@@ -221,6 +252,34 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
    */
   public SELF containsOnly(long... values) {
     arrays.assertContainsOnly(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual array contains only the values of the given array and nothing else, in any order.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new long[] { 1L, 2L, 3L }).containsOnly(new Long[] { 1L, 2L, 3L });
+   * assertThat(new long[] { 1L, 2L, 3L }).containsOnly(new Long[] { 2L, 3L, 1L });
+   * assertThat(new long[] { 1L, 1L, 2L }).containsOnly(new Long[] { 1L, 2L });
+   *
+   * // assertions will fail
+   * assertThat(new long[] { 1L, 2L, 3L }).containsOnly(new Long[] { 1L, 2L, 3L, 4L });
+   * assertThat(new long[] { 1L, 2L, 3L }).containsOnly(new Long[] { 4L, 7L });</code></pre>
+   *
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given values, i.e. the actual array contains some
+   *           or none of the given values, or the actual array contains more values than the given ones.
+   * @since 3.19.0
+   */
+  public SELF containsOnly(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertContainsOnly(info, actual, toPrimitiveLongArray(values));
     return myself;
   }
 
@@ -250,6 +309,33 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
   }
 
   /**
+   * Verifies that the actual array contains the values of the given array only once.
+   * <p>
+   * Examples :
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[] { 1, 2, 3 }).containsOnlyOnce(new Long[] { 1, 2 });
+   *
+   * // assertions will fail
+   * assertThat(new long[] { 1, 2, 1 }).containsOnlyOnce(new Long[] { 1 });
+   * assertThat(new long[] { 1, 2, 3 }).containsOnlyOnce(new Long[] { 4 });
+   * assertThat(new long[] { 1, 2, 3, 3 }).containsOnlyOnce(new Long[] { 0, 1, 2, 3, 4, 5 });</code></pre>
+   *
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group contains some
+   *           or none of the given values, or the actual group contains more than once these values.
+   * @since 3.19.0
+   */
+  public SELF containsOnlyOnce(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertContainsOnlyOnce(info, actual, toPrimitiveLongArray(values));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual array contains the given sequence, without any other values between them.
    * <p>
    * Example:
@@ -272,6 +358,30 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
   }
 
   /**
+   * Verifies that the actual array contains the given sequence, without any other values between them.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[] { 1, 2, 3 }).containsSequence(new Long[] { 1, 2 });
+   *
+   * // assertion will fail
+   * assertThat(new long[] { 1, 2, 3 }).containsSequence(new Long[] { 1, 3 });
+   * assertThat(new long[] { 1, 2, 3 }).containsSequence(new Long[] { 2, 1 });</code></pre>
+   *
+   * @param sequence the sequence of values to look for.
+   * @return myself assertion object.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the given array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given sequence.
+   * @since 3.19.0
+   */
+  public SELF containsSequence(Long[] sequence) {
+    requireNonNullParameter(sequence, "sequence");
+    arrays.assertContainsSequence(info, actual, toPrimitiveLongArray(sequence));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual array contains the given subsequence (possibly with other values between them).
    * <p>
    * Example:
@@ -290,6 +400,30 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
    */
   public SELF containsSubsequence(long... subsequence) {
     arrays.assertContainsSubsequence(info, actual, subsequence);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual array contains the given subsequence (possibly with other values between them).
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(new Long[] { 1, 2 });
+   * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(new Long[] { 1, 3 });
+   *
+   * // assertion will fail
+   * assertThat(new long[] { 1, 2, 3 }).containsSubsequence(new Long[] { 2, 1 });</code></pre>
+   *
+   * @param subsequence the subsequence of values to look for.
+   * @return myself assertion object.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the given array is {@code null}.
+   * @throws AssertionError if the actual array does not contain the given subsequence.
+   * @since 3.19.0
+   */
+  public SELF containsSubsequence(Long[] subsequence) {
+    requireNonNullParameter(subsequence, "subsequence");
+    arrays.assertContainsSubsequence(info, actual, toPrimitiveLongArray(subsequence));
     return myself;
   }
 
@@ -338,6 +472,30 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
    */
   public SELF doesNotContain(long... values) {
     arrays.assertDoesNotContain(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual array does not contain the values of the given array.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[] { 1L, 2L, 3L }).doesNotContain(new Long[] { 4L });
+   *
+   * // assertion will fail
+   * assertThat(new long[] { 1L, 2L, 3L }).doesNotContain(new Long[] { 2L });</code></pre>
+   *
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array contains any of the given values.
+   * @since 3.19.0
+   */
+  public SELF doesNotContain(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertDoesNotContain(info, actual, toPrimitiveLongArray(values));
     return myself;
   }
 
@@ -409,6 +567,32 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
   }
 
   /**
+   * Verifies that the actual array starts with the given sequence of values, without any other values between them.
+   * Similar to <code>{@link #containsSequence(Long[])}</code>, but it also verifies that the first element in the
+   * sequence is also first element of the actual array.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[] { 1L, 2L, 3L }).startsWith(new Long[] { 1L, 2L });
+   *
+   * // assertion will fail
+   * assertThat(new long[] { 1L, 2L, 3L }).startsWith(new Long[] { 2L, 3L });</code></pre>
+   *
+   * @param sequence the sequence of values to look for.
+   * @return myself assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array does not start with the given sequence.
+   * @since 3.19.0
+   */
+  public SELF startsWith(Long[] sequence) {
+    requireNonNullParameter(sequence, "sequence");
+    arrays.assertStartsWith(info, actual, toPrimitiveLongArray(sequence));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual array ends with the given sequence of values, without any other values between them.
    * Similar to <code>{@link #containsSequence(long...)}</code>, but it also verifies that the last element in the
    * sequence is also last element of the actual array.
@@ -429,6 +613,32 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
    */
   public SELF endsWith(long... sequence) {
     arrays.assertEndsWith(info, actual, sequence);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual array ends with the given sequence of values, without any other values between them.
+   * Similar to <code>{@link #containsSequence(Long[])}</code>, but it also verifies that the last element in the
+   * sequence is also last element of the actual array.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[] { 1L, 2L, 3L }).endsWith(new Long[] { 2L, 3L });
+   *
+   * // assertion will fail
+   * assertThat(new long[] { 1L, 2L, 3L }).endsWith(new Long[] { 3L, 4L });</code></pre>
+   *
+   * @param sequence the sequence of values to look for.
+   * @return myself assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws IllegalArgumentException if the given argument is an empty array.
+   * @throws AssertionError if the actual array is {@code null}.
+   * @throws AssertionError if the actual array does not end with the given sequence.
+   * @since 3.19.0
+   */
+  public SELF endsWith(Long[] sequence) {
+    requireNonNullParameter(sequence, "sequence");
+    arrays.assertEndsWith(info, actual, toPrimitiveLongArray(sequence));
     return myself;
   }
 
@@ -488,6 +698,33 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
   }
 
   /**
+   * Verifies that the actual group contains only the values of the given array and nothing else, <b>in order</b>.
+   * <p>
+   * Example :
+   * <pre><code class='java'> long[] longs = { 1, 2, 3 };
+   *
+   * // assertion will pass
+   * assertThat(longs).containsExactly(new Long[] { 1, 2, 3 });
+   *
+   * // assertion will fail as actual and expected order differ
+   * assertThat(longs).containsExactly(new Long[] { 2, 1, 3 });</code></pre>
+   *
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values with same order, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones
+   *           or values are the same but the order is not.
+   * @since 3.19.0
+   */
+  public SELF containsExactly(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertContainsExactly(info, actual, toPrimitiveLongArray(values));
+    return myself;
+  }
+
+  /**
    * Verifies that the actual group contains exactly the given values and nothing else, <b>in any order</b>.<br>
    * <p>
    * Example :
@@ -510,6 +747,33 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
    */
   public SELF containsExactlyInAnyOrder(long... values) {
     arrays.assertContainsExactlyInAnyOrder(info, actual, values);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual group contains exactly the values of the given array and nothing else, <b>in any order</b>.<br>
+   * <p>
+   * Example :
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(new long[] { 1L, 2L }).containsExactlyInAnyOrder(new Long[] { 1L, 2L });
+   * assertThat(new long[] { 1L, 2L, 1L }).containsExactlyInAnyOrder(new Long[] { 1L, 1L, 2L });
+   *
+   * // assertions will fail
+   * assertThat(new long[] { 1L, 2L }).containsExactlyInAnyOrder(new Long[] { 1L });
+   * assertThat(new long[] { 1L }).containsExactlyInAnyOrder(new Long[] { 1L, 2L });
+   * assertThat(new long[] { 1L, 2L, 1L }).containsExactlyInAnyOrder(new Long[] { 1L, 2L });</code></pre>
+   *
+   * @param values the given values.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given argument is {@code null}.
+   * @throws AssertionError if the actual group is {@code null}.
+   * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group
+   *           contains some or none of the given values, or the actual group contains more values than the given ones.
+   * @since 3.19.0
+   */
+  public SELF containsExactlyInAnyOrder(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertContainsExactlyInAnyOrder(info, actual, toPrimitiveLongArray(values));
     return myself;
   }
 
@@ -541,6 +805,45 @@ public abstract class AbstractLongArrayAssert<SELF extends AbstractLongArrayAsse
   public SELF containsAnyOf(long... values) {
     arrays.assertContainsAnyOf(info, actual, values);
     return myself;
+  }
+
+  /**
+   * Verifies that the actual array contains at least one value of the given array.
+   * <p>
+   * Example :
+   * <pre><code class='java'> long[] oneTwoThree = { 1L, 2L, 3L };
+   *
+   * // assertions will pass
+   * assertThat(oneTwoThree).containsAnyOf(new Long[] { 2L })
+   *                        .containsAnyOf(new Long[] { 2L, 3L })
+   *                        .containsAnyOf(new Long[] { 1L, 2L, 3L })
+   *                        .containsAnyOf(new Long[] { 1L, 2L, 3L, 4L })
+   *                        .containsAnyOf(new Long[] { 5L, 6L, 7L, 2L });
+   *
+   * // assertions will fail
+   * assertThat(oneTwoThree).containsAnyOf(new Long[] { 4L });
+   * assertThat(oneTwoThree).containsAnyOf(new Long[] { 4L, 5L, 6L, 7L });</code></pre>
+   *
+   * @param values the array of values whose at least one which is expected to be in the array under test.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the array of values is {@code null}.
+   * @throws IllegalArgumentException if the array of values is empty and the array under test is not empty.
+   * @throws AssertionError if the array under test is {@code null}.
+   * @throws AssertionError if the array under test does not contain any of the given {@code values}.
+   * @since 3.19.0
+   */
+  public SELF containsAnyOf(Long[] values) {
+    requireNonNullParameter(values, "values");
+    arrays.assertContainsAnyOf(info, actual, toPrimitiveLongArray(values));
+    return myself;
+  }
+
+  private static void requireNonNullParameter(Object parameter, String parameterName) {
+    requireNonNull(parameter, shouldNotBeNull(parameterName).create());
+  }
+
+  private static long[] toPrimitiveLongArray(Long[] values) {
+    return Arrays.stream(values).mapToLong(Long::longValue).toArray();
   }
 
 }

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsAnyOf_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsAnyOf_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsAnyOf(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsAnyOf(Long[])")
+class LongArrayAssert_containsAnyOf_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsAnyOf(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsAnyOf(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsAnyOf(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsExactlyInAnyOrder_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsExactlyInAnyOrder_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsExactlyInAnyOrder(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsExactlyInAnyOrder(Long[])")
+class LongArrayAssert_containsExactlyInAnyOrder_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsExactlyInAnyOrder(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsExactlyInAnyOrder(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsExactlyInAnyOrder(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsExactly_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsExactly_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsExactly(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsExactly(Long[])")
+class LongArrayAssert_containsExactly_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsExactly(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsExactly(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsExactly(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsOnlyOnce_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsOnlyOnce_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsOnlyOnce(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsOnlyOnce(Long[])")
+class LongArrayAssert_containsOnlyOnce_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsOnlyOnce(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsOnlyOnce(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsOnlyOnce(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsOnly_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsOnly_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsOnly(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsOnly(Long[])")
+class LongArrayAssert_containsOnly_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsOnly(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsOnly(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsOnly(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsSequence_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsSequence_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsSequence(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsSequence(Long[])")
+class LongArrayAssert_containsSequence_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] sequence = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsSequence(sequence));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("sequence").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsSequence(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsSequence(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsSubsequence_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_containsSubsequence_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#containsSubsequence(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert containsSubsequence(Long[])")
+class LongArrayAssert_containsSubsequence_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] subsequence = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.containsSubsequence(subsequence));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("subsequence").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.containsSubsequence(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContainsSubsequence(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_contains_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_contains_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#contains(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert contains(Long[])")
+class LongArrayAssert_contains_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.contains(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.contains(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertContains(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_doesNotContain_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_doesNotContain_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#doesNotContain(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert doesNotContain(Long[])")
+class LongArrayAssert_doesNotContain_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] values = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.doesNotContain(values));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("values").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.doesNotContain(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertDoesNotContain(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_endsWith_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_endsWith_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#endsWith(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert endsWith(Long[])")
+class LongArrayAssert_endsWith_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] sequence = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.endsWith(sequence));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("sequence").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.endsWith(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertEndsWith(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_startsWith_with_Long_array_Test.java
+++ b/src/test/java/org/assertj/core/api/longarray/LongArrayAssert_startsWith_with_Long_array_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.longarray;
+
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
+import static org.assertj.core.test.LongArrays.arrayOf;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.LongArrayAssert;
+import org.assertj.core.api.LongArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link LongArrayAssert#startsWith(Long[])}</code>.
+ * 
+ * @author Stefano Cordio
+ */
+@DisplayName("LongArrayAssert startsWith(Long[])")
+class LongArrayAssert_startsWith_with_Long_array_Test extends LongArrayAssertBaseTest {
+
+  @Test
+  void should_fail_if_values_is_null() {
+    // GIVEN
+    Long[] sequence = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> assertions.startsWith(sequence));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage(shouldNotBeNull("sequence").create());
+  }
+
+  @Override
+  protected LongArrayAssert invoke_api_method() {
+    return assertions.startsWith(new Long[] { 6L, 8L });
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertStartsWith(getInfo(assertions), getActual(assertions), arrayOf(6L, 8L));
+  }
+
+}


### PR DESCRIPTION
- [ ] `AbstractBooleanArrayAssert`
- [ ] `AbstractByteArrayAssert`
- [ ] `AbstractCharArrayAssert`
- [ ] `AbstractDoubleArrayAssert`
- [ ] `AbstractFloatArrayAssert`
- [ ] `AbstractIntArrayAssert`
- [X] `AbstractLongArrayAssert`
- [ ] `AbstractShortArrayAssert`

#### Check List:
* Fixes #1948
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


