### PR TITLE
Rework `StandardComparisonStrategy#areEqual` to avoid shortcuts

### DIFF
--- a/src/main/java/org/assertj/core/internal/AtomicReferenceArrayElementComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/AtomicReferenceArrayElementComparisonStrategy.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 public class AtomicReferenceArrayElementComparisonStrategy<T> extends StandardComparisonStrategy {
 
-  private Comparator<? super T> elementComparator;
+  private final Comparator<? super T> elementComparator;
 
   public AtomicReferenceArrayElementComparisonStrategy(Comparator<? super T> elementComparator) {
     this.elementComparator = elementComparator;

--- a/src/main/java/org/assertj/core/internal/IterableElementComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/IterableElementComparisonStrategy.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 
 public class IterableElementComparisonStrategy<T> extends StandardComparisonStrategy {
 
-  private Comparator<? super T> elementComparator;
+  private final Comparator<? super T> elementComparator;
 
   public IterableElementComparisonStrategy(Comparator<? super T> elementComparator) {
     this.elementComparator = elementComparator;

--- a/src/main/java/org/assertj/core/internal/ObjectArrayElementComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/ObjectArrayElementComparisonStrategy.java
@@ -19,7 +19,7 @@ import java.util.Comparator;
 
 public class ObjectArrayElementComparisonStrategy<T> extends StandardComparisonStrategy {
 
-  private Comparator<? super T> elementComparator;
+  private final Comparator<? super T> elementComparator;
 
   public ObjectArrayElementComparisonStrategy(Comparator<? super T> elementComparator) {
 	this.elementComparator = elementComparator;

--- a/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
@@ -66,15 +66,42 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
   }
 
   /**
-   * Returns true if actual and other are equal based on {@link java.util.Objects#deepEquals(Object, Object)}, false otherwise.
+   * Returns {@code true} if the arguments are deeply equal to each other, {@code false} otherwise.
+   * <p>
+   * It mimics the behavior of {@link java.util.Objects#deepEquals(Object, Object)}, but without performing a reference
+   * check between the two arguments. According to {@code deepEquals} javadoc, the reference check should be delegated
+   * to the {@link Object#equals equals} method of the first argument, but this is not happening. Bug JDK-8196069 also
+   * mentions this gap.
    *
-   * @param actual the object to compare to other
-   * @param other the object to compare to actual
-   * @return true if actual and other are equal based on {@link java.util.Objects#deepEquals(Object, Object)}, false otherwise.
+   * @param actual the object to compare to {@code other}
+   * @param other the object to compare to {@code actual}
+   * @return {@code true} if the arguments are deeply equal to each other, {@code false} otherwise
+   *
+   * @see <a href="https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8196069">JDK-8196069</a>
+   *
    */
   @Override
   public boolean areEqual(Object actual, Object other) {
-    return java.util.Objects.deepEquals(actual, other);
+    if (actual == null) return other == null;
+    if (actual instanceof Object[] && other instanceof Object[])
+      return java.util.Arrays.deepEquals((Object[]) actual, (Object[]) other);
+    if (actual instanceof byte[] && other instanceof byte[])
+      return java.util.Arrays.equals((byte[]) actual, (byte[]) other);
+    if (actual instanceof short[] && other instanceof short[])
+      return java.util.Arrays.equals((short[]) actual, (short[]) other);
+    if (actual instanceof int[] && other instanceof int[])
+      return java.util.Arrays.equals((int[]) actual, (int[]) other);
+    if (actual instanceof long[] && other instanceof long[])
+      return java.util.Arrays.equals((long[]) actual, (long[]) other);
+    if (actual instanceof char[] && other instanceof char[])
+      return java.util.Arrays.equals((char[]) actual, (char[]) other);
+    if (actual instanceof float[] && other instanceof float[])
+      return java.util.Arrays.equals((float[]) actual, (float[]) other);
+    if (actual instanceof double[] && other instanceof double[])
+      return java.util.Arrays.equals((double[]) actual, (double[]) other);
+    if (actual instanceof boolean[] && other instanceof boolean[])
+      return java.util.Arrays.equals((boolean[]) actual, (boolean[]) other);
+    return actual.equals(other);
   }
 
   /**

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_areEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_areEqual_Test.java
@@ -12,78 +12,409 @@
  */
 package org.assertj.core.internal;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import org.assertj.core.util.Objects;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Tests for {@link StandardComparisonStrategy#areEqual(Object, Object)}.<br>
- * Conceptually the same as {@link Objects#areEqual(Object, Object)} but I don't know how to verify/test that
- * {@link StandardComparisonStrategy#areEqual(Object, Object)} simply calls {@link Objects#areEqual(Object, Object)}
+ * Tests for {@link StandardComparisonStrategy#areEqual(Object, Object)}.
  * 
  * @author Joel Costigliola
  */
+@DisplayName("StandardComparisonStrategy areEqual")
 class StandardComparisonStrategy_areEqual_Test {
 
-  private static StandardComparisonStrategy standardComparisonStrategy = StandardComparisonStrategy.instance();
+  private final StandardComparisonStrategy underTest = StandardComparisonStrategy.instance();
 
   @Test
-  void should_return_true_if_both_Objects_are_null_with_verify() {
-    assertThat(standardComparisonStrategy.areEqual(null, null)).isTrue();
+  void should_return_true_if_both_actual_and_other_are_null() {
+    // WHEN
+    boolean result = underTest.areEqual(null, null);
+    // THEN
+    then(result).isTrue();
   }
 
   @Test
-  void should_return_true_if_both_Objects_are_null() {
-    assertThat(standardComparisonStrategy.areEqual(null, null)).isTrue();
+  void should_return_false_if_actual_is_null_and_other_is_not() {
+    // GIVEN
+    Object other = new Object();
+    // WHEN
+    boolean result = underTest.areEqual(null, other);
+    // THEN
+    then(result).isFalse();
   }
 
   @Test
-  void should_return_true_if_Objects_are_equal() {
-    assertThat(standardComparisonStrategy.areEqual("Yoda", "Yoda")).isTrue();
+  void should_return_true_if_Object_arrays_are_equal() {
+    // GIVEN
+    Object[] actual = { "Luke", "Yoda", "Leia" };
+    Object[] other = { "Luke", "Yoda", "Leia" };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
   }
 
   @Test
-  void should_return_are_not_equal_if_first_Object_is_null_and_second_is_not() {
-    assertThat(standardComparisonStrategy.areEqual(null, "Yoda")).isFalse();
+  void should_return_false_if_Object_arrays_are_not_equal() {
+    // GIVEN
+    Object[] actual = { "Luke", "Leia", "Yoda" };
+    Object[] other = { "Luke", "Yoda", "Leia" };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
   }
 
   @Test
-  void should_return_are_not_equal_if_second_Object_is_null_and_first_is_not() {
-    assertThat(standardComparisonStrategy.areEqual("Yoda", null)).isFalse();
+  void should_return_true_if_byte_arrays_are_equal() {
+    // GIVEN
+    byte[] actual = { 1, 2, 3 };
+    byte[] other = { 1, 2, 3 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
   }
 
   @Test
-  void should_return_are_not_equal_if_Objects_are_not_equal() {
-    assertThat(standardComparisonStrategy.areEqual("Yoda", 2)).isFalse();
+  void should_return_false_if_byte_arrays_are_not_equal() {
+    // GIVEN
+    byte[] actual = { 1, 2, 3 };
+    byte[] other = { 4, 5, 6 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
   }
 
   @Test
-  void should_return_true_if_arrays_of_Objects_are_equal() {
-    Object[] a1 = { "Luke", "Yoda", "Leia" };
-    Object[] a2 = { "Luke", "Yoda", "Leia" };
-    assertThat(standardComparisonStrategy.areEqual(a1, a2)).isTrue();
+  void should_return_true_if_short_arrays_are_equal() {
+    // GIVEN
+    short[] actual = { 1, 2, 3 };
+    short[] other = { 1, 2, 3 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
   }
 
   @Test
-  void should_return_true_if_arrays_of_primitives_are_equal() {
-    int[] a1 = { 6, 8, 10 };
-    int[] a2 = { 6, 8, 10 };
-    assertThat(standardComparisonStrategy.areEqual(a1, a2)).isTrue();
+  void should_return_false_if_short_arrays_are_not_equal() {
+    // GIVEN
+    short[] actual = { 1, 2, 3 };
+    short[] other = { 4, 5, 6 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
   }
 
   @Test
-  void should_return_false_if_arrays_of_Objects_are_not_equal() {
-    Object[] a1 = { "Luke", "Yoda", "Leia" };
-    Object[] a2 = new Object[0];
-    assertThat(standardComparisonStrategy.areEqual(a1, a2)).isFalse();
+  void should_return_true_if_int_arrays_are_equal() {
+    // GIVEN
+    int[] actual = { 1, 2, 3 };
+    int[] other = { 1, 2, 3 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
   }
 
   @Test
-  void should_return_false_if_arrays_of_primitives_are_not_equal() {
-    int[] a1 = { 6, 8, 10 };
-    boolean[] a2 = { true };
-    assertThat(standardComparisonStrategy.areEqual(a1, a2)).isFalse();
+  void should_return_false_if_int_arrays_are_not_equal() {
+    // GIVEN
+    int[] actual = { 1, 2, 3 };
+    int[] other = { 4, 5, 6 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
+  }
+
+  @Test
+  void should_return_true_if_long_arrays_are_equal() {
+    // GIVEN
+    long[] actual = { 1L, 2L, 3L };
+    long[] other = { 1L, 2L, 3L };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
+  }
+
+  @Test
+  void should_return_false_if_long_arrays_are_not_equal() {
+    // GIVEN
+    long[] actual = { 1L, 2L, 3L };
+    long[] other = { 4L, 5L, 6L };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
+  }
+
+  @Test
+  void should_return_true_if_char_arrays_are_equal() {
+    // GIVEN
+    char[] actual = { '1', '2', '3' };
+    char[] other = { '1', '2', '3' };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
+  }
+
+  @Test
+  void should_return_false_if_char_arrays_are_not_equal() {
+    // GIVEN
+    char[] actual = { '1', '2', '3' };
+    char[] other = { '4', '5', '6' };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
+  }
+
+  @Test
+  void should_return_true_if_float_arrays_are_equal() {
+    // GIVEN
+    float[] actual = { 1.0f, 2.0f, 3.0f };
+    float[] other = { 1.0f, 2.0f, 3.0f };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
+  }
+
+  @Test
+  void should_return_false_if_float_arrays_are_not_equal() {
+    // GIVEN
+    float[] actual = { 1.0f, 2.0f, 3.0f };
+    float[] other = { 4.0f, 5.0f, 6.0f };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
+  }
+
+  @Test
+  void should_return_true_if_double_arrays_are_equal() {
+    // GIVEN
+    double[] actual = { 1.0, 2.0, 3.0 };
+    double[] other = { 1.0, 2.0, 3.0 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
+  }
+
+  @Test
+  void should_return_false_if_double_arrays_are_not_equal() {
+    // GIVEN
+    double[] actual = { 1.0, 2.0, 3.0 };
+    double[] other = { 4.0, 5.0, 6.0 };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
+  }
+
+  @Test
+  void should_return_true_if_boolean_arrays_are_equal() {
+    // GIVEN
+    boolean[] actual = { true, false };
+    boolean[] other = { true, false };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isTrue();
+  }
+
+  @Test
+  void should_return_false_if_boolean_arrays_are_not_equal() {
+    // GIVEN
+    boolean[] actual = { true, false };
+    boolean[] other = { false, true };
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isFalse();
+  }
+
+  @Test
+  void should_fail_if_equals_implementation_fails() {
+    // GIVEN
+    Object actual = new EqualsThrowsException();
+    // WHEN
+    Throwable thrown = catchThrowable(() -> underTest.areEqual(actual, new Object()));
+    // THEN
+    then(thrown).isInstanceOf(RuntimeException.class)
+                .hasMessage("Boom!");
+  }
+
+  private static class EqualsThrowsException {
+
+    @Override
+    public boolean equals(Object obj) {
+      throw new RuntimeException("Boom!");
+    }
+
+  }
+
+  @ParameterizedTest
+  @MethodSource({ "correctEquals", "contractViolatingEquals" })
+  void should_delegate_to_equals_implementation_if_actual_is_not_null(Object actual, Object other, boolean expected) {
+    // WHEN
+    boolean result = underTest.areEqual(actual, other);
+    // THEN
+    then(result).isEqualTo(expected);
+  }
+
+  private static Stream<Arguments> correctEquals() {
+    Object object = new Object();
+
+    return Stream.of(arguments(object, null, false),
+                     arguments(object, object, true),
+                     arguments(object, new Object(), false),
+                     arguments("Luke", null, false),
+                     arguments("Luke", "Luke", true),
+                     arguments("Luke", "Yoda", false));
+  }
+
+  private static Stream<Arguments> contractViolatingEquals() {
+    AlwaysTrue alwaysTrue = new AlwaysTrue();
+    AlwaysFalse alwaysFalse = new AlwaysFalse();
+
+    NonReflexive nonReflexiveX = new NonReflexive();
+
+    NonSymmetric nonSymmetricY = new NonSymmetric(null);
+    NonSymmetric nonSymmetricX = new NonSymmetric(nonSymmetricY);
+
+    NonTransitive nonTransitiveZ = new NonTransitive(null, null);
+    NonTransitive nonTransitiveY = new NonTransitive(nonTransitiveZ, null);
+    NonTransitive nonTransitiveX = new NonTransitive(nonTransitiveY, nonTransitiveZ);
+
+    NonConsistent nonConsistentX = new NonConsistent();
+
+    return Stream.of(arguments(alwaysTrue, null, true),
+                     arguments(alwaysFalse, alwaysFalse, false),
+                     arguments(nonReflexiveX, nonReflexiveX, false),
+                     arguments(nonSymmetricX, nonSymmetricY, true),
+                     arguments(nonSymmetricY, nonSymmetricX, false),
+                     arguments(nonTransitiveX, nonTransitiveY, true),
+                     arguments(nonTransitiveY, nonTransitiveZ, true),
+                     arguments(nonTransitiveX, nonTransitiveZ, false),
+                     arguments(nonConsistentX, nonConsistentX, true),
+                     arguments(nonConsistentX, nonConsistentX, false),
+                     arguments(nonConsistentX, nonConsistentX, true));
+  }
+
+  private static class AlwaysTrue {
+
+    @Override
+    public boolean equals(Object obj) {
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "always true";
+    }
+
+  }
+
+  private static class AlwaysFalse {
+
+    @Override
+    public boolean equals(Object obj) {
+      return false;
+    }
+
+    @Override
+    public String toString() {
+      return "always false";
+    }
+
+  }
+
+  private static class NonReflexive {
+
+    @Override
+    public boolean equals(Object obj) {
+      return this != obj;
+    }
+
+    @Override
+    public String toString() {
+      return "non reflexive";
+    }
+
+  }
+
+  private static class NonSymmetric {
+
+    private final Object other;
+
+    NonSymmetric(Object other) {
+      this.other = other;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == other;
+    }
+
+    @Override
+    public String toString() {
+      return "non symmetric";
+    }
+
+  }
+
+  private static class NonTransitive {
+
+    private final Object y, z;
+
+    NonTransitive(Object y, Object z) {
+      this.y = y;
+      this.z = z;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == y || obj != z;
+    }
+
+    @Override
+    public String toString() {
+      return "non transitive";
+    }
+
+  }
+
+  private static class NonConsistent {
+
+    private int i = 0;
+
+    @Override
+    public boolean equals(Object obj) {
+      return (++i % 2) != 0;
+    }
+
+    @Override
+    public String toString() {
+      return "non consistent";
+    }
+
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertEqual_Test.java
@@ -83,7 +83,7 @@ class Objects_assertEqual_Test extends ObjectsBaseTest {
   void should_fail_if_compared_with_null() {
     Throwable error = catchThrowable(() -> objects.assertEqual(someInfo(), new MyObject(), null));
 
-    assertThat(error).isInstanceOf(AssertionError.class);
+    assertThat(error).isInstanceOf(MyObject.NullEqualsException.class);
   }
 
   @Test
@@ -94,6 +94,7 @@ class Objects_assertEqual_Test extends ObjectsBaseTest {
   }
 
   private static class MyObject {
+
     private final int anInt = 0;
 
     @Override
@@ -105,12 +106,14 @@ class Objects_assertEqual_Test extends ObjectsBaseTest {
       return anInt == myObject.anInt;
     }
 
-    private class NullEqualsException extends RuntimeException {
+    private static class NullEqualsException extends RuntimeException {
       private static final long serialVersionUID = 6906581676690444515L;
     }
 
-    private class DifferentClassesException extends RuntimeException {
+    private static class DifferentClassesException extends RuntimeException {
       private static final long serialVersionUID = -7330747471795712311L;
     }
+
   }
+
 }

--- a/verify.bndrun
+++ b/verify.bndrun
@@ -30,8 +30,8 @@
 # The version ranges will change as the version of
 # AssertJ and/or its dependencies change.
 -runbundles: \
-	assertj-core;version='[3.19.0,3.19.1)',\
-	assertj-core-tests;version='[3.19.0,3.19.1)',\
+	assertj-core;version='[3.19.1,3.19.2)',\
+	assertj-core-tests;version='[3.19.1,3.19.2)',\
 	junit-jupiter-api;version='[5.6.3,5.6.4)',\
 	junit-jupiter-engine;version='[5.6.3,5.6.4)',\
 	junit-platform-commons;version='[1.6.3,1.6.4)',\


### PR DESCRIPTION
The previous behavior relied on `java.util.Objects#deepEquals`, which
performs a reference check before invoking `equals` on the first
parameter. While this it not an issue for proper implementations of
the `equals` contract, it was behaving incorrectly in case of
implementations not satisfying the reflexive property. Also, performing
the reference check outside of the `equals` implementation reduced the
overall coverage.

The tests now provide thorough regression to ensure that no shortcut is
taken, especially in case of implementations violating the contract.

#### Check List:
* Fixes #1949
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


