### PR TITLE
Fix long overflow in AbstractTemporalAssert

### DIFF
--- a/src/main/java/org/assertj/core/data/TemporalUnitOffset.java
+++ b/src/main/java/org/assertj/core/data/TemporalUnitOffset.java
@@ -17,6 +17,7 @@ import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
+import java.time.Duration;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalUnit;
 
@@ -52,7 +53,11 @@ public abstract class TemporalUnitOffset implements TemporalOffset<Temporal> {
    */
   @Override
   public String getBeyondOffsetDifferenceDescription(Temporal temporal1, Temporal temporal2) {
-    return format("%s %s but difference was %s %s", value, unit, getDifference(temporal1, temporal2), unit);
+    try {
+      return format("%s %s but difference was %s %s", value, unit, getDifference(temporal1, temporal2), unit);
+    } catch (ArithmeticException e) {
+      return format("%s %s but difference was %s", value, unit, getDuration(temporal1, temporal2));
+    }
   }
 
   /**
@@ -64,6 +69,17 @@ public abstract class TemporalUnitOffset implements TemporalOffset<Temporal> {
    */
   protected long getDifference(Temporal temporal1, Temporal temporal2) {
     return abs(unit.between(temporal1, temporal2));
+  }
+
+  /**
+   * Returns absolute value of the difference as Duration.
+   *
+   * @param temporal1 the first {@link Temporal}
+   * @param temporal2 the second {@link Temporal}
+   * @return absolute value of the difference as Duration.
+   */
+  protected Duration getDuration(Temporal temporal1, Temporal temporal2) {
+    return Duration.between(temporal1, temporal2).abs();
   }
 
   public TemporalUnit getUnit() {

--- a/src/main/java/org/assertj/core/data/TemporalUnitWithinOffset.java
+++ b/src/main/java/org/assertj/core/data/TemporalUnitWithinOffset.java
@@ -12,6 +12,7 @@
  */
 package org.assertj.core.data;
 
+import java.time.*;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalUnit;
 
@@ -33,7 +34,11 @@ public class TemporalUnitWithinOffset extends TemporalUnitOffset {
    */
   @Override
   public boolean isBeyondOffset(Temporal temporal1, Temporal temporal2) {
-    return getDifference(temporal1, temporal2) > value;
+    try {
+      return getDifference(temporal1, temporal2) > value;
+    } catch (ArithmeticException e) {
+      return getDuration(temporal1, temporal2).compareTo(Duration.of(value, getUnit())) > 0;
+    }
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/AbstractTemporalAssert_isCloseTo_Test.java
+++ b/src/test/java/org/assertj/core/api/AbstractTemporalAssert_isCloseTo_Test.java
@@ -23,6 +23,7 @@ import static java.time.format.DateTimeFormatter.ISO_TIME;
 import static java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME;
 import static java.time.temporal.ChronoUnit.DAYS;
 import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.WEEKS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,6 +55,7 @@ public class AbstractTemporalAssert_isCloseTo_Test {
 
   private static AbstractTemporalAssert<?, ?>[] nullAsserts = {
       assertThat((Instant) null),
+      assertThat((Instant) null),
       assertThat((LocalDateTime) null),
       assertThat((LocalDate) null),
       assertThat((LocalTime) null),
@@ -71,6 +73,7 @@ public class AbstractTemporalAssert_isCloseTo_Test {
 
   private static AbstractTemporalAssert<?, ?>[] temporalAsserts = {
       assertThat(_2017_Mar_12_07_10_Instant),
+      assertThat(_2017_Mar_12_07_10_Instant),
       assertThat(_2017_Mar_12_07_10),
       assertThat(_2017_Mar_12),
       assertThat(_07_10),
@@ -86,6 +89,7 @@ public class AbstractTemporalAssert_isCloseTo_Test {
 
   private static Temporal[] closeTemporals = {
       _2017_Mar_12_07_12_Instant,
+      _2017_Mar_12_07_10_Instant.plusMillis(1L),
       _2017_Mar_10_07_12,
       _2017_Mar_10,
       _07_12,
@@ -102,6 +106,7 @@ public class AbstractTemporalAssert_isCloseTo_Test {
 
   private static Temporal[] farTemporals = new Temporal[] {
       _2017_Mar_08_07_10_Instant,
+      Instant.MIN,
       _2017_Mar_08_07_10,
       _2017_Mar_27,
       _07_23,
@@ -113,6 +118,8 @@ public class AbstractTemporalAssert_isCloseTo_Test {
   private static String[] differenceMessages = {
       format("%nExpecting:%n  <%s>%nto be close to:%n  <%s>%nwithin 50 Hours but difference was 96 Hours",
              _2017_Mar_12_07_10_Instant, _2017_Mar_08_07_10_Instant),
+      format("%nExpecting:%n  <%s>%nto be close to:%n  <%s>%nwithin 2 Millis but difference was PT8765837682367H10M",
+             _2017_Mar_12_07_10_Instant, Instant.MIN),
       format("%nExpecting:%n  <%s>%nto be close to:%n  <%s>%nwithin 50 Hours but difference was 96 Hours",
              _2017_Mar_12_07_10, _2017_Mar_08_07_10),
       format("%nExpecting:%n  <%s>%nto be close to:%n  <%s>%nwithin 3 Days but difference was 15 Days",
@@ -131,6 +138,7 @@ public class AbstractTemporalAssert_isCloseTo_Test {
 
   private static TemporalUnitOffset[] offsets = {
       within(50, HOURS),
+      within(2, MILLIS),
       within(50, HOURS),
       within(3, DAYS),
       within(5, MINUTES),
@@ -139,11 +147,12 @@ public class AbstractTemporalAssert_isCloseTo_Test {
       within(2, MINUTES)
   };
 
-  private static TemporalUnitOffset[] inapplicableOffsets = { null, null, within(1, MINUTES),
+  private static TemporalUnitOffset[] inapplicableOffsets = { null, null, null, within(1, MINUTES),
       within(1, DAYS), null, null, within(1, WEEKS) };
 
   public static Object[][] parameters() {
     DateTimeFormatter[] formatters = {
+        ISO_INSTANT,
         ISO_INSTANT,
         ISO_LOCAL_DATE_TIME,
         ISO_LOCAL_DATE,


### PR DESCRIPTION
If the difference between the actual and expected values was too large to fit in the specified `ChronoUnit`, an exception would be thrown. Fix that by falling back to `Duration.between()` instead of `ChronoUnit.between()`. It leads to ugly assertion messages, but it's better than an `ArithmeticException`.

An example would be comparing Instant.MIN (e. g. used to signify an “uninitialized” value) to something reasonable `within(1, MILLIS)`.

The appropriate unit test is added.

I'm not sure if some thing can happen with, say, `LocalDate`. (That is, can the number of `DAYS` be too large to fit in a `long`? Probably not.)