### PR TITLE
Prevent compiler warning when using extracting with SoftAssertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -774,11 +774,9 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    * @throws IntrospectionError if one of the given name does not match a field or property
    */
   @CheckReturnValue
-  public AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(String... propertiesOrFields) {
-    Tuple values = byName(propertiesOrFields).apply(actual);
-    String extractedPropertiesOrFieldsDescription = extractedDescriptionOf(propertiesOrFields);
-    String description = mostRelevantDescription(info.description(), extractedPropertiesOrFieldsDescription);
-    return newListAssertInstance(values.toList()).withAssertionState(myself).as(description);
+  @SafeVarargs
+  public final AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extracting(String... propertiesOrFields) {
+    return extractingForProxy(propertiesOrFields);
   }
 
   /**
@@ -1168,6 +1166,13 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
   // override for proxyable friendly AbstractObjectAssert
   protected <T> AbstractObjectAssert<?, T> newObjectAssert(T objectUnderTest) {
     return new ObjectAssert<>(objectUnderTest);
+  }
+
+  protected AbstractListAssert<?, List<?>, Object, ObjectAssert<Object>> extractingForProxy(String[] propertiesOrFields) {
+    Tuple values = byName(propertiesOrFields).apply(actual);
+    String extractedPropertiesOrFieldsDescription = extractedDescriptionOf(propertiesOrFields);
+    String description = mostRelevantDescription(info.description(), extractedPropertiesOrFieldsDescription);
+    return newListAssertInstance(values.toList()).withAssertionState(myself).as(description);
   }
 
   @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -2391,6 +2391,19 @@ class SoftAssertionsTest extends BaseAssertionsTest {
                                       .hasMessageContaining("MAN");
   }
 
+  @Test
+  void soft_assertions_with_extracting_should_not_have_any_compiler_warning() {
+    // GIVEN
+    TolkienCharacter legolas = TolkienCharacter.of("Legolas", 1000, ELF);
+
+    softly.assertThat(legolas)
+          .extracting(TolkienCharacter::getName, TolkienCharacter::getAge)
+          .contains("Legolas", 1000);
+
+    assertThat(legolas).extracting(TolkienCharacter::getName, TolkienCharacter::getAge)
+                       .contains("Legolas", 1000);
+  }
+
   @Nested
   class ExtractingFromEntries {
 


### PR DESCRIPTION
I'm not sure about the "fix". 
However, it seems we use the same way in ObjectAssert class: 

https://github.com/assertj/assertj-core/blob/14cd17293c62376abc8c762084819a1e08db1520/src/main/java/org/assertj/core/api/ObjectAssert.java#L43-L48

Because `SoftAssertions` (`Java6StandardSoftAssertionsProvider`) is building a `ProxyableObjectAssert` I added an override on the `extracting` method to be able to use the annotation `@SafeVarargs` on it.

#### Check List:
* Fixes #2161
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


