### PR TITLE
[Conditions] recalculate Description - nested Conditions for Not and Join

### DIFF
--- a/src/main/java/org/assertj/core/condition/DoesNotHave.java
+++ b/src/main/java/org/assertj/core/condition/DoesNotHave.java
@@ -36,11 +36,6 @@ public class DoesNotHave<T> extends Negative<T> {
 
   private DoesNotHave(Condition<? super T> condition) {
     super(condition);
+    describedAs("does not have :<%s>", condition);
   }
-
-  @Override
-  public String toString() {
-    return String.format("does not have :<%s>", condition);
-  }
-
 }

--- a/src/main/java/org/assertj/core/condition/Join.java
+++ b/src/main/java/org/assertj/core/condition/Join.java
@@ -58,14 +58,12 @@ public abstract class Join<T> extends Condition<T> {
    */
   protected Join(Iterable<? extends Condition<? super T>> conditions) {
     this(Streams.stream(checkNotNullConditions(conditions)));
+    calculateDescription();
   }
 
   private Join(Stream<? extends Condition<? super T>> stream) {
     this.conditions = stream.map(Join::notNull).collect(toList());
-    List<Description> descriptions = this.conditions.stream()
-                                                    .map(Condition::description)
-                                                    .collect(toList());
-    this.describedAs(new JoinDescription(descriptionPrefix() + ":[", "]", descriptions));
+    calculateDescription();
   }
 
   private static <T> T checkNotNullConditions(T conditions) {
@@ -78,6 +76,21 @@ public abstract class Join<T> extends Condition<T> {
    */
   public abstract String descriptionPrefix();
 
+  /**
+   * method used to calculate the the subclass join description
+   */
+  private void calculateDescription() {
+    List<Description> descriptions = this.conditions.stream()
+        .map(Condition::description)
+        .collect(toList());
+    this.describedAs(new JoinDescription(descriptionPrefix() + ":[", "]", descriptions));
+  }
+  
+  @Override
+  public String toString() {
+    calculateDescription();
+    return description().value();
+  }
   private static <T> T notNull(T condition) {
     return requireNonNull(condition, "The given conditions should not have null entries");
   }

--- a/src/main/java/org/assertj/core/condition/Not.java
+++ b/src/main/java/org/assertj/core/condition/Not.java
@@ -35,11 +35,6 @@ public class Not<T> extends Negative<T> {
 
   private Not(Condition<? super T> condition) {
     super(condition);
+    describedAs("not :<%s>", condition);
   }
-
-  @Override
-  public String toString() {
-    return String.format("not :<%s>", condition);
-  }
-
 }

--- a/src/test/java/org/assertj/core/condition/AllOf_toString_Test.java
+++ b/src/test/java/org/assertj/core/condition/AllOf_toString_Test.java
@@ -33,11 +33,22 @@ class AllOf_toString_Test {
     // GIVEN
     TestCondition<Object> condition1 = new TestCondition<>("Condition 1");
     TestCondition<Object> condition2 = new TestCondition<>("Condition 2");
-    Condition<Object> allOf = allOf(condition1, condition2);
+    DynamicCondition<Object> condition3 = new DynamicCondition<>("Condition 3");
+    Condition<Object> allOf = allOf(condition1, condition2,condition3);
     // THEN
     assertThat(allOf).hasToString(format("all of:[%n" +
                                          "   Condition 1,%n" +
-                                         "   Condition 2%n" +
+                                         "   Condition 2,%n" +
+                                         "   Condition 3%n" +
+                                         "]"));
+    condition1.shouldMatch(true);
+    condition2.shouldMatch(true);
+    allOf.matches(true);
+
+    assertThat(allOf).hasToString(format("all of:[%n" +
+                                         "   Condition 1,%n" +
+                                         "   Condition 2,%n" +
+                                         "   ChangedDescription%n" +
                                          "]"));
   }
 
@@ -46,11 +57,34 @@ class AllOf_toString_Test {
     // GIVEN
     TestCondition<Object> condition1 = new TestCondition<>("Condition 1");
     TestCondition<Object> condition2 = new TestCondition<>("Condition 2");
-    Condition<Object> allOf = allOf(list(condition1, condition2));
+    DynamicCondition<Object> condition3 = new DynamicCondition<>("Condition 3");
+    Condition<Object> allOf = allOf(list(condition1, condition2,condition3));
     // THEN
     assertThat(allOf).hasToString(format("all of:[%n" +
                                          "   Condition 1,%n" +
-                                         "   Condition 2%n" +
+                                         "   Condition 2,%n" +
+                                         "   Condition 3%n" +
                                          "]"));
+    condition1.shouldMatch(true);
+    condition2.shouldMatch(true);
+    allOf.matches(true);
+
+    assertThat(allOf).hasToString(format("all of:[%n" +
+                                         "   Condition 1,%n" +
+                                         "   Condition 2,%n" +
+                                         "   ChangedDescription%n" +
+                                         "]"));    
+  }
+
+  static class  DynamicCondition<T> extends TestCondition<T> {
+    public DynamicCondition(String description) {
+      super(description);
+    }
+
+    @Override
+    public boolean matches(T value) {
+      describedAs("ChangedDescription");
+      return true;
+    }
   }
 }

--- a/src/test/java/org/assertj/core/condition/Not_toString_Test.java
+++ b/src/test/java/org/assertj/core/condition/Not_toString_Test.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.condition;
 
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.allOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.condition.Not.not;
 
@@ -29,17 +31,28 @@ class Not_toString_Test {
 
   private TestCondition<Object> condition;
   private Condition<Object> not;
+  
+  private Condition<Object> allNot;
 
   @BeforeEach
   public void setUp() {
     condition = new TestCondition<>("Jedi");
     not = not(condition);
+    allNot = allOf(not(new TestCondition<>("AllNot")));
   }
 
   @Test
   void should_implement_toString_showing_descriptions_of_inner_Conditions() {
     String expected = "not :<Jedi>";
     assertThat(not).hasToString(expected);
+  }
+
+  @Test
+  void should_implement_toString_showing_descriptions_of_inner_Conditions_allOf() {
+    String expected = "all of:[%n"+
+             "   not :<AllNot>%n"+
+             "]";
+    assertThat(allNot).hasToString(format(expected));
   }
 
 }


### PR DESCRIPTION
recalculate the description of nested Conditions like `Not` and `Join`

1 - Respect change of Description after Construct

It could happen, that the Description changes while executing for example the matches Method.
At the moment there is the description in JoinConditions/(maybe also Not) only set in the constructor. It does not show the later changed Description.

2 - Not should be shown properly 
```
    allNot = allOf(not(new TestCondition<>("AllNot")));
```
shoult look like
```
  <all of:
    not :<AllNot>
 >
```
but was:
```
  <"all of:[
   Not
]">
```

#### Check List:
* Fixes #???
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES 

