### PR TITLE
Maps.assertContainsOnly(info, actual, entries) has inconsistent behaviour if `entries` is empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>assertj-core</artifactId>
-  <version>3.19.0</version>
+  <version>3.19.1-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>AssertJ fluent assertions</name>
   <description>Rich and fluent assertions for testing for Java</description>
@@ -16,7 +16,7 @@
     <developerConnection>scm:git:git@github.com:assertj/assertj-core.git</developerConnection>
     <connection>scm:git:git@github.com:assertj/assertj-core.git</connection>
     <url>git@github.com:assertj/assertj-core</url>
-    <tag>assertj-core-3.19.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <issueManagement>
     <system>github</system>

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -63,7 +63,6 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.Condition;
-import org.assertj.core.error.ShouldBeEmpty;
 import org.assertj.core.error.ShouldContainAnyOf;
 import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.util.VisibleForTesting;
@@ -889,7 +888,7 @@ public class Maps {
   private <K, V> void doEntriesEmptyCheck(AssertionInfo info, Map<K, V> actual,
                                             Map.Entry<? extends K, ? extends V>[] entries) {
     if(entries.length == 0) {
-      throw failures.failure(info, ShouldBeEmpty.shouldBeEmpty(actual));
+      throw failures.failure(info, shouldBeEmpty(actual));
     }
   }
 

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -63,6 +63,7 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.Condition;
+import org.assertj.core.error.ShouldBeEmpty;
 import org.assertj.core.error.ShouldContainAnyOf;
 import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.util.VisibleForTesting;
@@ -743,14 +744,12 @@ public class Maps {
       return;
     }
 
+    doEntriesEmptyCheck(info, actual, entries);
+
     Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
     Set<Map.Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
 
     compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
-
-    if(!actual.isEmpty() && entries.length == 0) {
-      throw failures.failure(info, shouldContainOnly(actual, entries, notFound, notExpected));
-    }
 
     if (!notFound.isEmpty() || !notExpected.isEmpty())
       throw failures.failure(info, shouldContainOnly(actual, entries, notFound, notExpected));
@@ -776,6 +775,7 @@ public class Maps {
                                            @SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) return;
+    doEntriesEmptyCheck(info, actual, entries);
     assertHasSameSizeAs(info, actual, entries);
 
     Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
@@ -884,6 +884,13 @@ public class Maps {
 
   private static <K, V> void failIfEmptySinceActualIsNotEmpty(Map.Entry<? extends K, ? extends V>[] values) {
     if (values.length == 0) throw new AssertionError("actual is not empty");
+  }
+
+  private <K, V> void doEntriesEmptyCheck(AssertionInfo info, Map<K, V> actual,
+                                            Map.Entry<? extends K, ? extends V>[] entries) {
+    if(entries.length == 0) {
+      throw failures.failure(info, ShouldBeEmpty.shouldBeEmpty(actual));
+    }
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -732,9 +732,9 @@ public class Maps {
    * @param entries the entries that should be in the actual map.
    * @throws AssertionError if the actual map is {@code null}.
    * @throws NullPointerException if the given entries array is {@code null}.
-   * @throws IllegalArgumentException if the given entries array is empty.
    * @throws AssertionError if the actual map does not contain the given entries, i.e. the actual map contains some or
-   *           none of the given entries, or the actual map contains more entries than the given ones.
+   *           none of the given entries, or the actual map contains more entries than the given ones, or if entries is
+   *           empty
    */
   public <K, V> void assertContainsOnly(AssertionInfo info, Map<K, V> actual,
                                         @SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
@@ -742,12 +742,15 @@ public class Maps {
     if (actual.isEmpty() && entries.length == 0) {
       return;
     }
-    failIfEmpty(entries);
 
     Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
     Set<Map.Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
 
     compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
+
+    if(!actual.isEmpty() && entries.length == 0) {
+      throw failures.failure(info, shouldContainOnly(actual, entries, notFound, notExpected));
+    }
 
     if (!notFound.isEmpty() || !notExpected.isEmpty())
       throw failures.failure(info, shouldContainOnly(actual, entries, notFound, notExpected));
@@ -765,7 +768,6 @@ public class Maps {
    * @param entries the given entries.
    * @throws NullPointerException if the given entries array is {@code null}.
    * @throws AssertionError if the actual map is {@code null}.
-   * @throws IllegalArgumentException if the given entries array is empty.
    * @throws AssertionError if the actual map does not contain the given entries with same order, i.e. the actual map
    *           contains some or none of the given entries, or the actual map contains more entries than the given ones
    *           or entries are the same but the order is not.
@@ -774,7 +776,6 @@ public class Maps {
                                            @SuppressWarnings("unchecked") Map.Entry<? extends K, ? extends V>... entries) {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) return;
-    failIfEmpty(entries);
     assertHasSameSizeAs(info, actual, entries);
 
     Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
@@ -13,16 +13,13 @@
 package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
-import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
-import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
@@ -84,11 +81,11 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
   void should_fail_if_given_entries_array_is_empty() {
     // GIVEN
     AssertionInfo info = someInfo();
+    MapEntry<String, String>[] expected = emptyEntries();
     // WHEN
-    ThrowingCallable code = () -> maps.assertContainsExactly(info, linkedActual, emptyEntries());
+    expectAssertionError(() -> maps.assertContainsExactly(info, actual, expected));
     // THEN
-    String error = shouldHaveSameSizeAs(linkedActual, emptyEntries(), linkedActual.size(), emptyEntries().length).create();
-    assertThatAssertionErrorIsThrownBy(code).withMessage(error);
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
@@ -13,12 +13,14 @@
 package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
+import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
@@ -80,9 +82,13 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
   @SuppressWarnings("unchecked")
   @Test
   void should_fail_if_given_entries_array_is_empty() {
-    assertThatIllegalArgumentException().isThrownBy(() -> maps.assertContainsExactly(someInfo(), linkedActual,
-                                                                                     emptyEntries()))
-                                        .withMessage(entriesToLookForIsEmpty());
+    // GIVEN
+    AssertionInfo info = someInfo();
+    // WHEN
+    ThrowingCallable code = () -> maps.assertContainsExactly(info, linkedActual, emptyEntries());
+    // THEN
+    String error = shouldHaveSameSizeAs(linkedActual, emptyEntries(), linkedActual.size(), emptyEntries().length).create();
+    assertThatAssertionErrorIsThrownBy(code).withMessage(error);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -14,11 +14,10 @@ package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.data.MapEntry.entry;
+import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
 import static org.assertj.core.error.ShouldContainOnly.shouldContainOnly;
-import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsEmpty;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
@@ -73,7 +72,7 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
     // WHEN
     expectAssertionError(() -> maps.assertContainsOnly(info, actual, expected));
     // THEN
-    verify(failures).failure(info, shouldContainOnly(actual, expected, emptySet(), actual.entrySet()));
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -67,8 +67,13 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
   @SuppressWarnings("unchecked")
   @Test
   void should_fail_if_given_entries_array_is_empty() {
-    assertThatIllegalArgumentException().isThrownBy(() -> maps.assertContainsOnly(someInfo(), actual, emptyEntries()))
-                                        .withMessage(entriesToLookForIsEmpty());
+    // GIVEN
+    AssertionInfo info = someInfo();
+    MapEntry<String, String>[] expected = emptyEntries();
+    // WHEN
+    expectAssertionError(() -> maps.assertContainsOnly(info, actual, expected));
+    // THEN
+    verify(failures).failure(info, shouldContainOnly(actual, expected, emptySet(), actual.entrySet()));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
#### Check List:
* Fixes #2107 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES


