### PR TITLE
Fix NullPointerException in StandardRepresentation

### DIFF
--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -80,6 +80,7 @@ import org.assertj.core.util.diff.InsertDelta;
  * Standard java object representation.
  *
  * @author Mariusz Smykula
+ * @author Jack Gough
  */
 public class StandardRepresentation implements Representation {
 
@@ -455,7 +456,7 @@ public class StandardRepresentation implements Representation {
   protected String toStringOf(Throwable throwable) {
     StackTraceElement[] elements = throwable.getStackTrace();
     // if the line limit is 0, we assume the user don't want to print stack trace
-    if (maxStackTraceElementsDisplayed == 0) return throwable.toString();
+    if (maxStackTraceElementsDisplayed == 0 || elements == null) return throwable.toString();
     // display the full stack trace
     if (maxStackTraceElementsDisplayed >= elements.length) return getStackTrace(throwable);
 

--- a/src/test/java/org/assertj/core/api/Assertions_catchThrowableOfType_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_catchThrowableOfType_Test.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 
@@ -117,6 +118,16 @@ class Assertions_catchThrowableOfType_Test {
   void should_pass_if_message_does_not_contain_description() {
     assertThatExceptionOfType(Exception.class).isThrownBy(codeThrowing(new Exception("boom")))
                                               .withMessageNotContaining("bam");
+  }
+
+  @Test
+  void should_catch_mocked_throwable() {
+    // GIVEN
+    Throwable throwable = mock(Throwable.class);
+    // WHEN
+    Throwable actual = catchThrowableOfType(() -> { throw throwable; }, Throwable.class);
+    // THEN
+    assertThat(actual).isSameAs(throwable);
   }
 
   private static ThrowingCallable raisingException(final String reason) {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_throwable_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_throwable_format_Test.java
@@ -15,8 +15,11 @@ package org.assertj.core.presentation;
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import org.assertj.core.configuration.Configuration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,6 +45,13 @@ class StandardRepresentation_throwable_format_Test {
     }
   }
 
+  @AfterEach
+  void afterEach() {
+    // Restore default configuration after each test
+    Configuration configuration = new Configuration();
+    configuration.apply();
+  }
+
   @Test
   void should_not_display_stacktrace_if_maxStackTraceElementsDisplayed_is_zero() {
     // GIVEN
@@ -65,11 +75,11 @@ class StandardRepresentation_throwable_format_Test {
     // THEN
     then(toString).matches("java\\.lang\\.RuntimeException\\R"
                            +
-                           "\\tat org\\.assertj\\.core\\.presentation\\.StandardRepresentation_throwable_format_Test\\$Test1\\$Test2\\.boom2\\(StandardRepresentation_throwable_format_Test\\.java:36\\)\\R"
+                           "\\tat org\\.assertj\\.core\\.presentation\\.StandardRepresentation_throwable_format_Test\\$Test1\\$Test2\\.boom2\\(StandardRepresentation_throwable_format_Test\\.java:\\d+\\)\\R"
                            +
-                           "\\tat org\\.assertj\\.core\\.presentation\\.StandardRepresentation_throwable_format_Test\\$Test1\\.boom\\(StandardRepresentation_throwable_format_Test\\.java:41\\)\\R"
+                           "\\tat org\\.assertj\\.core\\.presentation\\.StandardRepresentation_throwable_format_Test\\$Test1\\.boom\\(StandardRepresentation_throwable_format_Test\\.java:\\d+\\)\\R"
                            +
-                           "\\tat org\\.assertj\\.core\\.api\\.ThrowableAssert\\.catchThrowable\\(ThrowableAssert\\.java:62\\)\\R"
+                           "\\tat org\\.assertj\\.core\\.api\\.ThrowableAssert\\.catchThrowable\\(ThrowableAssert\\.java:\\d+\\)\\R"
                            +
                            "\\t\\.{3}\\(\\d+ remaining lines not displayed - this can be changed with Assertions\\.setMaxStackTraceElementsDisplayed\\)");
   }
@@ -88,4 +98,14 @@ class StandardRepresentation_throwable_format_Test {
                   .doesNotContain("remaining lines not displayed");
   }
 
+  @Test
+  void should_display_toString_when_null_stack() {
+    // GIVEN
+    Throwable throwable = mock(Throwable.class);
+    when(throwable.toString()).thenReturn("throwable string");
+    // WHEN
+    String actual = REPRESENTATION.toStringOf(throwable);
+    // THEN
+    then(actual).isEqualTo("throwable string");
+  }
 }


### PR DESCRIPTION
#### Check List:
* Fixes NullPointerException when null stackTrace (common in mocked Throwable)
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


Noticed this issue when upgrading from 3.18.1 -> 3.19.0.  A number of tests failed with the following stack trace when using `catchThrowableOfType` with a mocked Throwable.  Used to work fine in 3.18.1.  This is because mocked Throwable will return null from `Throwable::getStackTrace()`

```
java.lang.NullPointerException
	at org.assertj.core.presentation.StandardRepresentation.toStringOf(StandardRepresentation.java:460)
	at org.assertj.core.presentation.StandardRepresentation.toStringOf(StandardRepresentation.java:246)
	at org.assertj.core.error.MessageFormatter.asText(MessageFormatter.java:78)
	at org.assertj.core.error.MessageFormatter.format(MessageFormatter.java:69)
	at org.assertj.core.error.MessageFormatter.format(MessageFormatter.java:62)
	at org.assertj.core.error.BasicErrorMessageFactory.create(BasicErrorMessageFactory.java:119)
	at org.assertj.core.api.ThrowableAssert.catchThrowableOfType(ThrowableAssert.java:75)
	at org.assertj.core.api.AssertionsForClassTypes.catchThrowableOfType(AssertionsForClassTypes.java:919)
	at org.assertj.core.api.Assertions.catchThrowableOfType(Assertions.java:1375)
	at ...
```

