### PR TITLE
Use org.junit.ComparisonFailure when available and org.opentest4j.AssertionFailedError is not.

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -237,7 +237,7 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
     String errorMessage = Optional.ofNullable(info.overridingErrorMessage())
                                   .orElse(format(errorMessageFormat, arguments));
     String description = MessageFormatter.instance().format(info.description(), info.representation(), errorMessage);
-    AssertionError assertionError = assertionErrorCreator.assertionError(description, actual, expected);
+    AssertionError assertionError = assertionErrorCreator.assertionError(description, actual, expected, info.representation ());
     Failures.instance().removeAssertJRelatedElementsFromStackTraceIfNeeded(assertionError);
     removeCustomAssertRelatedElementsFromStackTraceIfNeeded(assertionError);
     return assertionError;

--- a/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonDifference.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonDifference.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import org.assertj.core.configuration.ConfigurationProvider;
+import org.assertj.core.internal.UnambiguousRepresentation;
 import org.assertj.core.presentation.Representation;
 
 public class ComparisonDifference implements Comparable<ComparisonDifference> {
@@ -94,24 +95,13 @@ public class ComparisonDifference implements Comparable<ComparisonDifference> {
   }
 
   public String multiLineDescription(Representation representation) {
-
-    String actualRepresentation = representation.toStringOf(actual);
-    String expectedRepresentation = representation.toStringOf(expected);
-
-    boolean sameRepresentation = Objects.equals(actualRepresentation, expectedRepresentation);
-    String unambiguousActualRepresentation = sameRepresentation
-        ? representation.unambiguousToStringOf(actual)
-        : actualRepresentation;
-    String unambiguousExpectedRepresentation = sameRepresentation
-        ? representation.unambiguousToStringOf(expected)
-        : expectedRepresentation;
-
+    UnambiguousRepresentation unambiguousRepresentation = new UnambiguousRepresentation (representation, actual, expected);
     String additionalInfo = additionalInformation.map(ComparisonDifference::formatOnNewline)
                                                  .orElse("");
     return format(TEMPLATE,
                   fieldPathDescription(),
-                  unambiguousActualRepresentation,
-                  unambiguousExpectedRepresentation,
+                  unambiguousRepresentation.getActual (),
+                  unambiguousRepresentation.getExpected (),
                   additionalInfo);
   }
 

--- a/src/main/java/org/assertj/core/error/AssertionErrorCreator.java
+++ b/src/main/java/org/assertj/core/error/AssertionErrorCreator.java
@@ -21,6 +21,8 @@ import java.util.Optional;
 import org.assertj.core.api.SoftAssertionError;
 import org.assertj.core.description.Description;
 import org.assertj.core.internal.Failures;
+import org.assertj.core.internal.UnambiguousRepresentation;
+import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 
@@ -28,6 +30,8 @@ import org.assertj.core.util.introspection.PropertyOrFieldSupport;
 public class AssertionErrorCreator {
 
   private static final Class<?>[] MSG_ARG_TYPES_FOR_ASSERTION_FAILED_ERROR = array(String.class, Object.class, Object.class);
+
+  private static final Class<?>[] MSG_ARG_TYPES_FOR_COMPARISON_FAILURE = array (String.class, String.class, String.class);
 
   private static final Class<?>[] MULTIPLE_FAILURES_ERROR_ARGUMENT_TYPES = array(String.class, List.class);
 
@@ -44,8 +48,10 @@ public class AssertionErrorCreator {
 
   // single assertion error
 
-  public AssertionError assertionError(String message, Object actual, Object expected) {
-    return assertionFailedError(message, actual, expected).orElse(assertionError(message));
+  public AssertionError assertionError(String message, Object actual, Object expected, Representation representation) {
+    return assertionFailedError (message, actual, expected)
+      .orElse (comparisonFailure (message, actual, expected, representation)
+        .orElse (assertionError (message)));
   }
 
   private Optional<AssertionError> assertionFailedError(String message, Object actual, Object expected) {
@@ -62,6 +68,30 @@ public class AssertionErrorCreator {
     } catch (Throwable ignored) {
     }
     return Optional.empty();
+  }
+
+  private Optional<AssertionError> comparisonFailure (
+    String message,
+    Object actual,
+    Object expected,
+    Representation representation
+  ) {
+    try {
+      UnambiguousRepresentation unambiguousRepresentation = new UnambiguousRepresentation (representation, actual, expected);
+
+      Object o = constructorInvoker.newInstance (
+        "org.junit.ComparisonFailure",
+        MSG_ARG_TYPES_FOR_COMPARISON_FAILURE,
+        message,
+        unambiguousRepresentation.getExpected (),
+        unambiguousRepresentation.getActual ()
+      );
+      if (o instanceof AssertionError) {
+        return Optional.of ((AssertionError) o);
+      }
+    } catch (Throwable ignored) {
+    }
+    return Optional.empty ();
   }
 
   private static AssertionError assertionError(String message) {

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualByComparingFieldByFieldRecursively.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.assertj.core.api.recursive.comparison.ComparisonDifference;
 import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
 import org.assertj.core.internal.DeepDifference.Difference;
+import org.assertj.core.internal.UnambiguousRepresentation;
 import org.assertj.core.presentation.Representation;
 
 public class ShouldBeEqualByComparingFieldByFieldRecursively extends BasicErrorMessageFactory {
@@ -73,19 +74,8 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively extends BasicErrorM
   }
 
   private static String describeDifference(Difference difference, Representation representation) {
-
-    String actualFieldValue = representation.toStringOf(difference.getActual());
-    String otherFieldValue = representation.toStringOf(difference.getOther());
-
-    boolean sameRepresentation = Objects.equals(actualFieldValue, otherFieldValue);
-
-    String actualFieldValueRepresentation = sameRepresentation
-        ? representation.unambiguousToStringOf(difference.getActual())
-        : actualFieldValue;
-
-    String otherFieldValueRepresentation = sameRepresentation
-        ? representation.unambiguousToStringOf(difference.getOther())
-        : otherFieldValue;
+    UnambiguousRepresentation unambiguousRepresentation =
+      new UnambiguousRepresentation (representation, difference.getActual (), difference.getOther ());
 
     String additionalInfo = difference.getDescription()
                                       .map(desc -> format("%n- reason  : %s", escapePercent(desc)))
@@ -94,8 +84,8 @@ public class ShouldBeEqualByComparingFieldByFieldRecursively extends BasicErrorM
                   "- actual  : <%s>%n" +
                   "- expected: <%s>" + additionalInfo,
                   join(difference.getPath()).with("."),
-                  escapePercent(actualFieldValueRepresentation),
-                  escapePercent(otherFieldValueRepresentation));
+                  escapePercent(unambiguousRepresentation.getActual ()),
+                  escapePercent(unambiguousRepresentation.getExpected ()));
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/Failures.java
+++ b/src/main/java/org/assertj/core/internal/Failures.java
@@ -130,7 +130,7 @@ public class Failures {
 
   public AssertionError failure(AssertionInfo info, ErrorMessageFactory messageFactory, Object actual, Object expected) {
     String assertionErrorMessage = assertionErrorMessage(info, messageFactory);
-    AssertionError assertionError = assertionErrorCreator.assertionError(assertionErrorMessage, actual, expected);
+    AssertionError assertionError = assertionErrorCreator.assertionError(assertionErrorMessage, actual, expected, info.representation ());
     removeAssertJRelatedElementsFromStackTraceIfNeeded(assertionError);
     printThreadDumpIfNeeded();
     return assertionError;

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -611,7 +611,8 @@ public class Strings {
     String actualNormalized = normalizeNewlines(actual);
     String expectedNormalized = normalizeNewlines(expected);
     if (!actualNormalized.equals(expectedNormalized))
-      throw failures.failure(info, shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
+      throw failures.failure(info, shouldBeEqualIgnoringNewLineDifferences(actual, expected), actualNormalized,
+                             expectedNormalized);
   }
 
   private static String normalizeNewlines(CharSequence actual) {
@@ -673,8 +674,11 @@ public class Strings {
    * @since 2.8.0 / 3.8.0
    */
   public void assertEqualsNormalizingWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    if (!areEqualNormalizingWhitespace(actual, expected))
-      throw failures.failure(info, shouldBeEqualNormalizingWhitespace(actual, expected), actual, expected);
+    if (actual != null) checkCharSequenceIsNotNull (expected);
+    String normalizedActual = normalizeWhitespace (actual);
+    String normalizedExpected = normalizeWhitespace (expected);
+    if (!java.util.Objects.equals (normalizedActual, normalizedExpected))
+      throw failures.failure(info, shouldBeEqualNormalizingWhitespace(actual, expected), normalizedActual, normalizedExpected);
   }
 
   /**
@@ -688,17 +692,17 @@ public class Strings {
    * @since 2.8.0 / 3.8.0
    */
   public void assertNotEqualsNormalizingWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    if (areEqualNormalizingWhitespace(actual, expected))
+    if (actual != null) checkCharSequenceIsNotNull (expected);
+    String normalizedActual = normalizeWhitespace (actual);
+    String normalizedExpected = normalizeWhitespace (expected);
+    if (java.util.Objects.equals (normalizedActual, normalizedExpected))
       throw failures.failure(info, shouldNotBeEqualNormalizingWhitespace(actual, expected));
   }
 
-  private boolean areEqualNormalizingWhitespace(CharSequence actual, CharSequence expected) {
-    if (actual == null) return expected == null;
-    checkCharSequenceIsNotNull(expected);
-    return normalizeWhitespace(actual).equals(normalizeWhitespace(expected));
-  }
-
   private static String normalizeWhitespace(CharSequence toNormalize) {
+    if (toNormalize == null) {
+      return null;
+    }
     final StringBuilder result = new StringBuilder(toNormalize.length());
     boolean lastWasSpace = true;
     for (int i = 0; i < toNormalize.length(); i++) {
@@ -725,17 +729,17 @@ public class Strings {
    * @since 3.16.0
    */
   public void assertEqualsNormalizingPunctuationAndWhitespace(AssertionInfo info, CharSequence actual, CharSequence expected) {
-    if (!areEqualNormalizingPunctuationAndWhitespace(actual, expected))
-      throw failures.failure(info, shouldBeEqualNormalizingPunctuationAndWhitespace(actual, expected), actual, expected);
-  }
-
-  private static boolean areEqualNormalizingPunctuationAndWhitespace(CharSequence actual, CharSequence expected) {
-    if (actual == null) return expected == null;
-    checkCharSequenceIsNotNull(expected);
-    return normalizeWhitespaceAndPunctuation(actual).equals(normalizeWhitespaceAndPunctuation(expected));
+    if (actual != null) checkCharSequenceIsNotNull (expected);
+    String normalizedActual = normalizeWhitespaceAndPunctuation (actual);
+    String normalizedExpected = normalizeWhitespaceAndPunctuation (expected);
+    if (!java.util.Objects.equals (normalizedActual, normalizedExpected))
+      throw failures.failure(info, shouldBeEqualNormalizingPunctuationAndWhitespace(actual, expected), normalizedActual, normalizedExpected);
   }
 
   private static String normalizeWhitespaceAndPunctuation(CharSequence toNormalize) {
+    if (toNormalize == null) {
+      return null;
+    }
     return normalizeWhitespace(toNormalize.toString().replaceAll(PUNCTUATION_REGEX, ""));
   }
 

--- a/src/main/java/org/assertj/core/internal/UnambiguousRepresentation.java
+++ b/src/main/java/org/assertj/core/internal/UnambiguousRepresentation.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import java.util.Objects;
+
+import org.assertj.core.presentation.Representation;
+
+/**
+ * Utility class around {@link Representation} to provide the {@link Representation#toStringOf(Object) toStringOf}
+ * representations of {@code actual} and {@code expected} when they are different,
+ * and their {@link Representation#unambiguousToStringOf(Object) unambiguousToStringOf}
+ * representations if not.
+ */
+public class UnambiguousRepresentation {
+
+  private final String actual;
+
+  private final String expected;
+
+  public UnambiguousRepresentation(Representation representation, Object actual, Object expected) {
+    String actualRepresentation = representation.toStringOf(actual);
+    String expectedRepresentation = representation.toStringOf(expected);
+
+    boolean sameRepresentation = Objects.equals(actualRepresentation, expectedRepresentation);
+    this.actual = sameRepresentation
+        ? representation.unambiguousToStringOf(actual)
+        : actualRepresentation;
+    this.expected = sameRepresentation
+        ? representation.unambiguousToStringOf(expected)
+        : expectedRepresentation;
+  }
+
+  /**
+   * Provide a representation of {@code actual} guaranteed to be different
+   * from {@link #getExpected()}.
+   * @return a suitable representation of the {@code actual} object given at
+   * construction time.
+   */
+  public String getActual() {
+    return actual;
+  }
+
+  /**
+   * Provide a representation of {@code expected} guaranteed to be different
+   * from {@link #getActual()}.
+   * @return a suitable representation of the {@code expected} object given at
+   * construction time.
+   */
+  public String getExpected() {
+    return expected;
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/AssertionErrorCreator_assertionError_Test.java
+++ b/src/test/java/org/assertj/core/error/AssertionErrorCreator_assertionError_Test.java
@@ -15,9 +15,13 @@ package org.assertj.core.error;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import org.assertj.core.presentation.Representation;
+import org.junit.ComparisonFailure;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
@@ -31,8 +35,9 @@ class AssertionErrorCreator_assertionError_Test {
     String actual = "actual";
     String expected = "expected";
     String message = "error message";
+    Representation representation = mock(Representation.class);
     // WHEN
-    AssertionError assertionError = assertionErrorCreator.assertionError(message, actual, expected);
+    AssertionError assertionError = assertionErrorCreator.assertionError(message, actual, expected, representation);
     // THEN
     then(assertionError).isInstanceOf(AssertionFailedError.class)
                         .hasMessage(message);
@@ -42,14 +47,33 @@ class AssertionErrorCreator_assertionError_Test {
   }
 
   @Test
-  void should_create_AssertionError_when_AssertionFailedError_could_not_be_created() throws Exception {
+  void should_create_ComparisonFailure_when_AssertionFailedError_could_not_be_created() throws Exception {
+    // GIVEN
+    String message = "error message";
+    Representation representation = mock(Representation.class);
+    ConstructorInvoker constructorInvoker = mock(ConstructorInvoker.class);
+    ComparisonFailure expectedFailure = new ComparisonFailure(message, "expected", "actual");
+    given(constructorInvoker.newInstance(eq(AssertionFailedError.class.getName()), any(Class[].class), any()))
+      .willThrow(Exception.class);
+    when (constructorInvoker.newInstance(eq(ComparisonFailure.class.getName()), any(Class[].class), any()))
+      .thenReturn (expectedFailure);
+    assertionErrorCreator.constructorInvoker = constructorInvoker;
+    // WHEN
+    AssertionError assertionError = assertionErrorCreator.assertionError(message, new Object(), new Object(), representation);
+    // THEN
+    then(assertionError).isSameAs(expectedFailure);
+  }
+
+  @Test
+  void should_create_AssertionError_when_neither_AssertionFailedError_nor_ComparisonFailure_could_be_created() throws Exception {
     // GIVEN
     String message = "error message";
     ConstructorInvoker constructorInvoker = mock(ConstructorInvoker.class);
-    given(constructorInvoker.newInstance(anyString(), any(Class[].class), any(Object[].class))).willThrow(Exception.class);
+    Representation representation = mock(Representation.class);
+    given(constructorInvoker.newInstance(anyString(), any(Class[].class), any())).willThrow(Exception.class);
     assertionErrorCreator.constructorInvoker = constructorInvoker;
     // WHEN
-    AssertionError assertionError = assertionErrorCreator.assertionError(message, "actual", "expected");
+    AssertionError assertionError = assertionErrorCreator.assertionError(message, "actual", "expected", representation);
     // THEN
     then(assertionError).isNotInstanceOf(AssertionFailedError.class)
                         .hasMessage(message);

--- a/src/test/java/org/assertj/core/internal/UnambiguousRepresentation_Test.java
+++ b/src/test/java/org/assertj/core/internal/UnambiguousRepresentation_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2020 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.BDDMockito.given;
+
+import org.assertj.core.presentation.Representation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Tests for {@link UnambiguousRepresentation}.
+ */
+@ExtendWith(MockitoExtension.class)
+class UnambiguousRepresentation_Test {
+
+  @Mock
+  private Representation representation;
+
+  @Test
+  void should_use_toStringOf_given_they_are_different() {
+    // GIVEN
+    Object actual = new Object ();
+    Object expected = new Object ();
+    given (representation.toStringOf (actual)).willReturn ("actual");
+    given (representation.toStringOf (expected)).willReturn ("expected");
+    // WHEN
+    UnambiguousRepresentation actualRepresentation = new UnambiguousRepresentation (representation, actual, expected);
+    // THEN
+    then (actualRepresentation.getActual ()).isEqualTo ("actual");
+    then (actualRepresentation.getExpected ()).isEqualTo ("expected");
+  }
+
+  @Test
+  void should_use_unambiguousToStringOf_whe_toStringOf_are_equal () {
+    // GIVEN
+    Object actual = new Object ();
+    Object expected = new Object ();
+    given (representation.toStringOf (actual)).willReturn ("representation");
+    given (representation.toStringOf (expected)).willReturn ("representation");
+    given (representation.unambiguousToStringOf (actual)).willReturn ("actual");
+    given (representation.unambiguousToStringOf (expected)).willReturn ("expected");
+    // WHEN
+    UnambiguousRepresentation actualRepresentation = new UnambiguousRepresentation (representation, actual, expected);
+    // THEN
+    then (actualRepresentation.getActual ()).isEqualTo ("actual");
+    then (actualRepresentation.getExpected ()).isEqualTo ("expected");
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test.java
@@ -40,9 +40,9 @@ class Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test extends Strin
     String expected = "";
     AssertionInfo info = someInfo();
     // WHEN
-    expectAssertionError(() -> strings.assertEqualsNormalizingPunctuationAndWhitespace(info, actual, expected));
+    expectAssertionError(() -> strings.assertEqualsNormalizingPunctuationAndWhitespace(info, "{Game} of} Thrones{)", expected));
     // THEN
-    verifyFailureWhenStringsAreNotEqualNormalizingPunctuationAndWhitespace(info, actual, expected);
+    verify(failures).failure(info, shouldBeEqualNormalizingPunctuationAndWhitespace(actual, expected), "Game of Thrones", expected);
   }
 
   @Test
@@ -54,7 +54,7 @@ class Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test extends Strin
     // WHEN
     expectAssertionError(() -> strings.assertEqualsNormalizingPunctuationAndWhitespace(info, actual, expected));
     // THEN
-    verifyFailureWhenStringsAreNotEqualNormalizingPunctuationAndWhitespace(info, actual, expected);
+    verify(failures).failure(info, shouldBeEqualNormalizingPunctuationAndWhitespace(actual, expected), "GameofThrones", expected);
   }
 
   @ParameterizedTest
@@ -85,8 +85,4 @@ class Strings_assertEqualsNormalizingPunctuationAndWhitespace_Test extends Strin
                      Arguments.of("Game {} of () Thrones {})()!'", "Game  of  Thrones "));
   }
 
-  private void verifyFailureWhenStringsAreNotEqualNormalizingPunctuationAndWhitespace(AssertionInfo info, String actual,
-                                                                                      String expected) {
-    verify(failures).failure(info, shouldBeEqualNormalizingPunctuationAndWhitespace(actual, expected), actual, expected);
-  }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertIsEqualToNormalizingNewlines_Test.java
@@ -53,7 +53,7 @@ class Strings_assertIsEqualToNormalizingNewlines_Test extends StringsBaseTest {
     Throwable error = catchThrowable(() -> strings.assertIsEqualToNormalizingNewlines(someInfo(), actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected), actual, expected);
+    verify(failures).failure(someInfo(), shouldBeEqualIgnoringNewLineDifferences(actual, expected), "Lord of the Rings\n\nis cool", expected);
   }
 
 }


### PR DESCRIPTION
As I saw that the "show difference" link was available in IntelliJ for any failure when OpenTest4J is on the classpath, I ended up using an `org.junit.ComparisonFailure` for any failed assertions, not only `isEqualToNormalizingXxx()`.

For the special case of `isEqualToNormalizingXxx()` the `expected` and `actual` string representations are now that of normalized objects (see 5e2ef20122c91ddb643612505d4d244e85ed3573). If that is not the desired behavior, that commit can easily be removed.

#### Check List:
* Fixes #2062.
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
