### PR TITLE
Add doesNotHaveToString assertion

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -522,6 +522,13 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
 
   /** {@inheritDoc} */
   @Override
+  public SELF doesNotHaveToString(String otherToString) {
+    objects.assertDoesNotHaveToString(info, actual, otherToString);
+    return myself;
+  }
+
+  /** {@inheritDoc} */
+  @Override
   public SELF doesNotHaveSameClassAs(Object other) {
     objects.assertDoesNotHaveSameClassAs(info, actual, other);
     return myself;

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -481,8 +481,7 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    * // Instead of writing ...
    * assertThat(homer.toString()).isNotEqualTo("Marge");
    * // ... you can simply write:
-   * assertThat(homer).doesNotHaveToString("Marge");
-   * </code></pre>
+   * assertThat(homer).doesNotHaveToString("Marge");</code></pre>
    *
    * @param otherToString the String to check against.
    * @return this assertion object.

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -467,7 +467,7 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
    *
    * @param expectedToString the expected String description of actual.
    * @return this assertion object.
-   * @throws AssertionError if {@code actual.toString()} result is not to the given {@code String}.
+   * @throws AssertionError if {@code actual.toString()} result is not equal to the given {@code String}.
    * @throws AssertionError if actual is {@code null}.
    */
   SELF hasToString(String expectedToString);

--- a/src/main/java/org/assertj/core/api/Assert.java
+++ b/src/main/java/org/assertj/core/api/Assert.java
@@ -473,6 +473,25 @@ public interface Assert<SELF extends Assert<SELF, ACTUAL>, ACTUAL> extends Descr
   SELF hasToString(String expectedToString);
 
   /**
+   * Verifies that actual {@code actual.toString()} is not equal to the given {@code String}.
+   * <p>
+   * Example :
+   * <pre><code class='java'> CartoonCharacter homer = new CartoonCharacter("Homer");
+   *
+   * // Instead of writing ...
+   * assertThat(homer.toString()).isNotEqualTo("Marge");
+   * // ... you can simply write:
+   * assertThat(homer).doesNotHaveToString("Marge");
+   * </code></pre>
+   *
+   * @param otherToString the String to check against.
+   * @return this assertion object.
+   * @throws AssertionError if {@code actual.toString()} result is equal to the given {@code String}.
+   * @throws AssertionError if actual is {@code null}.
+   */
+  SELF doesNotHaveToString(String otherToString);
+
+  /**
    * Verifies that the actual value does not have the same class as the given object.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/error/ShouldHaveToString.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveToString.java
@@ -19,6 +19,6 @@ public class ShouldHaveToString extends BasicErrorMessageFactory {
   }
 
   private ShouldHaveToString(Object actual, String expectedToString) {
-    super("%nExpecting actual's toString() to return:%n  <%s>%nbut was:%n  <%s>", expectedToString, actual);
+    super("%nExpecting actual's toString() to return:%n  <%s>%nbut was:%n  <%s>", expectedToString, actual.toString());
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldNotHaveToString.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotHaveToString.java
@@ -14,11 +14,11 @@ package org.assertj.core.error;
 
 public class ShouldNotHaveToString extends BasicErrorMessageFactory {
 
-  public static ErrorMessageFactory shouldNotHaveToString(Object actual, String other) {
-    return new ShouldNotHaveToString(actual, other);
+  public static ErrorMessageFactory shouldNotHaveToString(String other) {
+    return new ShouldNotHaveToString(other);
   }
 
-  private ShouldNotHaveToString(Object actual, String other) {
-    super("%nExpecting actual's toString() not to be equal to:%n  <%s>%nbut was:%n  <%s>", other, actual.toString());
+  private ShouldNotHaveToString(String other) {
+    super("%nExpecting actual's toString() not to be equal to:%n  <%s>", other);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldNotHaveToString.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotHaveToString.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+public class ShouldNotHaveToString extends BasicErrorMessageFactory {
+
+  public static ErrorMessageFactory shouldNotHaveToString(Object actual, String other) {
+    return new ShouldNotHaveToString(actual, other);
+  }
+
+  private ShouldNotHaveToString(Object actual, String other) {
+    super("%nExpecting actual's toString() not to be equal to:%n  <%s>%nbut was:%n  <%s>", other, actual.toString());
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -415,6 +415,15 @@ public class Objects {
     if (actual == other) throw failures.failure(info, shouldNotBeSame(actual));
   }
 
+  /**
+   * Verifies that the actual ToString value is equal to the given String.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given object.
+   * @param expectedToString the string to compare against.
+   * @throws AssertionError if the actual ToString value is not equal to the given String.
+   * @throws NullPointerException if the actual value is null.
+   */
   public void assertHasToString(AssertionInfo info, Object actual, String expectedToString) {
     assertNotNull(info, actual);
     String actualString = actual.toString();

--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -46,6 +46,7 @@ import static org.assertj.core.error.ShouldNotBeOfClassIn.shouldNotBeOfClassIn;
 import static org.assertj.core.error.ShouldNotBeSame.shouldNotBeSame;
 import static org.assertj.core.error.ShouldNotHaveSameClass.shouldNotHaveSameClass;
 import static org.assertj.core.error.ShouldNotHaveSameHashCode.shouldNotHaveSameHashCode;
+import static org.assertj.core.error.ShouldNotHaveToString.shouldNotHaveToString;
 import static org.assertj.core.internal.CommonValidations.checkTypeIsNotNull;
 import static org.assertj.core.internal.DeepDifference.determineDifferences;
 import static org.assertj.core.util.Lists.list;
@@ -419,6 +420,22 @@ public class Objects {
     String actualString = actual.toString();
     if (!actualString.equals(expectedToString))
       throw failures.failure(info, shouldHaveToString(actualString, expectedToString), actualString, expectedToString);
+  }
+
+  /**
+   * Verifies that the actual ToString value is not equal to the given String.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the given object.
+   * @param otherToString the string to compare against.
+   * @throws AssertionError if the actual ToString value is equal to the given String.
+   * @throws NullPointerException if the actual value is null.
+   */
+  public void assertDoesNotHaveToString(AssertionInfo info, Object actual, String otherToString) {
+    assertNotNull(info, actual);
+    String actualToString = actual.toString();
+    if (actualToString.equals(otherToString))
+      throw failures.failure(info, shouldNotHaveToString(actualToString, otherToString));
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -444,7 +444,7 @@ public class Objects {
     assertNotNull(info, actual);
     String actualToString = actual.toString();
     if (actualToString.equals(otherToString))
-      throw failures.failure(info, shouldNotHaveToString(actualToString, otherToString));
+      throw failures.failure(info, shouldNotHaveToString(otherToString));
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_doesNotHaveToString_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_doesNotHaveToString_Test.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.api.abstract_;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AbstractAssertBaseTest;
+import org.assertj.core.api.ConcreteAssert;
+
+class AbstractAssert_doesNotHaveToString_Test extends AbstractAssertBaseTest {
+
+  @Override
+  protected ConcreteAssert invoke_api_method() {
+    return assertions.doesNotHaveToString("some description");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(objects).assertDoesNotHaveToString(getInfo(assertions), getActual(assertions), "some description");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveToString_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveToString_create_Test.java
@@ -18,6 +18,7 @@ import static org.assertj.core.error.ShouldHaveToString.shouldHaveToString;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import org.assertj.core.internal.TestDescription;
+import org.assertj.core.test.Jedi;
 import org.junit.jupiter.api.Test;
 
 class ShouldHaveToString_create_Test {
@@ -25,17 +26,17 @@ class ShouldHaveToString_create_Test {
   @Test
   void should_create_error_message() {
     // GIVEN
-    String actual = "c++";
-    String expectedToString = "java";
+    Jedi actual = new Jedi("Yoda", "green");
+    String expectedToString = "Luke the Jedi";
     // WHEN
     String errorMessage = shouldHaveToString(actual, expectedToString).create(new TestDescription("TEST"),
                                                                               STANDARD_REPRESENTATION);
     // THEN
     then(errorMessage).isEqualTo(format("[TEST] %n" +
                                         "Expecting actual's toString() to return:%n" +
-                                        "  <\"java\">%n" +
+                                        "  <\"Luke the Jedi\">%n" +
                                         "but was:%n" +
-                                        "  <\"c++\">"));
+                                        "  <\"Yoda the Jedi\">"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotHaveToString_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotHaveToString_create_Test.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotHaveToString.shouldNotHaveToString;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import org.assertj.core.internal.TestDescription;
+import org.assertj.core.test.Jedi;
+import org.junit.jupiter.api.Test;
+
+class ShouldNotHaveToString_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    Jedi actual = new Jedi("Yoda", "green");
+    String otherString = "Yoda the Jedi";
+    ErrorMessageFactory factory = shouldNotHaveToString(actual, otherString);
+    // WHEN
+    String errorMessage = factory.create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
+    // THEN
+    then(errorMessage).isEqualTo(format("[TEST] %n" +
+                                        "Expecting actual's toString() not to be equal to:%n" +
+                                        "  <\"Yoda the Jedi\">%n" +
+                                        "but was:%n" +
+                                        "  <\"Yoda the Jedi\">"));
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldNotHaveToString_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotHaveToString_create_Test.java
@@ -18,7 +18,6 @@ import static org.assertj.core.error.ShouldNotHaveToString.shouldNotHaveToString
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 import org.assertj.core.internal.TestDescription;
-import org.assertj.core.test.Jedi;
 import org.junit.jupiter.api.Test;
 
 class ShouldNotHaveToString_create_Test {
@@ -26,16 +25,13 @@ class ShouldNotHaveToString_create_Test {
   @Test
   void should_create_error_message() {
     // GIVEN
-    Jedi actual = new Jedi("Yoda", "green");
     String otherString = "Yoda the Jedi";
-    ErrorMessageFactory factory = shouldNotHaveToString(actual, otherString);
+    ErrorMessageFactory factory = shouldNotHaveToString(otherString);
     // WHEN
     String errorMessage = factory.create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
     // THEN
     then(errorMessage).isEqualTo(format("[TEST] %n" +
                                         "Expecting actual's toString() not to be equal to:%n" +
-                                        "  <\"Yoda the Jedi\">%n" +
-                                        "but was:%n" +
                                         "  <\"Yoda the Jedi\">"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveToString_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveToString_Test.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal.objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.error.ShouldNotHaveToString.shouldNotHaveToString;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.internal.ObjectsBaseTest;
+import org.assertj.core.test.Person;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class Objects_assertDoesNotHaveToString_Test extends ObjectsBaseTest {
+
+  private static Person actual;
+
+  @BeforeAll
+  static void setUpOnce() {
+    actual = new Person("foo");
+  }
+
+  @Test
+  void should_pass_if_actual_toString_is_not_equal_to_the_other_toString() {
+    objects.assertDoesNotHaveToString(someInfo(), actual, "bar");
+    objects.assertDoesNotHaveToString(someInfo(), actual, null);
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Object actualObject = null;
+    // WHEN
+    ThrowingCallable code = () -> objects.assertDoesNotHaveToString(someInfo(), actualObject, "bar");
+    // THEN
+    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_toString_is_equal_to_the_other_String() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    // WHEN
+    AssertionError error = expectAssertionError(() -> objects.assertDoesNotHaveToString(info, actual, "Person[name='foo']"));
+    // THEN
+    verify(failures).failure(info, shouldNotHaveToString("Person[name='foo']", "Person[name='foo']"));
+    assertThat(error).hasMessageContainingAll("Person[name='foo']");
+  }
+}

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveToString_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertDoesNotHaveToString_Test.java
@@ -15,13 +15,11 @@ package org.assertj.core.internal.objects;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldNotHaveToString.shouldNotHaveToString;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.internal.ObjectsBaseTest;
 import org.assertj.core.test.Person;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,9 +45,9 @@ class Objects_assertDoesNotHaveToString_Test extends ObjectsBaseTest {
     // GIVEN
     Object actualObject = null;
     // WHEN
-    ThrowingCallable code = () -> objects.assertDoesNotHaveToString(someInfo(), actualObject, "bar");
+    AssertionError error = expectAssertionError(() -> objects.assertDoesNotHaveToString(someInfo(), actualObject, "bar"));
     // THEN
-    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+    assertThat(error).hasMessage(actualIsNull());
   }
 
   @Test
@@ -57,9 +55,8 @@ class Objects_assertDoesNotHaveToString_Test extends ObjectsBaseTest {
     // GIVEN
     AssertionInfo info = someInfo();
     // WHEN
-    AssertionError error = expectAssertionError(() -> objects.assertDoesNotHaveToString(info, actual, "Person[name='foo']"));
+    expectAssertionError(() -> objects.assertDoesNotHaveToString(info, actual, "Person[name='foo']"));
     // THEN
-    verify(failures).failure(info, shouldNotHaveToString("Person[name='foo']", "Person[name='foo']"));
-    assertThat(error).hasMessageContainingAll("Person[name='foo']");
+    verify(failures).failure(info, shouldNotHaveToString("Person[name='foo']"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertHasToString_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertHasToString_Test.java
@@ -15,7 +15,6 @@ package org.assertj.core.internal.objects;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.error.ShouldHaveToString.shouldHaveToString;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.mock;
@@ -23,7 +22,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.internal.ObjectsBaseTest;
 import org.assertj.core.test.Person;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,9 +49,9 @@ class Objects_assertHasToString_Test extends ObjectsBaseTest {
     // GIVEN
     Object object = null;
     // WHEN
-    ThrowingCallable code = () -> objects.assertHasToString(someInfo(), object, "foo");
+    AssertionError error = expectAssertionError(() -> objects.assertHasToString(someInfo(), object, "foo"));
     // THEN
-    assertThatAssertionErrorIsThrownBy(code).withMessage(actualIsNull());
+    assertThat(error).hasMessage(actualIsNull());
   }
 
   @Test
@@ -61,9 +59,8 @@ class Objects_assertHasToString_Test extends ObjectsBaseTest {
     // GIVEN
     AssertionInfo info = someInfo();
     // WHEN
-    AssertionError error = expectAssertionError(() -> objects.assertHasToString(info, actual, "bar"));
+    expectAssertionError(() -> objects.assertHasToString(info, actual, "bar"));
     // THEN
     verify(failures).failure(info, shouldHaveToString("foo", "bar"), "foo", "bar");
-    assertThat(error).hasMessageContainingAll("\"foo\"", "\"bar\"");
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2028 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES

Minor fixes for `hasToString` doc description and `ShouldHaveToString` error as well.