### PR TITLE
Fix #2068 isValidGetter checks if return type of method is not void

### DIFF
--- a/src/main/java/org/assertj/core/util/introspection/Introspection.java
+++ b/src/main/java/org/assertj/core/util/introspection/Introspection.java
@@ -107,7 +107,7 @@ public final class Introspection {
   }
 
   private static boolean isValidGetter(Method method) {
-    return method != null && !Modifier.isStatic(method.getModifiers());
+    return method != null && !Modifier.isStatic(method.getModifiers()) && !Void.TYPE.equals(method.getReturnType());
   }
 
   private static Method findMethod(String name, Object target) {

--- a/src/test/java/org/assertj/core/util/Introspection_getProperty_Test.java
+++ b/src/test/java/org/assertj/core/util/Introspection_getProperty_Test.java
@@ -61,7 +61,14 @@ public class Introspection_getProperty_Test {
                                                                                            new Example()))
                                                        .withMessage("No public getter for property 'name' in org.assertj.core.util.Introspection_getProperty_Test$Example");
   }
-
+  
+  @Test
+  void should_raise_an_error_because_of_getter_with_void_return_type()  {
+	assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> getPropertyGetter("surname",
+                                                                                           new VoidGetter()))
+                                                        .withMessage("No getter for property 'surname' in org.assertj.core.util.Introspection_getProperty_Test$VoidGetter");
+  }
+  
   public static class Example extends Super {
   }
 
@@ -69,6 +76,12 @@ public class Introspection_getProperty_Test {
     @SuppressWarnings("unused")
     private String getName() {
       return "a";
+    }
+  }
+  
+  public static class VoidGetter
+  {
+    public void getSurname() {
     }
   }
 }

--- a/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
+++ b/src/test/java/org/assertj/core/util/introspection/PropertyOrFieldSupport_getValueOf_Test.java
@@ -193,6 +193,13 @@ class PropertyOrFieldSupport_getValueOf_Test {
     assertThat(value).isEqualTo("New York");
   }
 
+  @Test
+  void should_extract_field_value_if_only_void_method_matches_name() {
+    Object value = propertyOrFieldSupport.getValueOf("city", new VoidGetterPropertyEmployee());
+
+    assertThat(value).isEqualTo("New York");
+  }
+
   private Employee employeeWithBrokenName(String name) {
     return new Employee(1L, new Name(name), 0) {
       @Override
@@ -240,4 +247,8 @@ class PropertyOrFieldSupport_getValueOf_Test {
     }
   }
 
+  static class VoidGetterPropertyEmployee extends Employee {
+    public void getCity() {
+    }
+  }
 }


### PR DESCRIPTION
Method isValidGetter of class Introspection checks if return type of
given method is not void

Added a test on Introspection_getProperty_Test that assures a exception
is thrown if getter method returns void

Added a test on PropertyOrFieldSupport_getValueOf_Test that assures a
field value is read even if a getter method with void return type exists

#### Check List:
* Fixes #2068
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


