### PR TITLE
Fix NullPointerException in primitive double assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractDoubleAssert.java
@@ -42,6 +42,7 @@ import org.assertj.core.util.VisibleForTesting;
  * @author Joel Costigliola
  * @author Mikhail Mazursky
  * @author Nicolas François
+ * @author Jack Gough
  */
 public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SELF>> extends
     AbstractComparableAssert<SELF, Double> implements FloatingPointNumberAssert<SELF, Double> {
@@ -463,6 +464,8 @@ public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SEL
    */
   public SELF isEqualTo(double expected) {
     if (noCustomComparatorSet()) {
+      // check for null first to avoid casting a null to primitive
+      isNotNull();
       // use primitive comparison since the parameter is a primitive.
       if (expected == actual) return myself;
       // At this point we know that the assertion failed, if actual and expected are Double.NaN we want to
@@ -580,6 +583,8 @@ public abstract class AbstractDoubleAssert<SELF extends AbstractDoubleAssert<SEL
    */
   public SELF isNotEqualTo(double other) {
     if (noCustomComparatorSet()) {
+      // check for null first to avoid casting a null to primitive
+      isNotNull();
       // use primitive comparison since the parameter is a primitive.
       if (other != actual) return myself;
       throw Failures.instance().failure(info, shouldNotBeEqual(actual, other));

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isEqualTo_double_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isEqualTo_double_Test.java
@@ -90,4 +90,15 @@ class DoubleAssert_isEqualTo_double_Test extends DoubleAssertBaseTest {
     // THEN
     then(assertionError).hasMessage(format("Actual and expected values were compared with == because expected was a primitive double, the assertion failed as both were Double.NaN and Double.NaN != Double.NaN (as per Double#equals javadoc)"));
   }
+
+  @Test
+  void should_fail_when_actual_null_expected_primitive() {
+    // GIVEN
+    Double actual = null;
+    double expected = 1.0d;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualTo(expected));
+    // THEN
+    then(assertionError).hasMessageContaining("Expecting actual not to be null");
+  }
 }

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotEqualTo_double_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotEqualTo_double_Test.java
@@ -79,4 +79,15 @@ class DoubleAssert_isNotEqualTo_double_Test extends DoubleAssertBaseTest {
                                            "not to be equal to:%n" +
                                            "  -0.0%n"));
   }
+
+  @Test
+  void should_fail_when_actual_null_expected_primitive() {
+    // GIVEN
+    Double actual = null;
+    double expected = 1.0d;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotEqualTo(expected));
+    // THEN
+    then(assertionError).hasMessageContaining("Expecting actual not to be null");
+  }
 }


### PR DESCRIPTION
#### Check List:
* Fixes NullPointerException in AbstractDoubleAssert
* Unit tests : YES
* Javadoc with a code example (on API only) : NA

The Javadoc for the `isEqualTo(double)` and `isNotEqualTo(double)` (with primitive parameter) states that an `AssertionError` will be thrown if `actual == null`, however it was actually throwing a `NullPointerException` when casting `actual` to primitive in the `==` and `!=` checks.

Javadoc:
```
* @throws AssertionError if the actual value is {@code null}.
```

Reproduction:
```
assertThat((Double)null).isEqualTo(5.0d);
```

Threw NPE here when it tried to cast boxed null actual to primitive double
```
if (expected == actual) return myself;
                ^-- npe
```
