### PR TITLE
Honor map key comparison semantics with `containsOnly` assertions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
                 <bannedDependencies>
                   <includes>
                     <include>net.bytebuddy:byte-buddy</include>
+                    <include>org.objenesis:objenesis</include>
                   </includes>
                   <excludes>
                     <exclude>org.assertj:assertj-core</exclude>
@@ -250,6 +251,7 @@
         <executions>
           <!-- STEP 2a: execute maven shade to rename bytebuddy -->
           <execution>
+            <id>bytebuddy</id>
             <phase>package</phase>
             <goals>
               <goal>shade</goal>
@@ -277,6 +279,7 @@
           </execution>
           <!-- STEP 2b: execute maven shade to rename objenesis -->
           <execution>
+            <id>objenesis</id>
             <phase>package</phase>
             <goals>
               <goal>shade</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -192,6 +192,12 @@
       <version>3.16.200</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>assertj-core</artifactId>
   <version>3.19.1-SNAPSHOT</version>
@@ -27,6 +28,7 @@
     <javadocAdditionalOptions>-html5 --allow-script-in-comments --no-module-directories</javadocAdditionalOptions>
     <byte-buddy.version>1.11.0</byte-buddy.version>
     <opentest4j.version>1.2.0</opentest4j.version>
+    <objenesis.version>3.2</objenesis.version>
     <bnd.version>5.3.0</bnd.version>
     <!-- Dependency versions overriding -->
     <junit.version>4.13.2</junit.version>
@@ -57,6 +59,11 @@
         <groupId>org.opentest4j</groupId>
         <artifactId>opentest4j</artifactId>
         <version>${opentest4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.objenesis</groupId>
+        <artifactId>objenesis</artifactId>
+        <version>${objenesis.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -120,6 +127,10 @@
       <artifactId>byte-buddy</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -155,6 +166,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.12.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+      <version>4.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -231,7 +248,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.4</version>
         <executions>
-          <!-- STEP 2: execute maven shade to rename bytebuddy -->
+          <!-- STEP 2a: execute maven shade to rename bytebuddy -->
           <execution>
             <phase>package</phase>
             <goals>
@@ -251,6 +268,35 @@
               <filters>
                 <filter>
                   <artifact>net.bytebuddy:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+          <!-- STEP 2b: execute maven shade to rename objenesis -->
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>true</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <include>org.objenesis:objenesis</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.objenesis</pattern>
+                  <shadedPattern>org.assertj.core.internal.objenesis</shadedPattern>
+                </relocation>
+              </relocations>
+              <filters>
+                <filter>
+                  <artifact>org.objenesis:*</artifact>
                   <excludes>
                     <exclude>META-INF/**</exclude>
                   </excludes>
@@ -669,7 +715,9 @@
         <jdk>[16,)</jdk>
       </activation>
       <properties>
-        <argLine>-Dnet.bytebuddy.experimental=true --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED</argLine>
+        <argLine>-Dnet.bytebuddy.experimental=true --add-opens=java.base/java.lang=ALL-UNNAMED
+          --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED
+          --add-opens=java.base/sun.nio.fs=ALL-UNNAMED</argLine>
       </properties>
     </profile>
   </profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>assertj-core</artifactId>
   <version>3.19.1-SNAPSHOT</version>
@@ -28,7 +27,6 @@
     <javadocAdditionalOptions>-html5 --allow-script-in-comments --no-module-directories</javadocAdditionalOptions>
     <byte-buddy.version>1.11.0</byte-buddy.version>
     <opentest4j.version>1.2.0</opentest4j.version>
-    <objenesis.version>3.2</objenesis.version>
     <bnd.version>5.3.0</bnd.version>
     <!-- Dependency versions overriding -->
     <junit.version>4.13.2</junit.version>
@@ -59,11 +57,6 @@
         <groupId>org.opentest4j</groupId>
         <artifactId>opentest4j</artifactId>
         <version>${opentest4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.objenesis</groupId>
-        <artifactId>objenesis</artifactId>
-        <version>${objenesis.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -125,10 +118,6 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
@@ -215,7 +204,6 @@
                 <bannedDependencies>
                   <includes>
                     <include>net.bytebuddy:byte-buddy</include>
-                    <include>org.objenesis:objenesis</include>
                   </includes>
                   <excludes>
                     <exclude>org.assertj:assertj-core</exclude>
@@ -255,7 +243,7 @@
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.4</version>
         <executions>
-          <!-- STEP 2a: execute maven shade to rename bytebuddy -->
+          <!-- STEP 2: execute maven shade to rename bytebuddy -->
           <execution>
             <id>bytebuddy</id>
             <phase>package</phase>
@@ -276,36 +264,6 @@
               <filters>
                 <filter>
                   <artifact>net.bytebuddy:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/**</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
-          </execution>
-          <!-- STEP 2b: execute maven shade to rename objenesis -->
-          <execution>
-            <id>objenesis</id>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <createDependencyReducedPom>true</createDependencyReducedPom>
-              <artifactSet>
-                <includes>
-                  <include>org.objenesis:objenesis</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>org.objenesis</pattern>
-                  <shadedPattern>org.assertj.core.internal.objenesis</shadedPattern>
-                </relocation>
-              </relocations>
-              <filters>
-                <filter>
-                  <artifact>org.objenesis:*</artifact>
                   <excludes>
                     <exclude>META-INF/**</exclude>
                   </excludes>

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1138,7 +1138,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * Verifies that the actual map contains only the given keys and nothing else, in any order.
    * <p>
    * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
-   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified  correctly
+   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified correctly
    * (e.g., due to immutability).
    * <p>
    * Examples :
@@ -1176,7 +1176,10 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
 
   /**
    * Verifies that the actual map contains only the given keys and nothing else, in any order.
-   *
+   * <p>
+   * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
+   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified correctly
+   * (e.g., due to immutability).
    * <p>
    * Examples :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
@@ -1303,7 +1306,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
    * Verifies that the actual map contains only the given entries and nothing else, in any order.
    * <p>
    * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
-   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified  correctly
+   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified correctly
    * (e.g., due to immutability).
    * <p>
    * Examples :

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1136,7 +1136,10 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
 
   /**
    * Verifies that the actual map contains only the given keys and nothing else, in any order.
-   *
+   * <p>
+   * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
+   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified  correctly
+   * (e.g., due to immutability).
    * <p>
    * Examples :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
@@ -1298,7 +1301,10 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
 
   /**
    * Verifies that the actual map contains only the given entries and nothing else, in any order.
-   *
+   * <p>
+   * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
+   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified  correctly
+   * (e.g., due to immutability).
    * <p>
    * Examples :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();

--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -1137,9 +1137,10 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   /**
    * Verifies that the actual map contains only the given keys and nothing else, in any order.
    * <p>
-   * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
-   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified correctly
-   * (e.g., due to immutability).
+   * The verification tries to honor the key comparison semantic of the underlying map implementation.
+   * The map under test has to be cloned to identify unexpected elements, but depending on the map implementation
+   * this may not always be possible. In case it is not possible, a regular map is used and the key comparison strategy
+   * may not be the same as the map under test.
    * <p>
    * Examples :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
@@ -1177,9 +1178,10 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   /**
    * Verifies that the actual map contains only the given keys and nothing else, in any order.
    * <p>
-   * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
-   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified correctly
-   * (e.g., due to immutability).
+   * The verification tries to honor the key comparison semantic of the underlying map implementation.
+   * The map under test has to be cloned to identify unexpected elements, but depending on the map implementation
+   * this may not always be possible. In case it is not possible, a regular map is used and the key comparison strategy
+   * may not be the same as the map under test.
    * <p>
    * Examples :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();
@@ -1305,9 +1307,10 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
   /**
    * Verifies that the actual map contains only the given entries and nothing else, in any order.
    * <p>
-   * The verification tries to honor the key comparison semantic of the underlying map implementation, but there might
-   * be some cases where the semantic cannot be honored and not all the unexpected elements are identified correctly
-   * (e.g., due to immutability).
+   * The verification tries to honor the key comparison semantic of the underlying map implementation.
+   * The map under test has to be cloned to identify unexpected elements, but depending on the map implementation
+   * this may not always be possible. In case it is not possible, a regular map is used and the key comparison strategy
+   * may not be the same as the map under test.
    * <p>
    * Examples :
    * <pre><code class='java'> Map&lt;Ring, TolkienCharacter&gt; ringBearers = new HashMap&lt;&gt;();

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -575,12 +575,7 @@ public class Maps {
   // The method cannot be made final and annotated with @SafeVarargs because the class is mocked in tests
   public <K, V> void assertContainsKeys(AssertionInfo info, Map<K, V> actual, K[] keys) {
     assertNotNull(info, actual);
-    Set<K> notFound = new LinkedHashSet<>();
-    for (K key : keys) {
-      if (!actual.containsKey(key)) {
-        notFound.add(key);
-      }
-    }
+    Set<K> notFound = getNotFoundKeys(actual, keys);
     if (notFound.isEmpty()) return;
     throw failures.failure(info, shouldContainKeys(actual, notFound));
   }
@@ -683,7 +678,7 @@ public class Maps {
   private static <K> Set<K> getNotFoundKeys(Map<K, ?> actual, K[] keys) {
     return Stream.of(keys)
                  .filter(key -> !actual.containsKey(key))
-                 .collect(Collectors.toSet());
+                 .collect(Collectors.toCollection(LinkedHashSet::new));
   }
 
   private static <K> Set<K> getNotExpectedKeys(Map<K, ?> actual, K[] keys) {
@@ -851,23 +846,6 @@ public class Maps {
     }
 
     throw failures.failure(info, shouldContainExactly(actual, asList(entries), notFound, notExpected));
-  }
-
-  private <K, V> void compareActualMapAndExpectedKeys(Map<K, V> actual, K[] keys, Set<K> notExpected, Set<K> notFound) {
-    Map<K, V> actualCopy = instantiate(actual.getClass());
-    actualCopy.putAll(actual);
-    Map<K, V> actualEntries = actualCopy;
-    for (K key : keys) {
-      if (actualEntries.containsKey(key)) {
-        // this is an expected key
-        actualEntries.remove(key);
-      } else {
-        // this is a not found key
-        notFound.add(key);
-      }
-    }
-    // All remaining keys from actual copy are not expected entries.
-    notExpected.addAll(actualEntries.keySet());
   }
 
   private <V, K> Map<K, V> instantiate(Class<? extends Map> mapClass) {

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -342,12 +342,7 @@ public class Maps {
 
   public <K, V> void assertDoesNotContainKeys(AssertionInfo info, Map<K, V> actual, K[] keys) {
     assertNotNull(info, actual);
-    Set<K> found = new LinkedHashSet<>();
-    for (K key : keys) {
-      if (key != null && actual.containsKey(key)) {
-        found.add(key);
-      }
-    }
+    Set<K> found = getFoundKeys(actual, keys);
     if (!found.isEmpty()) throw failures.failure(info, shouldNotContainKeys(actual, found));
   }
 
@@ -373,6 +368,14 @@ public class Maps {
 
     if (!notFound.isEmpty() || !notExpected.isEmpty())
       throw failures.failure(info, shouldContainOnlyKeys(actual, keys, notFound, notExpected));
+  }
+
+  private static <K> Set<K> getFoundKeys(Map<K, ?> actual, K[] expectedKeys) {
+    Set<K> found = new LinkedHashSet<>();
+    for (K expectedKey : expectedKeys) {
+      if (actual.containsKey(expectedKey)) found.add(expectedKey);
+    }
+    return found;
   }
 
   private static <K> Set<K> getNotFoundKeys(Map<K, ?> actual, K[] expectedKeys) {

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -54,7 +54,6 @@ import static org.assertj.core.util.IterableUtil.toArray;
 import static org.assertj.core.util.Objects.areEqual;
 import static org.assertj.core.util.Preconditions.checkArgument;
 
-import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -379,9 +378,7 @@ public class Maps {
   private static <K> Set<K> getNotFoundKeys(Map<K, ?> actual, K[] expectedKeys) {
     Set<K> notFound = new LinkedHashSet<>();
     for (K expectedKey : expectedKeys) {
-      if (!actual.containsKey(expectedKey)) {
-        notFound.add(expectedKey);
-      }
+      if (!actual.containsKey(expectedKey)) notFound.add(expectedKey);
     }
     return notFound;
   }
@@ -453,7 +450,8 @@ public class Maps {
 
     Set<Entry<? extends K, ? extends V>> notFound = getNotFoundEntries(actual, entries);
     Set<Entry<K, V>> notExpected = getNotExpectedEntries(actual, entries);
-    if (!notFound.isEmpty() || !notExpected.isEmpty())
+
+    if (!(notFound.isEmpty() && notExpected.isEmpty()))
       throw failures.failure(info, shouldContainOnly(actual, entries, notFound, notExpected));
   }
 
@@ -461,9 +459,7 @@ public class Maps {
                                                                                 Entry<? extends K, ? extends V>[] entries) {
     Set<Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
     for (Entry<? extends K, ? extends V> entry : entries) {
-      if (!containsEntry(actual, entry)) {
-        notFound.add(entry);
-      }
+      if (!containsEntry(actual, entry)) notFound.add(entry);
     }
     return notFound;
   }
@@ -498,12 +494,11 @@ public class Maps {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) return;
     failIfEntriesIsEmptyEmptySinceActualIsNotEmpty(info, actual, entries);
+
+    Set<Entry<? extends K, ? extends V>> notFound = getNotFoundEntries(actual, entries);
+    Set<Entry<K, V>> notExpected = getNotExpectedEntries(actual, entries);
+
     assertHasSameSizeAs(info, actual, entries);
-
-    Set<Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    Set<Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
-
-    compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
 
     if (notExpected.isEmpty() && notFound.isEmpty()) {
       // check entries order
@@ -522,37 +517,6 @@ public class Maps {
     throw failures.failure(info, shouldContainExactly(actual, asList(entries), notFound, notExpected));
   }
 
-  private <V, K> Map<K, V> instantiate(Class<? extends Map> mapClass) {
-    try {
-      Constructor<?> constructor = mapClass.getConstructor();
-      return (Map<K, V>) constructor.newInstance();
-    } catch (Exception e) {
-      // default map but might not honor mapClass semantics (ex: CaseInsensitiveMap)
-      return new LinkedHashMap<>();
-    }
-  }
-
-  private <K, V> void compareActualMapAndExpectedEntries(Map<K, V> actual, Entry<? extends K, ? extends V>[] entries,
-                                                         Set<Entry<? extends K, ? extends V>> notExpected,
-                                                         Set<Entry<? extends K, ? extends V>> notFound) {
-    Map<K, V> expectedEntries = entriesToMap(entries);
-    Map<K, V> actualEntries = instantiate(actual.getClass());
-    actualEntries.putAll(actual);
-    for (Entry<K, V> entry : expectedEntries.entrySet()) {
-      if (containsEntry(actualEntries, entry(entry.getKey(), entry.getValue()))) {
-        // this is an expected entry
-        actualEntries.remove(entry.getKey());
-      } else {
-        // this is a not found entry
-        notFound.add(entry(entry.getKey(), entry.getValue()));
-      }
-    }
-    // All remaining entries from actual copy are not expected entries.
-    for (Entry<K, V> entry : actualEntries.entrySet()) {
-      notExpected.add(entry(entry.getKey(), entry.getValue()));
-    }
-  }
-
   private <K, V> void doCommonContainsCheck(AssertionInfo info, Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
     assertNotNull(info, actual);
     failIfNull(entries);
@@ -565,14 +529,6 @@ public class Maps {
       if (!containsEntry(actual, entry)) notFound.add(entry);
     }
     if (!notFound.isEmpty()) throw failures.failure(info, shouldContain(actual, entries, notFound));
-  }
-
-  private static <K, V> Map<K, V> entriesToMap(Entry<? extends K, ? extends V>[] entries) {
-    Map<K, V> expectedEntries = new LinkedHashMap<>();
-    for (Entry<? extends K, ? extends V> entry : entries) {
-      expectedEntries.put(entry.getKey(), entry.getValue());
-    }
-    return expectedEntries;
   }
 
   private static <K> void failIfEmpty(K[] keys, String errorMessage) {

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -71,8 +71,6 @@ import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.Condition;
 import org.assertj.core.error.UnsatisfiedRequirement;
 import org.assertj.core.util.VisibleForTesting;
-import org.objenesis.Objenesis;
-import org.objenesis.ObjenesisStd;
 
 /**
  * Reusable assertions for <code>{@link Map}</code>s.
@@ -84,8 +82,6 @@ import org.objenesis.ObjenesisStd;
 public class Maps {
 
   private static final Maps INSTANCE = new Maps();
-
-  Objenesis objenesis = new ObjenesisStd();
 
   /**
    * Returns the singleton instance of this class.
@@ -892,7 +888,6 @@ public class Maps {
     try {
       Constructor<?> constructor = mapClass.getConstructor();
       return (Map<K, V>) constructor.newInstance();
-      // return objenesis.newInstance(class1);
     } catch (Exception e) {
       // default map but might not honor mapClass semantics (ex: CaseInsensitiveMap)
       return new LinkedHashMap<>();

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -60,6 +60,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -116,7 +117,7 @@ public class Maps {
   }
 
   private static <K, V> Optional<UnsatisfiedRequirement> failsRequirements(BiConsumer<? super K, ? super V> entryRequirements,
-                                                                           Map.Entry<K, V> entry) {
+                                                                           Entry<K, V> entry) {
     try {
       entryRequirements.accept(entry.getKey(), entry.getValue());
     } catch (AssertionError ex) {
@@ -131,7 +132,7 @@ public class Maps {
     assertNotNull(info, actual);
 
     List<UnsatisfiedRequirement> unsatisfiedRequirements = new ArrayList<>();
-    for (Map.Entry<K, V> entry : actual.entrySet()) {
+    for (Entry<K, V> entry : actual.entrySet()) {
       Optional<UnsatisfiedRequirement> result = failsRequirements(entryRequirements, entry);
       if (!result.isPresent()) return; // entry satisfied the requirements
       unsatisfiedRequirements.add(result.get());
@@ -144,17 +145,17 @@ public class Maps {
     requireNonNull(entryRequirements, "The BiConsumer<K, V> expressing the assertions requirements must not be null");
     assertNotNull(info, actual);
 
-    List<Map.Entry<K, V>> erroneousEntries = actual.entrySet().stream()
-                                                   .map(entry -> failsRestrictions(entry, entryRequirements))
-                                                   .filter(Optional::isPresent)
-                                                   .map(Optional::get)
-                                                   .collect(toList());
+    List<Entry<K, V>> erroneousEntries = actual.entrySet().stream()
+                                               .map(entry -> failsRestrictions(entry, entryRequirements))
+                                               .filter(Optional::isPresent)
+                                               .map(Optional::get)
+                                               .collect(toList());
 
     if (erroneousEntries.size() > 0) throw failures.failure(info, noElementsShouldSatisfy(actual, erroneousEntries));
   }
 
-  private <V, K> Optional<Map.Entry<K, V>> failsRestrictions(Map.Entry<K, V> entry,
-                                                             BiConsumer<? super K, ? super V> entryRequirements) {
+  private <V, K> Optional<Entry<K, V>> failsRestrictions(Entry<K, V> entry,
+                                                         BiConsumer<? super K, ? super V> entryRequirements) {
     try {
       entryRequirements.accept(entry.getKey(), entry.getValue());
     } catch (AssertionError e) {
@@ -347,7 +348,7 @@ public class Maps {
    * @throws AssertionError if the given {@code Map} is {@code null}.
    * @throws AssertionError if the given {@code Map} does not contain the given entries.
    */
-  public <K, V> void assertContains(AssertionInfo info, Map<K, V> actual, Map.Entry<? extends K, ? extends V>[] entries) {
+  public <K, V> void assertContains(AssertionInfo info, Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
     failIfNull(entries);
     assertNotNull(info, actual);
     // if both actual and values are empty, then assertion passes.
@@ -373,17 +374,17 @@ public class Maps {
     assertNotNull(info, actual);
     // assertion passes if other is empty since actual contains all other entries.
     if (other.isEmpty()) return;
-    failIfAnyEntryNotFoundInActualMap(info, actual, other.entrySet().toArray(new Map.Entry[0]));
+    failIfAnyEntryNotFoundInActualMap(info, actual, other.entrySet().toArray(new Entry[0]));
   }
 
   public <K, V> void assertContainsAnyOf(AssertionInfo info, Map<K, V> actual,
-                                         Map.Entry<? extends K, ? extends V>[] entries) {
+                                         Entry<? extends K, ? extends V>[] entries) {
     failIfNull(entries);
     assertNotNull(info, actual);
     // if both actual and values are empty, then assertion passes.
     if (actual.isEmpty() && entries.length == 0) return;
     failIfEntriesIsEmptyEmptySinceActualIsNotEmpty(info, actual, entries);
-    for (Map.Entry<? extends K, ? extends V> entry : entries) {
+    for (Entry<? extends K, ? extends V> entry : entries) {
       if (containsEntry(actual, entry)) return;
     }
     throw failures.failure(info, shouldContainAnyOf(actual, entries));
@@ -448,10 +449,10 @@ public class Maps {
    * @since 2.7.0 / 3.7.0
    */
   public <K, V> void assertHasEntrySatisfying(AssertionInfo info, Map<K, V> actual,
-                                              Condition<? super Map.Entry<K, V>> entryCondition) {
+                                              Condition<? super Entry<K, V>> entryCondition) {
     assertNotNull(info, actual);
     conditions.assertIsNotNull(entryCondition);
-    for (Map.Entry<K, V> entry : actual.entrySet()) {
+    for (Entry<K, V> entry : actual.entrySet()) {
       if (entryCondition.matches(entry)) return;
     }
 
@@ -480,7 +481,7 @@ public class Maps {
     conditions.assertIsNotNull(keyCondition, "The condition to evaluate for entries key should not be null");
     conditions.assertIsNotNull(valueCondition, "The condition to evaluate for entries value should not be null");
 
-    for (Map.Entry<K, V> entry : actual.entrySet()) {
+    for (Entry<K, V> entry : actual.entrySet()) {
       if (keyCondition.matches(entry.getKey()) && valueCondition.matches(entry.getValue())) return;
     }
 
@@ -547,11 +548,11 @@ public class Maps {
    * @throws AssertionError if the given {@code Map} is {@code null}.
    * @throws AssertionError if the given {@code Map} contains any of the given entries.
    */
-  public <K, V> void assertDoesNotContain(AssertionInfo info, Map<K, V> actual, Map.Entry<? extends K, ? extends V>[] entries) {
+  public <K, V> void assertDoesNotContain(AssertionInfo info, Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
     failIfNullOrEmpty(entries);
     assertNotNull(info, actual);
-    Set<Map.Entry<? extends K, ? extends V>> found = new LinkedHashSet<>();
-    for (Map.Entry<? extends K, ? extends V> entry : entries) {
+    Set<Entry<? extends K, ? extends V>> found = new LinkedHashSet<>();
+    for (Entry<? extends K, ? extends V> entry : entries) {
       if (containsEntry(actual, entry)) {
         found.add(entry);
       }
@@ -684,14 +685,14 @@ public class Maps {
   private static <K> Set<K> getNotExpectedKeys(Map<K, ?> actual, K[] keys) {
     List<K> expectedKeys = java.util.Arrays.asList(keys);
     try {
-      Set<K> unexpectedKeys = clone(actual).keySet();
-      expectedKeys.forEach(unexpectedKeys::remove);
-      return unexpectedKeys;
+      Map<K, ?> clonedMap = clone(actual);
+      expectedKeys.forEach(clonedMap::remove);
+      return clonedMap.keySet();
     } catch (NoSuchMethodException | UnsupportedOperationException e) {
-      // actual cannot be copied or is unmodifiable, falling back to LinkedHashMap
-      Set<K> unexpectedKeys = new LinkedHashMap<>(actual).keySet();
-      expectedKeys.forEach(unexpectedKeys::remove);
-      return unexpectedKeys;
+      // actual cannot be cloned or is unmodifiable, falling back to LinkedHashMap
+      Map<K, ?> copiedMap = new LinkedHashMap<>(actual);
+      expectedKeys.forEach(copiedMap::remove);
+      return copiedMap.keySet();
     }
   }
 
@@ -790,16 +791,37 @@ public class Maps {
    */
   // varargs are not used in order to avoid a "Possible heap pollution" warning.
   // The method cannot be made final and annotated with @SafeVarargs because the class is mocked in tests
-  public <K, V> void assertContainsOnly(AssertionInfo info, Map<K, V> actual, Map.Entry<? extends K, ? extends V>[] entries) {
+  public <K, V> void assertContainsOnly(AssertionInfo info, Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) return;
     failIfEntriesIsEmptyEmptySinceActualIsNotEmpty(info, actual, entries);
 
-    Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    Set<Map.Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
-    compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
+    Set<Entry<? extends K, ? extends V>> notFound = getNotFoundEntries(actual, entries);
+    Set<Entry<K, V>> notExpected = getNotExpectedEntries(actual, entries);
+
     if (!notFound.isEmpty() || !notExpected.isEmpty())
       throw failures.failure(info, shouldContainOnly(actual, entries, notFound, notExpected));
+  }
+
+  private static <K, V> Set<Entry<? extends K, ? extends V>> getNotFoundEntries(Map<K, V> actual,
+                                                                                Entry<? extends K, ? extends V>[] entries) {
+    return Stream.of(entries)
+                 .filter(entry -> !(actual.containsKey(entry.getKey()) && actual.containsValue(entry.getValue())))
+                 .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+
+  private static <K, V> Set<Entry<K, V>> getNotExpectedEntries(Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
+    List<Entry<? extends K, ? extends V>> expectedEntries = java.util.Arrays.asList(entries);
+    try {
+      Map<K, V> clonedMap = clone(actual);
+      expectedEntries.forEach(entry -> clonedMap.remove(entry.getKey(), entry.getValue()));
+      return clonedMap.entrySet();
+    } catch (NoSuchMethodException | UnsupportedOperationException e) {
+      // actual cannot be cloned or is unmodifiable, falling back to LinkedHashMap
+      Map<K, V> copiedMap = new LinkedHashMap<>(actual);
+      expectedEntries.forEach(entry -> copiedMap.remove(entry.getKey(), entry.getValue()));
+      return copiedMap.entrySet();
+    }
   }
 
   /**
@@ -820,14 +842,14 @@ public class Maps {
    */
   // varargs are not used in order to avoid a "Possible heap pollution" warning.
   // The method cannot be made final and annotated with @SafeVarargs because the class is mocked in tests
-  public <K, V> void assertContainsExactly(AssertionInfo info, Map<K, V> actual, Map.Entry<? extends K, ? extends V>[] entries) {
+  public <K, V> void assertContainsExactly(AssertionInfo info, Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
     doCommonContainsCheck(info, actual, entries);
     if (actual.isEmpty() && entries.length == 0) return;
     failIfEntriesIsEmptyEmptySinceActualIsNotEmpty(info, actual, entries);
     assertHasSameSizeAs(info, actual, entries);
 
-    Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    Set<Map.Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
+    Set<Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
+    Set<Entry<? extends K, ? extends V>> notExpected = new LinkedHashSet<>();
 
     compareActualMapAndExpectedEntries(actual, entries, notExpected, notFound);
 
@@ -836,7 +858,7 @@ public class Maps {
       int index = 0;
       for (K keyFromActual : actual.keySet()) {
         if (!areEqual(keyFromActual, entries[index].getKey())) {
-          Map.Entry<K, V> actualEntry = entry(keyFromActual, actual.get(keyFromActual));
+          Entry<K, V> actualEntry = entry(keyFromActual, actual.get(keyFromActual));
           throw failures.failure(info, elementsDifferAtIndex(actualEntry, entries[index], index));
         }
         index++;
@@ -859,13 +881,13 @@ public class Maps {
   }
 
   private <K, V> void compareActualMapAndExpectedEntries(Map<K, V> actual,
-                                                         Map.Entry<? extends K, ? extends V>[] entries,
-                                                         Set<Map.Entry<? extends K, ? extends V>> notExpected,
-                                                         Set<Map.Entry<? extends K, ? extends V>> notFound) {
+                                                         Entry<? extends K, ? extends V>[] entries,
+                                                         Set<Entry<? extends K, ? extends V>> notExpected,
+                                                         Set<Entry<? extends K, ? extends V>> notFound) {
     Map<K, V> expectedEntries = entriesToMap(entries);
     Map<K, V> actualEntries = instantiate(actual.getClass());
     actualEntries.putAll(actual);
-    for (Map.Entry<K, V> entry : expectedEntries.entrySet()) {
+    for (Entry<K, V> entry : expectedEntries.entrySet()) {
       if (containsEntry(actualEntries, entry(entry.getKey(), entry.getValue()))) {
         // this is an expected entry
         actualEntries.remove(entry.getKey());
@@ -875,29 +897,29 @@ public class Maps {
       }
     }
     // All remaining entries from actual copy are not expected entries.
-    for (Map.Entry<K, V> entry : actualEntries.entrySet()) {
+    for (Entry<K, V> entry : actualEntries.entrySet()) {
       notExpected.add(entry(entry.getKey(), entry.getValue()));
     }
   }
 
   private <K, V> void doCommonContainsCheck(AssertionInfo info, Map<K, V> actual,
-                                            Map.Entry<? extends K, ? extends V>[] entries) {
+                                            Entry<? extends K, ? extends V>[] entries) {
     assertNotNull(info, actual);
     failIfNull(entries);
   }
 
   private <K, V> void failIfAnyEntryNotFoundInActualMap(AssertionInfo info, Map<K, V> actual,
-                                                        Map.Entry<? extends K, ? extends V>[] entries) {
-    Set<Map.Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
-    for (Map.Entry<? extends K, ? extends V> entry : entries) {
+                                                        Entry<? extends K, ? extends V>[] entries) {
+    Set<Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
+    for (Entry<? extends K, ? extends V> entry : entries) {
       if (!containsEntry(actual, entry)) notFound.add(entry);
     }
     if (!notFound.isEmpty()) throw failures.failure(info, shouldContain(actual, entries, notFound));
   }
 
-  private static <K, V> Map<K, V> entriesToMap(Map.Entry<? extends K, ? extends V>[] entries) {
+  private static <K, V> Map<K, V> entriesToMap(Entry<? extends K, ? extends V>[] entries) {
     Map<K, V> expectedEntries = new LinkedHashMap<>();
-    for (Map.Entry<? extends K, ? extends V> entry : entries) {
+    for (Entry<? extends K, ? extends V> entry : entries) {
       expectedEntries.put(entry.getKey(), entry.getValue());
     }
     return expectedEntries;
@@ -907,11 +929,11 @@ public class Maps {
     checkArgument(keys.length > 0, errorMessage);
   }
 
-  private static <K, V> void failIfEmpty(Map.Entry<? extends K, ? extends V>[] entries) {
+  private static <K, V> void failIfEmpty(Entry<? extends K, ? extends V>[] entries) {
     checkArgument(entries.length > 0, "The array of entries to look for should not be empty");
   }
 
-  private static <K, V> void failIfNullOrEmpty(Map.Entry<? extends K, ? extends V>[] entries) {
+  private static <K, V> void failIfNullOrEmpty(Entry<? extends K, ? extends V>[] entries) {
     failIfNull(entries);
     failIfEmpty(entries);
   }
@@ -920,7 +942,7 @@ public class Maps {
     requireNonNull(keys, errorMessage);
   }
 
-  private static <K, V> void failIfNull(Map.Entry<? extends K, ? extends V>[] entries) {
+  private static <K, V> void failIfNull(Entry<? extends K, ? extends V>[] entries) {
     requireNonNull(entries, ErrorMessages.entriesToLookForIsNull());
   }
 
@@ -928,7 +950,7 @@ public class Maps {
     requireNonNull(map, ErrorMessages.mapOfEntriesToLookForIsNull());
   }
 
-  private <K, V> boolean containsEntry(Map<K, V> actual, Map.Entry<? extends K, ? extends V> entry) {
+  private <K, V> boolean containsEntry(Map<K, V> actual, Entry<? extends K, ? extends V> entry) {
     requireNonNull(entry, ErrorMessages.entryToLookForIsNull());
     return actual.containsKey(entry.getKey()) && areEqual(actual.get(entry.getKey()), entry.getValue());
   }
@@ -939,7 +961,7 @@ public class Maps {
 
   // this should be only called when actual is not empty
   private <K, V> void failIfEntriesIsEmptyEmptySinceActualIsNotEmpty(AssertionInfo info, Map<K, V> actual,
-                                                                     Map.Entry<? extends K, ? extends V>[] entries) {
+                                                                     Entry<? extends K, ? extends V>[] entries) {
     if (entries.length == 0) throw failures.failure(info, shouldBeEmpty(actual));
   }
 

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -342,6 +342,7 @@ public class Maps {
 
   public <K, V> void assertDoesNotContainKeys(AssertionInfo info, Map<K, V> actual, K[] keys) {
     assertNotNull(info, actual);
+    requireNonNull(keys, keysToLookForIsNull("array of keys"));
     Set<K> found = getFoundKeys(actual, keys);
     if (!found.isEmpty()) throw failures.failure(info, shouldNotContainKeys(actual, found));
   }
@@ -357,7 +358,7 @@ public class Maps {
 
   private <K, V> void assertContainsOnlyKeys(AssertionInfo info, Map<K, V> actual, String placeholderForErrorMessages, K[] keys) {
     assertNotNull(info, actual);
-    failIfNull(keys, keysToLookForIsNull(placeholderForErrorMessages));
+    requireNonNull(keys, keysToLookForIsNull(placeholderForErrorMessages));
     if (actual.isEmpty() && keys.length == 0) {
       return;
     }
@@ -580,10 +581,6 @@ public class Maps {
   private static <K, V> void failIfNullOrEmpty(Entry<? extends K, ? extends V>[] entries) {
     failIfNull(entries);
     failIfEmpty(entries);
-  }
-
-  private static <K> void failIfNull(K[] keys, String errorMessage) {
-    requireNonNull(keys, errorMessage);
   }
 
   private static <K, V> void failIfNull(Entry<? extends K, ? extends V>[] entries) {

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -720,22 +720,17 @@ public class Maps {
 
   @SuppressWarnings({ "unchecked" })
   private static <K, V> Map<K, V> clone(Map<K, V> map) throws NoSuchMethodException {
-    if (map instanceof Cloneable) {
-      try {
-        return (Map<K, V>) map.getClass().getMethod("clone").invoke(map);
-      } catch (IllegalAccessException | InvocationTargetException e) {
-        throw new IllegalStateException(e);
-      }
-    }
     try {
-      @SuppressWarnings("rawtypes")
-      Class<? extends Map> type = map.getClass();
+      if (map instanceof Cloneable) {
+        return (Map<K, V>) map.getClass().getMethod("clone").invoke(map);
+      }
+
       try {
         // try with copying constructor
-        return type.getConstructor(Map.class).newInstance(map);
+        return map.getClass().getConstructor(Map.class).newInstance(map);
       } catch (NoSuchMethodException e) {
         // try with default constructor
-        Map<K, V> newMap = type.getConstructor().newInstance();
+        Map<K, V> newMap = map.getClass().getConstructor().newInstance();
         newMap.putAll(map);
         return newMap;
       }

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -371,6 +371,7 @@ public class Maps {
   }
 
   private static <K> Set<K> getFoundKeys(Map<K, ?> actual, K[] expectedKeys) {
+    // Stream API avoided for performance reasons
     Set<K> found = new LinkedHashSet<>();
     for (K expectedKey : expectedKeys) {
       if (actual.containsKey(expectedKey)) found.add(expectedKey);
@@ -379,6 +380,7 @@ public class Maps {
   }
 
   private static <K> Set<K> getNotFoundKeys(Map<K, ?> actual, K[] expectedKeys) {
+    // Stream API avoided for performance reasons
     Set<K> notFound = new LinkedHashSet<>();
     for (K expectedKey : expectedKeys) {
       if (!actual.containsKey(expectedKey)) notFound.add(expectedKey);
@@ -387,6 +389,7 @@ public class Maps {
   }
 
   private static <K> Set<K> getNotExpectedKeys(Map<K, ?> actual, K[] expectedKeys) {
+    // Stream API avoided for performance reasons
     try {
       Map<K, ?> clonedMap = clone(actual);
       for (K expectedKey : expectedKeys) {
@@ -460,6 +463,7 @@ public class Maps {
 
   private static <K, V> Set<Entry<? extends K, ? extends V>> getNotFoundEntries(Map<K, V> actual,
                                                                                 Entry<? extends K, ? extends V>[] entries) {
+    // Stream API avoided for performance reasons
     Set<Entry<? extends K, ? extends V>> notFound = new LinkedHashSet<>();
     for (Entry<? extends K, ? extends V> entry : entries) {
       if (!containsEntry(actual, entry)) notFound.add(entry);
@@ -468,6 +472,7 @@ public class Maps {
   }
 
   private static <K, V> Set<Entry<K, V>> getNotExpectedEntries(Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {
+    // Stream API avoided for performance reasons
     Set<Entry<K, V>> notExpected = new LinkedHashSet<>();
     for (Entry<K, V> entry : mapWithoutExpectedEntries(actual, entries).entrySet()) {
       MapEntry<K, V> mapEntry = entry(entry.getKey(), entry.getValue());
@@ -477,6 +482,7 @@ public class Maps {
   }
 
   private static <K, V> Map<K, V> mapWithoutExpectedEntries(Map<K, V> actual, Entry<? extends K, ? extends V>[] expectedEntries) {
+    // Stream API avoided for performance reasons
     try {
       Map<K, V> clonedMap = clone(actual);
       for (Entry<? extends K, ? extends V> expectedEntry : expectedEntries) {

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -660,20 +660,6 @@ public class Maps {
     assertContainsOnlyKeys(info, actual, "array of keys", keys);
   }
 
-  /**
-   * Verifies that the actual map contains only the given keys and nothing else, in any order.
-   *
-   * @param <K> key type
-   * @param <V> value type
-   * @param info contains information about the assertion.
-   * @param actual the given {@code Map}.
-   * @param keys the keys that are expected to be in the given {@code Map}.
-   * @throws NullPointerException if the array of keys is {@code null}.
-   * @throws IllegalArgumentException if the array of keys is empty.
-   * @throws AssertionError if the given {@code Map} is {@code null}.
-   * @throws AssertionError if the given {@code Map} does not contain the given keys or if the given {@code Map}
-   *           contains keys that are not in the given array.
-   */
   public <K, V> void assertContainsOnlyKeys(AssertionInfo info, Map<K, V> actual, Iterable<? extends K> keys) {
     final K[] keysAsArray = toArray(keys);
     assertContainsOnlyKeys(info, actual, "keys iterable", keysAsArray);

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -397,7 +397,7 @@ public class Maps {
     }
   }
 
-  @SuppressWarnings({ "unchecked" })
+  @SuppressWarnings("unchecked")
   private static <K, V> Map<K, V> clone(Map<K, V> map) throws NoSuchMethodException {
     try {
       if (map instanceof Cloneable) {

--- a/src/main/java/org/assertj/core/util/Lists.java
+++ b/src/main/java/org/assertj/core/util/Lists.java
@@ -20,13 +20,19 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * Utility methods related to {@code java.util.List}s.
+ * Utility methods related to {@link List}s.
  *
  * @author Yvonne Wang
  * @author Alex Ruiz
  * @author Joel Costigliola
  */
 public final class Lists {
+
+  @SafeVarargs
+  public static <T> List<T> list(T... elements) {
+    return newArrayList(elements);
+  }
+
   /**
    * Creates a <em>mutable</em> {@link ArrayList} containing the given elements.
    *
@@ -36,16 +42,6 @@ public final class Lists {
    */
   @SafeVarargs
   public static <T> ArrayList<T> newArrayList(T... elements) {
-    if (elements == null) {
-      return null;
-    }
-    ArrayList<T> list = newArrayList();
-    Collections.addAll(list, elements);
-    return list;
-  }
-
-  @SafeVarargs
-  public static <T> List<T> list(T... elements) {
     if (elements == null) {
       return null;
     }
@@ -100,6 +96,5 @@ public final class Lists {
     return Collections.emptyList();
   }
 
-  private Lists() {
-  }
+  private Lists() {}
 }

--- a/src/main/java/org/assertj/core/util/Sets.java
+++ b/src/main/java/org/assertj/core/util/Sets.java
@@ -22,9 +22,22 @@ import java.util.TreeSet;
 /**
  * Utility methods related to {@link Set}s.
  *
- * @author alruiz
+ * @author Alex Ruiz
  */
 public final class Sets {
+
+  /**
+   * Creates a <em>mutable</em> {@link HashSet} containing the given elements.
+   *
+   * @param <T> the generic type of the {@code HashSet} to create.
+   * @param elements the elements to store in the {@code HashSet}.
+   * @return the created {@code HashSet}, or {@code null} if the given array of elements is {@code null}.
+   */
+  @SafeVarargs
+  public static <T> Set<T> set(T... elements) {
+    return newLinkedHashSet(elements);
+  }
+
   /**
    * Creates a <em>mutable</em> {@code HashSet}.
    *

--- a/src/test/java/org/assertj/core/internal/MapsBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/MapsBaseTest.java
@@ -24,7 +24,6 @@ import org.assertj.core.data.MapEntry;
 import org.assertj.core.test.WithPlayerData;
 import org.junit.jupiter.api.BeforeEach;
 
-
 /**
  * Base class for {@link Maps} unit tests
  * <p>
@@ -42,7 +41,7 @@ public class MapsBaseTest extends WithPlayerData {
   protected AssertionInfo info;
 
   @BeforeEach
-  public void setUp() {
+  protected void setUp() {
     actual = mapOf(entry("name", "Yoda"), entry("color", "green"));
     failures = spy(new Failures());
     maps = new Maps();
@@ -54,8 +53,9 @@ public class MapsBaseTest extends WithPlayerData {
   protected static MapEntry[] emptyEntries() {
     return new MapEntry[0];
   }
-  
+
   protected static String[] emptyKeys() {
     return new String[0];
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
@@ -12,12 +12,8 @@
  */
 package org.assertj.core.internal.maps;
 
-import static java.lang.String.CASE_INSENSITIVE_ORDER;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
@@ -25,74 +21,52 @@ import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
-import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.list;
-import static org.assertj.core.util.Sets.set;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.verify;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
-import java.util.TreeMap;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 
-import org.apache.commons.collections4.map.CaseInsensitiveMap;
-import org.apache.commons.collections4.map.SingletonMap;
-import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.MapEntry;
-import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-
-import com.google.common.collect.ImmutableMap;
 
 /**
- * Tests for <code>{@link Maps#assertContainsExactly(AssertionInfo, Map, Entry[])}</code>.
+ * Tests for
+ * <code>{@link org.assertj.core.internal.Maps#assertContainsExactly(org.assertj.core.api.AssertionInfo, java.util.Map, java.util.Map.Entry...)}</code>
+ * .
  *
  * @author Jean-Christophe Gay
  */
 class Maps_assertContainsExactly_Test extends MapsBaseTest {
 
-  private static final Supplier<Map<String, String>> CASE_INSENSITIVE_TREE_MAP = () -> new TreeMap<>(CASE_INSENSITIVE_ORDER);
+  private LinkedHashMap<String, String> linkedActual;
 
-  @SuppressWarnings("unchecked")
-  private static final Supplier<Map<String, String>>[] CASE_INSENSITIVE_MAPS = new Supplier[] {
-      // org.apache.commons.collections4.map.CaseInsensitiveMap not included due to slightly different behavior
-      LinkedCaseInsensitiveMap::new,
-      CASE_INSENSITIVE_TREE_MAP
-  };
-
-  @SuppressWarnings("unchecked")
-  private static final Supplier<Map<String, String>>[] MODIFIABLE_MAPS = ArrayUtils.addAll(CASE_INSENSITIVE_MAPS,
-                                                                                           CaseInsensitiveMap::new,
-                                                                                           HashMap::new,
-                                                                                           IdentityHashMap::new,
-                                                                                           LinkedHashMap::new);
+  @BeforeEach
+  void initLinkedHashMap() {
+    linkedActual = new LinkedHashMap<>(2);
+    linkedActual.put("name", "Yoda");
+    linkedActual.put("color", "green");
+  }
 
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
-    Entry<String, String>[] entries = array(entry("name", "Yoda"));
+    actual = null;
+    MapEntry<String, String>[] expected = array(entry("name", "Yoda"));
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsExactly(someInfo(), null, entries));
+    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsExactly(someInfo(), actual, expected));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -100,151 +74,22 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
   @Test
   void should_fail_if_given_entries_array_is_null() {
     // GIVEN
-    Entry<String, String>[] entries = null;
-    // WHEN
-    Throwable thrown = catchThrowable(() -> maps.assertContainsExactly(someInfo(), actual, entries));
-    // THEN
-    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(entriesToLookForIsNull());
+    MapEntry<String, String>[] entries = null;
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() -> maps.assertContainsExactly(someInfo(), linkedActual, entries))
+                                    .withMessage(entriesToLookForIsNull());
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   void should_fail_if_given_entries_array_is_empty() {
     // GIVEN
-    Entry<String, String>[] entries = emptyEntries();
+    AssertionInfo info = someInfo();
+    MapEntry<String, String>[] expected = emptyEntries();
     // WHEN
-    AssertionError error = expectAssertionError(() -> maps.assertContainsExactly(someInfo(), actual, entries));
+    expectAssertionError(() -> maps.assertContainsExactly(info, actual, expected));
     // THEN
-    then(error).hasMessage(shouldBeEmpty(actual).create());
+    verify(failures).failure(info, shouldBeEmpty(actual));
   }
-
-  @ParameterizedTest
-  @MethodSource({
-      "unmodifiableMapsSuccessfulTestCases",
-      "modifiableMapsSuccessfulTestCases",
-      "caseInsensitiveMapsSuccessfulTestCases",
-  })
-  void should_pass(Map<String, String> actual, Entry<String, String>[] expected) {
-    // WHEN/THEN
-    assertThatNoException().as(actual.getClass().getName())
-                           .isThrownBy(() -> maps.assertContainsExactly(info, actual, expected));
-  }
-
-  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(), emptyEntries()),
-                     arguments(Collections.singletonMap("name", "Yoda"),
-                               array(entry("name", "Yoda"))),
-                     arguments(new SingletonMap<>("name", "Yoda"),
-                               array(entry("name", "Yoda"))),
-                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
-                               array(entry("name", "Yoda"), entry("job", "Jedi"))),
-                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
-                               array(entry("name", "Yoda"), entry("job", "Jedi"))));
-  }
-
-  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
-    return Stream.of(MODIFIABLE_MAPS)
-                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array(entry("name", "Yoda"), entry("job", "Jedi"))),
-                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array(entry("job", "Jedi"), entry("name", "Yoda")))));
-  }
-
-  private static Stream<Arguments> caseInsensitiveMapsSuccessfulTestCases() {
-    return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAPS, CaseInsensitiveMap::new))
-                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array(entry("name", "Yoda"), entry("job", "Jedi"))),
-                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array(entry("Name", "Yoda"), entry("Job", "Jedi")))));
-  }
-
-  @ParameterizedTest
-  @MethodSource({
-      "unmodifiableMapsFailureTestCases",
-      "modifiableMapsFailureTestCases",
-      "caseInsensitiveMapsFailureTestCases",
-      "commonsCollectionsCaseInsensitiveMapFailureTestCases",
-      "orderDependentFailureTestCases",
-  })
-  void should_fail(Map<String, String> actual, Entry<String, String>[] expected,
-                   Set<Entry<String, String>> notFound, Set<Entry<String, String>> notExpected) {
-    // WHEN
-    AssertionError error = expectAssertionError(() -> maps.assertContainsExactly(info, actual, expected));
-    // THEN
-    then(error).as(actual.getClass().getName())
-               .hasMessage(shouldContainExactly(actual, asList(expected), notFound, notExpected).create());
-  }
-
-  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(),
-                               array(entry("name", "Yoda")),
-                               set(entry("name", "Yoda")),
-                               emptySet()),
-                     arguments(Collections.singletonMap("name", "Yoda"),
-                               array(entry("color", "Green")),
-                               set(entry("color", "Green")),
-                               set(entry("name", "Yoda"))),
-                     arguments(new SingletonMap<>("name", "Yoda"),
-                               array(entry("color", "Green")),
-                               set(entry("color", "Green")),
-                               set(entry("name", "Yoda"))),
-                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
-                               array(entry("name", "Yoda"), entry("color", "Green")),
-                               set(entry("color", "Green")),
-                               set(entry("job", "Jedi"))),
-                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
-                               array(entry("name", "Yoda"), entry("color", "Green")),
-                               set(entry("color", "Green")),
-                               set(entry("job", "Jedi"))));
-  }
-
-  private static Stream<Arguments> modifiableMapsFailureTestCases() {
-    return Stream.of(MODIFIABLE_MAPS)
-                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
-                                                          array(entry("name", "Yoda"), entry("color", "Green")),
-                                                          set(entry("color", "Green")),
-                                                          emptySet()),
-                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array(entry("name", "Yoda")),
-                                                          emptySet(),
-                                                          set(entry("job", "Jedi"))),
-                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array(entry("name", "Yoda"), entry("color", "Green")),
-                                                          set(entry("color", "Green")),
-                                                          set(entry("job", "Jedi")))));
-  }
-
-  private static Stream<Arguments> caseInsensitiveMapsFailureTestCases() {
-    return Stream.of(CASE_INSENSITIVE_MAPS)
-                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array(entry("name", "Yoda"), entry("color", "Green")),
-                                                          set(entry("color", "Green")),
-                                                          set(entry("Job", "Jedi"))),
-                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array(entry("Name", "Yoda"), entry("Color", "Green")),
-                                                          set(entry("Color", "Green")),
-                                                          set(entry("Job", "Jedi")))));
-  }
-
-  private static Stream<Arguments> commonsCollectionsCaseInsensitiveMapFailureTestCases() {
-    return Stream.of(arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                               array(entry("name", "Yoda"), entry("color", "Green")),
-                               set(entry("color", "Green")),
-                               set(entry("job", "Jedi"))),  // internal keys are always lowercase
-                     arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                               array(entry("Name", "Yoda"), entry("Color", "Green")),
-                               set(entry("Color", "Green")),
-                               set(entry("job", "Jedi"))));  // internal keys are always lowercase
-  }
-
-  private static Stream<Arguments> orderDependentFailureTestCases() {
-    return Stream.of(arguments(mapOf(LinkedHashMap::new, entry("name", "Yoda"), entry("job", "Jedi")),
-                               array(entry("name", "Jedi"), entry("job", "Yoda")),
-                               set(entry("name", "Jedi"), entry("job", "Yoda")),
-                               set(entry("name", "Yoda"), entry("job", "Jedi"))));
-  }
-
-  // ------------------------------------------------------------------------------------------------------------
 
   @Test
   void should_pass_if_actual_and_entries_are_empty() {
@@ -253,7 +98,7 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
 
   @Test
   void should_pass_if_actual_contains_given_entries_in_order() {
-    maps.assertContainsExactly(someInfo(), actual, array(entry("name", "Yoda"), entry("color", "green")));
+    maps.assertContainsExactly(someInfo(), linkedActual, array(entry("name", "Yoda"), entry("color", "green")));
   }
 
   @Test
@@ -261,7 +106,7 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
     // GIVEN
     AssertionInfo info = someInfo();
     // WHEN
-    expectAssertionError(() -> maps.assertContainsExactly(info, actual,
+    expectAssertionError(() -> maps.assertContainsExactly(info, linkedActual,
                                                           array(entry("color", "green"), entry("name", "Yoda"))));
     // THEN
     verify(failures).failure(info, elementsDifferAtIndex(entry("name", "Yoda"), entry("color", "green"), 0));
@@ -273,9 +118,9 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
     AssertionInfo info = someInfo();
     MapEntry<String, String>[] expected = array(entry("name", "Yoda"));
     // WHEN
-    ThrowingCallable code = () -> maps.assertContainsExactly(info, actual, expected);
+    ThrowingCallable code = () -> maps.assertContainsExactly(info, linkedActual, expected);
     // THEN
-    String error = shouldHaveSameSizeAs(actual, expected, actual.size(), expected.length).create();
+    String error = shouldHaveSameSizeAs(linkedActual, expected, linkedActual.size(), expected.length).create();
     assertThatAssertionErrorIsThrownBy(code).withMessage(error);
   }
 
@@ -301,7 +146,7 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
     // WHEN
     expectAssertionError(() -> maps.assertContainsExactly(info, actual, expectedEntries));
     // THEN
-    verify(failures).failure(info, shouldContainExactly(actual, org.assertj.core.util.Arrays.asList(expectedEntries),
+    verify(failures).failure(info, shouldContainExactly(actual, asList(expectedEntries),
                                                         newHashSet(entry("color", "yellow")),
                                                         newHashSet(entry("color", "green"))));
   }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsExactly_Test.java
@@ -12,8 +12,12 @@
  */
 package org.assertj.core.internal.maps;
 
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldBeEmpty.shouldBeEmpty;
@@ -21,52 +25,74 @@ import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.error.ShouldHaveSameSizeAs.shouldHaveSameSizeAs;
 import static org.assertj.core.internal.ErrorMessages.entriesToLookForIsNull;
+import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
-import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.Sets.set;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.verify;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.commons.collections4.map.SingletonMap;
+import org.apache.commons.lang3.ArrayUtils;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.data.MapEntry;
+import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
- * Tests for
- * <code>{@link org.assertj.core.internal.Maps#assertContainsExactly(org.assertj.core.api.AssertionInfo, java.util.Map, java.util.Map.Entry...)}</code>
- * .
+ * Tests for <code>{@link Maps#assertContainsExactly(AssertionInfo, Map, Entry[])}</code>.
  *
  * @author Jean-Christophe Gay
  */
 class Maps_assertContainsExactly_Test extends MapsBaseTest {
 
-  private LinkedHashMap<String, String> linkedActual;
+  private static final Supplier<Map<String, String>> CASE_INSENSITIVE_TREE_MAP = () -> new TreeMap<>(CASE_INSENSITIVE_ORDER);
 
-  @BeforeEach
-  void initLinkedHashMap() {
-    linkedActual = new LinkedHashMap<>(2);
-    linkedActual.put("name", "Yoda");
-    linkedActual.put("color", "green");
-  }
+  @SuppressWarnings("unchecked")
+  private static final Supplier<Map<String, String>>[] CASE_INSENSITIVE_MAPS = new Supplier[] {
+      // org.apache.commons.collections4.map.CaseInsensitiveMap not included due to slightly different behavior
+      LinkedCaseInsensitiveMap::new,
+      CASE_INSENSITIVE_TREE_MAP
+  };
+
+  @SuppressWarnings("unchecked")
+  private static final Supplier<Map<String, String>>[] MODIFIABLE_MAPS = ArrayUtils.addAll(CASE_INSENSITIVE_MAPS,
+                                                                                           CaseInsensitiveMap::new,
+                                                                                           HashMap::new,
+                                                                                           IdentityHashMap::new,
+                                                                                           LinkedHashMap::new);
 
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
-    actual = null;
-    MapEntry<String, String>[] expected = array(entry("name", "Yoda"));
+    Entry<String, String>[] entries = array(entry("name", "Yoda"));
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsExactly(someInfo(), actual, expected));
+    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsExactly(someInfo(), null, entries));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -74,22 +100,151 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
   @Test
   void should_fail_if_given_entries_array_is_null() {
     // GIVEN
-    MapEntry<String, String>[] entries = null;
-    // WHEN/THEN
-    assertThatNullPointerException().isThrownBy(() -> maps.assertContainsExactly(someInfo(), linkedActual, entries))
-                                    .withMessage(entriesToLookForIsNull());
+    Entry<String, String>[] entries = null;
+    // WHEN
+    Throwable thrown = catchThrowable(() -> maps.assertContainsExactly(someInfo(), actual, entries));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(entriesToLookForIsNull());
   }
 
+  @SuppressWarnings("unchecked")
   @Test
   void should_fail_if_given_entries_array_is_empty() {
     // GIVEN
-    AssertionInfo info = someInfo();
-    MapEntry<String, String>[] expected = emptyEntries();
+    Entry<String, String>[] entries = emptyEntries();
     // WHEN
-    expectAssertionError(() -> maps.assertContainsExactly(info, actual, expected));
+    AssertionError error = expectAssertionError(() -> maps.assertContainsExactly(someInfo(), actual, entries));
     // THEN
-    verify(failures).failure(info, shouldBeEmpty(actual));
+    then(error).hasMessage(shouldBeEmpty(actual).create());
   }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsSuccessfulTestCases",
+      "modifiableMapsSuccessfulTestCases",
+      "caseInsensitiveMapsSuccessfulTestCases",
+  })
+  void should_pass(Map<String, String> actual, Entry<String, String>[] expected) {
+    // WHEN/THEN
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsExactly(info, actual, expected));
+  }
+
+  private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
+    return Stream.of(arguments(Collections.emptyMap(), emptyEntries()),
+                     arguments(Collections.singletonMap("name", "Yoda"),
+                               array(entry("name", "Yoda"))),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               array(entry("name", "Yoda"))),
+                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               array(entry("name", "Yoda"), entry("job", "Jedi"))),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array(entry("name", "Yoda"), entry("job", "Jedi"))));
+  }
+
+  private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array(entry("name", "Yoda"), entry("job", "Jedi"))),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array(entry("job", "Jedi"), entry("name", "Yoda")))));
+  }
+
+  private static Stream<Arguments> caseInsensitiveMapsSuccessfulTestCases() {
+    return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAPS, CaseInsensitiveMap::new))
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array(entry("name", "Yoda"), entry("job", "Jedi"))),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array(entry("Name", "Yoda"), entry("Job", "Jedi")))));
+  }
+
+  @ParameterizedTest
+  @MethodSource({
+      "unmodifiableMapsFailureTestCases",
+      "modifiableMapsFailureTestCases",
+      "caseInsensitiveMapsFailureTestCases",
+      "commonsCollectionsCaseInsensitiveMapFailureTestCases",
+      "orderDependentFailureTestCases",
+  })
+  void should_fail(Map<String, String> actual, Entry<String, String>[] expected,
+                   Set<Entry<String, String>> notFound, Set<Entry<String, String>> notExpected) {
+    // WHEN
+    AssertionError error = expectAssertionError(() -> maps.assertContainsExactly(info, actual, expected));
+    // THEN
+    then(error).as(actual.getClass().getName())
+               .hasMessage(shouldContainExactly(actual, asList(expected), notFound, notExpected).create());
+  }
+
+  private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
+    return Stream.of(arguments(Collections.emptyMap(),
+                               array(entry("name", "Yoda")),
+                               set(entry("name", "Yoda")),
+                               emptySet()),
+                     arguments(Collections.singletonMap("name", "Yoda"),
+                               array(entry("color", "Green")),
+                               set(entry("color", "Green")),
+                               set(entry("name", "Yoda"))),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               array(entry("color", "Green")),
+                               set(entry("color", "Green")),
+                               set(entry("name", "Yoda"))),
+                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               array(entry("name", "Yoda"), entry("color", "Green")),
+                               set(entry("color", "Green")),
+                               set(entry("job", "Jedi"))),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array(entry("name", "Yoda"), entry("color", "Green")),
+                               set(entry("color", "Green")),
+                               set(entry("job", "Jedi"))));
+  }
+
+  private static Stream<Arguments> modifiableMapsFailureTestCases() {
+    return Stream.of(MODIFIABLE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
+                                                          array(entry("name", "Yoda"), entry("color", "Green")),
+                                                          set(entry("color", "Green")),
+                                                          emptySet()),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array(entry("name", "Yoda")),
+                                                          emptySet(),
+                                                          set(entry("job", "Jedi"))),
+                                                arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
+                                                          array(entry("name", "Yoda"), entry("color", "Green")),
+                                                          set(entry("color", "Green")),
+                                                          set(entry("job", "Jedi")))));
+  }
+
+  private static Stream<Arguments> caseInsensitiveMapsFailureTestCases() {
+    return Stream.of(CASE_INSENSITIVE_MAPS)
+                 .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array(entry("name", "Yoda"), entry("color", "Green")),
+                                                          set(entry("color", "Green")),
+                                                          set(entry("Job", "Jedi"))),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array(entry("Name", "Yoda"), entry("Color", "Green")),
+                                                          set(entry("Color", "Green")),
+                                                          set(entry("Job", "Jedi")))));
+  }
+
+  private static Stream<Arguments> commonsCollectionsCaseInsensitiveMapFailureTestCases() {
+    return Stream.of(arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                               array(entry("name", "Yoda"), entry("color", "Green")),
+                               set(entry("color", "Green")),
+                               set(entry("job", "Jedi"))),  // internal keys are always lowercase
+                     arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                               array(entry("Name", "Yoda"), entry("Color", "Green")),
+                               set(entry("Color", "Green")),
+                               set(entry("job", "Jedi"))));  // internal keys are always lowercase
+  }
+
+  private static Stream<Arguments> orderDependentFailureTestCases() {
+    return Stream.of(arguments(mapOf(LinkedHashMap::new, entry("name", "Yoda"), entry("job", "Jedi")),
+                               array(entry("name", "Jedi"), entry("job", "Yoda")),
+                               set(entry("name", "Jedi"), entry("job", "Yoda")),
+                               set(entry("name", "Yoda"), entry("job", "Jedi"))));
+  }
+
+  // ------------------------------------------------------------------------------------------------------------
 
   @Test
   void should_pass_if_actual_and_entries_are_empty() {
@@ -98,7 +253,7 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
 
   @Test
   void should_pass_if_actual_contains_given_entries_in_order() {
-    maps.assertContainsExactly(someInfo(), linkedActual, array(entry("name", "Yoda"), entry("color", "green")));
+    maps.assertContainsExactly(someInfo(), actual, array(entry("name", "Yoda"), entry("color", "green")));
   }
 
   @Test
@@ -106,7 +261,7 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
     // GIVEN
     AssertionInfo info = someInfo();
     // WHEN
-    expectAssertionError(() -> maps.assertContainsExactly(info, linkedActual,
+    expectAssertionError(() -> maps.assertContainsExactly(info, actual,
                                                           array(entry("color", "green"), entry("name", "Yoda"))));
     // THEN
     verify(failures).failure(info, elementsDifferAtIndex(entry("name", "Yoda"), entry("color", "green"), 0));
@@ -118,9 +273,9 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
     AssertionInfo info = someInfo();
     MapEntry<String, String>[] expected = array(entry("name", "Yoda"));
     // WHEN
-    ThrowingCallable code = () -> maps.assertContainsExactly(info, linkedActual, expected);
+    ThrowingCallable code = () -> maps.assertContainsExactly(info, actual, expected);
     // THEN
-    String error = shouldHaveSameSizeAs(linkedActual, expected, linkedActual.size(), expected.length).create();
+    String error = shouldHaveSameSizeAs(actual, expected, actual.size(), expected.length).create();
     assertThatAssertionErrorIsThrownBy(code).withMessage(error);
   }
 
@@ -146,7 +301,7 @@ class Maps_assertContainsExactly_Test extends MapsBaseTest {
     // WHEN
     expectAssertionError(() -> maps.assertContainsExactly(info, actual, expectedEntries));
     // THEN
-    verify(failures).failure(info, shouldContainExactly(actual, asList(expectedEntries),
+    verify(failures).failure(info, shouldContainExactly(actual, org.assertj.core.util.Arrays.asList(expectedEntries),
                                                         newHashSet(entry("color", "yellow")),
                                                         newHashSet(entry("color", "green"))));
   }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
@@ -19,14 +19,12 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
-import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 
-import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
@@ -54,28 +52,6 @@ class Maps_assertContainsKey_Test extends MapsBaseTest {
   }
 
   @Test
-  void should_pass_if_case_insensitive_actual_contains_given_key() {
-    // GIVEN
-    actual = new CaseInsensitiveMap<>();
-    actual.put("NAME", "Yoda");
-    actual.put("Color", "green");
-    // THEN
-    maps.assertContainsKeys(someInfo(), actual, "Name");
-  }
-
-  @Test
-  void should_fail_if_actual_contains_different_keys_according_to_custom_key_comparison() {
-    // GIVEN
-    actual = new CaseInsensitiveMap<>();
-    actual.put("NAME", "green");
-    actual.put("cool", "green");
-    // THEN
-    expectAssertionError(() -> maps.assertContainsKeys(someInfo(), actual, "Name", "Color"));
-    // THEN
-    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet("Color")));
-  }
-
-  @Test
   void should_fail_if_actual_is_null() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> maps.assertContainsKey(someInfo(), null, "name"))
                                                    .withMessage(actualIsNull());
@@ -96,4 +72,5 @@ class Maps_assertContainsKey_Test extends MapsBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet(key)));
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsKey_Test.java
@@ -19,12 +19,14 @@ import static org.assertj.core.data.MapEntry.entry;
 import static org.assertj.core.error.ShouldContainKeys.shouldContainKeys;
 import static org.assertj.core.test.Maps.mapOf;
 import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
@@ -33,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for <code>{@link Maps#assertContainsKey(AssertionInfo, Map, Object)}</code>.
- * 
+ *
  * @author Nicolas François
  * @author Joel Costigliola
  */
@@ -49,6 +51,28 @@ class Maps_assertContainsKey_Test extends MapsBaseTest {
   @Test
   void should_pass_if_actual_contains_given_key() {
     maps.assertContainsKey(someInfo(), actual, "name");
+  }
+
+  @Test
+  void should_pass_if_case_insensitive_actual_contains_given_key() {
+    // GIVEN
+    actual = new CaseInsensitiveMap<>();
+    actual.put("NAME", "Yoda");
+    actual.put("Color", "green");
+    // THEN
+    maps.assertContainsKeys(someInfo(), actual, "Name");
+  }
+
+  @Test
+  void should_fail_if_actual_contains_different_keys_according_to_custom_key_comparison() {
+    // GIVEN
+    actual = new CaseInsensitiveMap<>();
+    actual.put("NAME", "green");
+    actual.put("cool", "green");
+    // THEN
+    expectAssertionError(() -> maps.assertContainsKeys(someInfo(), actual, "Name", "Color"));
+    // THEN
+    verify(failures).failure(info, shouldContainKeys(actual, newLinkedHashSet("Color")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -33,6 +33,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -55,7 +56,9 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   @SuppressWarnings("unchecked")
   private static final Supplier<Map<String, String>>[] CASE_INSENSITIVE_MAP_SUPPLIERS = new Supplier[] {
       CaseInsensitiveMap::new,
-      LinkedCaseInsensitiveMap::new };
+      LinkedCaseInsensitiveMap::new,
+      () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)
+  };
 
   @SuppressWarnings("unchecked")
   private static final Supplier<Map<String, String>>[] MODIFIABLE_MAP_SUPPLIERS = ArrayUtils.addAll(CASE_INSENSITIVE_MAP_SUPPLIERS,

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.maps;
 
 import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.data.MapEntry.entry;
@@ -100,7 +101,8 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   })
   void should_succeed(Map<String, String> actual, String[] keys) {
     // WHEN/THEN
-    maps.assertContainsOnlyKeys(info, actual, keys);
+    assertThatNoException().as(actual.getClass().getName())
+                           .isThrownBy(() -> maps.assertContainsOnlyKeys(info, actual, keys));
   }
 
   private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
@@ -138,7 +140,8 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
     // WHEN
     AssertionError error = expectAssertionError(() -> maps.assertContainsOnlyKeys(info, actual, expectedKeys));
     // THEN
-    then(error).hasMessage(shouldContainOnlyKeys(actual, expectedKeys, notFound, notExpected).create());
+    then(error).as(actual.getClass().getName())
+               .hasMessage(shouldContainOnlyKeys(actual, expectedKeys, notFound, notExpected).create());
   }
 
   private static Stream<Arguments> unmodifiableMapsFailureTestCases() {

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -112,10 +112,10 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
       "modifiableMapsSuccessfulTestCases",
       "caseInsensitiveMapsSuccessfulTestCases",
   })
-  void should_pass(Map<String, String> actual, String[] keys) {
+  void should_pass(Map<String, String> actual, String[] expectedKeys) {
     // WHEN/THEN
     assertThatNoException().as(actual.getClass().getName())
-                           .isThrownBy(() -> maps.assertContainsOnlyKeys(info, actual, keys));
+                           .isThrownBy(() -> maps.assertContainsOnlyKeys(info, actual, expectedKeys));
   }
 
   private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
@@ -158,35 +158,54 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   }
 
   private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(), array("name"),
-                               set("name"), emptySet()),
-                     arguments(Collections.singletonMap("name", "Yoda"), array("color"),
-                               set("color"), set("name")),
-                     arguments(new SingletonMap<>("name", "Yoda"), array("color"),
-                               set("color"), set("name")),
+    return Stream.of(arguments(Collections.emptyMap(),
+                               array("name"),
+                               set("name"),
+                               emptySet()),
+                     arguments(Collections.singletonMap("name", "Yoda"),
+                               array("color"),
+                               set("color"),
+                               set("name")),
+                     arguments(new SingletonMap<>("name", "Yoda"),
+                               array("color"),
+                               set("color"),
+                               set("name")),
                      arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
                                array("name", "color"),
-                               set("color"), set("job")),
-                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("name", "color"),
-                               set("color"), set("job")));
+                               set("color"),
+                               set("job")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array("name", "color"),
+                               set("color"),
+                               set("job")));
   }
 
   private static Stream<Arguments> modifiableMapsFailureTestCases() {
     return Stream.of(MODIFIABLE_MAP_SUPPLIERS)
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("name", "Yoda")),
-                                                          array("name", "color"), set("color"), emptySet()),
+                                                          array("name", "color"),
+                                                          set("color"),
+                                                          emptySet()),
                                                 arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array("name"), emptySet(), set("job")),
+                                                          array("name"),
+                                                          emptySet(),
+                                                          set("job")),
                                                 arguments(mapOf(supplier, entry("name", "Yoda"), entry("job", "Jedi")),
-                                                          array("name", "color"), set("color"), set("job"))));
+                                                          array("name", "color"),
+                                                          set("color"),
+                                                          set("job"))));
   }
 
   private static Stream<Arguments> caseInsensitiveMapsFailureTestCases() {
     return Stream.of(CASE_INSENSITIVE_MAP_SUPPLIERS)
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("name", "color"), set("color"), set("Job")),
+                                                          array("name", "color"),
+                                                          set("color"),
+                                                          set("Job")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("Name", "Color"), set("Color"), set("Job"))));
+                                                          array("Name", "Color"),
+                                                          set("Color"),
+                                                          set("Job"))));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -78,8 +78,10 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
 
   @Test
   void should_fail_if_actual_is_null() {
+    // GIVEN
+    String[] keys = { "name" };
     // WHEN
-    AssertionError error = expectAssertionError(() -> maps.assertContainsOnlyKeys(someInfo(), null, "name"));
+    AssertionError error = expectAssertionError(() -> maps.assertContainsOnlyKeys(someInfo(), null, keys));
     // THEN
     then(error).hasMessage(actualIsNull());
   }
@@ -96,8 +98,10 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
 
   @Test
   void should_fail_if_given_keys_array_is_empty() {
+    // GIVEN
+    String[] keys = emptyKeys();
     // WHEN
-    Throwable thrown = catchThrowable(() -> maps.assertContainsOnlyKeys(someInfo(), actual, emptyKeys()));
+    Throwable thrown = catchThrowable(() -> maps.assertContainsOnlyKeys(someInfo(), actual, keys));
     // THEN
     then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(keysToLookForIsEmpty(ARRAY_OF_KEYS));
   }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.verify;
 import java.util.HashSet;
 import java.util.Map;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.internal.MapsBaseTest;
@@ -78,6 +79,29 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   void should_pass_if_actual_contains_only_expected_keys() {
     maps.assertContainsOnlyKeys(someInfo(), actual, array("color", "name"));
     maps.assertContainsOnlyKeys(someInfo(), actual, array("name", "color"));
+  }
+
+  @Test
+  void should_pass_if_case_insensitive_actual_contains_only_expected_keys() {
+    // GIVEN
+    actual = new CaseInsensitiveMap<>();
+    actual.put("NAME", "Yoda");
+    actual.put("Color", "green");
+    // THEN
+    maps.assertContainsOnlyKeys(someInfo(), actual, "Name", "Color");
+  }
+
+  @Test
+  void should_fail_if_actual_contains_different_keys_according_to_custom_key_comparison() {
+    // GIVEN
+    actual = new CaseInsensitiveMap<>();
+    actual.put("NAME", "green");
+    actual.put("cool", "green");
+    String[] expectedKeys = { "Name", "Color" };
+    // THEN
+    expectAssertionError(() -> maps.assertContainsOnlyKeys(someInfo(), actual, "Name", "Color"));
+    // THEN
+    verify(failures).failure(info, shouldContainOnlyKeys(actual, expectedKeys, set("Color"), set("cool")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -63,13 +63,14 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
 
   @SuppressWarnings("unchecked")
   private static final Supplier<Map<String, String>>[] CASE_INSENSITIVE_MAP_SUPPLIERS = new Supplier[] {
-      CaseInsensitiveMap::new,
+      // org.apache.commons.collections4.map.CaseInsensitiveMap not included due to different behavior in some cases
       LinkedCaseInsensitiveMap::new,
       () -> new TreeMap<>(String.CASE_INSENSITIVE_ORDER)
   };
 
   @SuppressWarnings("unchecked")
   private static final Supplier<Map<String, String>>[] MODIFIABLE_MAP_SUPPLIERS = ArrayUtils.addAll(CASE_INSENSITIVE_MAP_SUPPLIERS,
+                                                                                                    CaseInsensitiveMap::new,
                                                                                                     HashMap::new,
                                                                                                     IdentityHashMap::new,
                                                                                                     LinkedHashMap::new);
@@ -136,7 +137,7 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   }
 
   private static Stream<Arguments> caseInsensitiveMapsSuccessfulTestCases() {
-    return Stream.of(CASE_INSENSITIVE_MAP_SUPPLIERS)
+    return Stream.of(ArrayUtils.add(CASE_INSENSITIVE_MAP_SUPPLIERS, CaseInsensitiveMap::new))
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
                                                           array("name", "job")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
@@ -148,6 +149,7 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
       "unmodifiableMapsFailureTestCases",
       "modifiableMapsFailureTestCases",
       "caseInsensitiveMapsFailureTestCases",
+      "commonsCollectionsCaseInsensitiveMapFailureTestCases",
   })
   void should_fail(Map<String, String> actual, String[] expectedKeys, Set<String> notFound, Set<String> notExpected) {
     // WHEN
@@ -206,6 +208,17 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
                                                           array("Name", "Color"),
                                                           set("Color"),
                                                           set("Job"))));
+  }
+
+  private static Stream<Arguments> commonsCollectionsCaseInsensitiveMapFailureTestCases() {
+    return Stream.of(arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                               array("name", "color"),
+                               set("color"),
+                               set("job")), // keys are always lowercase internally
+                     arguments(mapOf(CaseInsensitiveMap::new, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                               array("Name", "Color"),
+                               set("Color"),
+                               set("job"))); // keys are always lowercase internally
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -41,6 +41,8 @@ import java.util.stream.Stream;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.collections4.map.SingletonMap;
 import org.apache.commons.lang3.ArrayUtils;
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,6 +53,11 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
 
 import com.google.common.collect.ImmutableMap;
 
+/**
+ * Tests for <code>{@link Maps#assertContainsOnlyKeys(AssertionInfo, Map, Object[])}</code>.
+ *
+ * @author Christopher Arnott
+ */
 @DisplayName("Maps assertContainsOnlyKeys(Object[])")
 class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
 

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -129,7 +129,9 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
                      arguments(singletonMap("name", "Yoda"), array("name")),
                      arguments(new SingletonMap<>("name", "Yoda"), array("name")),
                      arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("name", "job")),
-                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("name", "job")));
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("job", "name")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("name", "job")),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("job", "name")));
   }
 
   private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
@@ -145,7 +147,11 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
                                                           array("name", "job")),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array("Name", "Job"))));
+                                                          array("job", "name")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("Name", "Job")),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array("Job", "Name"))));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -13,7 +13,10 @@
 package org.assertj.core.internal.maps;
 
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -29,7 +32,6 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.set;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -123,11 +125,10 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   }
 
   private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(), emptyKeys()),
-                     arguments(Collections.singletonMap("name", "Yoda"), array("name")),
+    return Stream.of(arguments(emptyMap(), emptyKeys()),
+                     arguments(singletonMap("name", "Yoda"), array("name")),
                      arguments(new SingletonMap<>("name", "Yoda"), array("name")),
-                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
-                               array("name", "job")),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))), array("name", "job")),
                      arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"), array("name", "job")));
   }
 
@@ -163,11 +164,11 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
   }
 
   private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(),
+    return Stream.of(arguments(emptyMap(),
                                array("name"),
                                set("name"),
                                emptySet()),
-                     arguments(Collections.singletonMap("name", "Yoda"),
+                     arguments(singletonMap("name", "Yoda"),
                                array("color"),
                                set("color"),
                                set("name")),
@@ -175,7 +176,7 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
                                array("color"),
                                set("color"),
                                set("name")),
-                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
                                array("name", "color"),
                                set("color"),
                                set("job")),

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnlyKeys_Test.java
@@ -86,8 +86,10 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
 
   @Test
   void should_fail_if_given_keys_array_is_null() {
+    // GIVEN
+    String[] keys = null;
     // WHEN
-    Throwable thrown = catchThrowable(() -> maps.assertContainsOnlyKeys(someInfo(), actual, (String[]) null));
+    Throwable thrown = catchThrowable(() -> maps.assertContainsOnlyKeys(someInfo(), actual, keys));
     // THEN
     then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull(ARRAY_OF_KEYS));
   }
@@ -106,7 +108,7 @@ class Maps_assertContainsOnlyKeys_Test extends MapsBaseTest {
       "modifiableMapsSuccessfulTestCases",
       "caseInsensitiveMapsSuccessfulTestCases",
   })
-  void should_succeed(Map<String, String> actual, String[] keys) {
+  void should_pass(Map<String, String> actual, String[] keys) {
     // WHEN/THEN
     assertThatNoException().as(actual.getClass().getName())
                            .isThrownBy(() -> maps.assertContainsOnlyKeys(info, actual, keys));

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -129,8 +129,12 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
                                array(entry("name", "Yoda"))),
                      arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
                                array(entry("name", "Yoda"), entry("job", "Jedi"))),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                               array(entry("job", "Jedi"), entry("name", "Yoda"))),
                      arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
-                               array(entry("name", "Yoda"), entry("job", "Jedi"))));
+                               array(entry("name", "Yoda"), entry("job", "Jedi"))),
+                     arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
+                               array(entry("job", "Jedi"), entry("name", "Yoda"))));
   }
 
   private static Stream<Arguments> modifiableMapsSuccessfulTestCases() {
@@ -146,7 +150,11 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
                  .flatMap(supplier -> Stream.of(arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
                                                           array(entry("name", "Yoda"), entry("job", "Jedi"))),
                                                 arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
-                                                          array(entry("Name", "Yoda"), entry("Job", "Jedi")))));
+                                                          array(entry("job", "Jedi"), entry("name", "Yoda"))),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array(entry("Name", "Yoda"), entry("Job", "Jedi"))),
+                                                arguments(mapOf(supplier, entry("NAME", "Yoda"), entry("Job", "Jedi")),
+                                                          array(entry("Job", "Jedi"), entry("Name", "Yoda")))));
   }
 
   @ParameterizedTest

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -13,7 +13,10 @@
 package org.assertj.core.internal.maps;
 
 import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonMap;
+import static java.util.Collections.unmodifiableMap;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
@@ -29,7 +32,6 @@ import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.set;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -120,12 +122,12 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
   }
 
   private static Stream<Arguments> unmodifiableMapsSuccessfulTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(), emptyEntries()),
-                     arguments(Collections.singletonMap("name", "Yoda"),
+    return Stream.of(arguments(emptyMap(), emptyEntries()),
+                     arguments(singletonMap("name", "Yoda"),
                                array(entry("name", "Yoda"))),
                      arguments(new SingletonMap<>("name", "Yoda"),
                                array(entry("name", "Yoda"))),
-                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
                                array(entry("name", "Yoda"), entry("job", "Jedi"))),
                      arguments(ImmutableMap.of("name", "Yoda", "job", "Jedi"),
                                array(entry("name", "Yoda"), entry("job", "Jedi"))));
@@ -165,11 +167,11 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
   }
 
   private static Stream<Arguments> unmodifiableMapsFailureTestCases() {
-    return Stream.of(arguments(Collections.emptyMap(),
+    return Stream.of(arguments(emptyMap(),
                                array(entry("name", "Yoda")),
                                set(entry("name", "Yoda")),
                                emptySet()),
-                     arguments(Collections.singletonMap("name", "Yoda"),
+                     arguments(singletonMap("name", "Yoda"),
                                array(entry("color", "Green")),
                                set(entry("color", "Green")),
                                set(entry("name", "Yoda"))),
@@ -177,7 +179,7 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
                                array(entry("color", "Green")),
                                set(entry("color", "Green")),
                                set(entry("name", "Yoda"))),
-                     arguments(Collections.unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
+                     arguments(unmodifiableMap(mapOf(entry("name", "Yoda"), entry("job", "Jedi"))),
                                array(entry("name", "Yoda"), entry("color", "Green")),
                                set(entry("color", "Green")),
                                set(entry("job", "Jedi"))),

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -75,11 +75,12 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
                                                                                                     IdentityHashMap::new,
                                                                                                     LinkedHashMap::new);
 
-  @SuppressWarnings("unchecked")
   @Test
   void should_fail_if_actual_is_null() {
+    // GIVEN
+    Entry<String, String>[] entries = array(entry("name", "Yoda"));
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsOnly(someInfo(), null, entry("name", "Yoda")));
+    AssertionError assertionError = expectAssertionError(() -> maps.assertContainsOnly(someInfo(), null, entries));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -97,8 +98,10 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
   @SuppressWarnings("unchecked")
   @Test
   void should_fail_if_given_entries_array_is_empty() {
+    // GIVEN
+    Entry<String, String>[] entries = emptyEntries();
     // WHEN
-    Throwable thrown = catchThrowable(() -> maps.assertContainsOnly(someInfo(), actual, emptyEntries()));
+    Throwable thrown = catchThrowable(() -> maps.assertContainsOnly(someInfo(), actual, entries));
     // THEN
     then(thrown).isInstanceOf(IllegalArgumentException.class).hasMessage(entriesToLookForIsEmpty());
   }
@@ -106,8 +109,8 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
   @ParameterizedTest
   @MethodSource({
       "unmodifiableMapsSuccessfulTestCases",
-//      "modifiableMapsSuccessfulTestCases",
-//      "caseInsensitiveMapsSuccessfulTestCases",
+      // "modifiableMapsSuccessfulTestCases",
+      // "caseInsensitiveMapsSuccessfulTestCases",
   })
   void should_pass(Map<String, String> actual, Entry<String, String>[] entries) {
     // WHEN/THEN
@@ -125,13 +128,6 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
                                array(entry("name", "Yoda"), entry("job", "Jedi"))));
   }
 
-  @SuppressWarnings("unchecked")
-  @Test
-  void should_pass_if_actual_contains_only_expected_entries() {
-    maps.assertContainsOnly(someInfo(), actual, entry("name", "Yoda"), entry("color", "green"));
-  }
-
-  @SuppressWarnings("unchecked")
   @Test
   void should_pass_if_case_insensitive_actual_contains_only_expected_entries() {
     // GIVEN
@@ -139,7 +135,7 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
     actual.put("NAME", "Yoda");
     actual.put("Color", "green");
     // THEN
-    maps.assertContainsOnly(someInfo(), actual, entry("Name", "Yoda"), entry("COLOR", "green"));
+    maps.assertContainsOnly(someInfo(), actual, array(entry("Name", "Yoda"), entry("COLOR", "green")));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -28,7 +28,9 @@ import static org.mockito.Mockito.verify;
 
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.data.MapEntry;
 import org.assertj.core.internal.MapsBaseTest;
@@ -83,6 +85,34 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
   @Test
   void should_pass_if_actual_contains_only_expected_entries() {
     maps.assertContainsOnly(someInfo(), actual, array(entry("name", "Yoda"), entry("color", "green")));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void should_pass_if_case_insensitive_actual_contains_only_expected_entries() {
+    // GIVEN
+    actual = new CaseInsensitiveMap<>();
+    actual.put("NAME", "Yoda");
+    actual.put("Color", "green");
+    // THEN
+    maps.assertContainsOnly(someInfo(), actual, entry("Name", "Yoda"), entry("COLOR", "green"));
+  }
+
+  @Test
+  void should_fail_if_actual_contains_unexpected_entry_according_to_case_insensitive_key_comparison() {
+    // GIVEN
+    AssertionInfo info = someInfo();
+    actual = new CaseInsensitiveMap<>();
+    actual.put("NAME", "green");
+    actual.put("Color", "green");
+    MapEntry<String, String>[] expected = array(entry("name", "green"), entry("cool", "green"));
+    // WHEN
+    expectAssertionError(() -> maps.assertContainsOnly(info, actual, expected));
+    // THEN
+    // should logically be: entry("Color", "green") but CaseInsensitiveMap lowecase all keys
+    Set<MapEntry<String, String>> notExpected = set(entry("color", "green"));
+    Set<MapEntry<String, String>> notFound = set(entry("cool", "green"));
+    verify(failures).failure(info, shouldContainOnly(actual, expected, notFound, notExpected));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_Test.java
@@ -20,16 +20,19 @@ import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Sets.set;
 import static org.mockito.Mockito.verify;
 
+import java.util.Map;
+
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link org.assertj.core.internal.Maps#assertDoesNotContainKeys(AssertionInfo, java.util.Map, Object[])}</code>.
+ * Tests for <code>{@link Maps#assertDoesNotContainKeys(AssertionInfo, Map, Object[])}</code>.
  *
  * @author dorzey
  */
@@ -37,7 +40,7 @@ class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
 
   @Override
   @BeforeEach
-  public void setUp() {
+  protected void setUp() {
     super.setUp();
     actual.put(null, null);
   }
@@ -59,8 +62,12 @@ class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
   }
 
   @Test
-  void should_pass_if_key_is_null() {
-    maps.assertDoesNotContainKeys(someInfo(), actual, new String[] { null });
+  void should_fail_if_key_is_null() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), actual,
+                                                                                             new String[] { null }));
+    // THEN
+    then(assertionError).hasMessage(shouldNotContainKeys(actual, set((String) null)).create());
   }
 
   @Test
@@ -71,7 +78,7 @@ class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
     Throwable error = catchThrowable(() -> maps.assertDoesNotContainKeys(info, actual, new String[] { key }));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldNotContainKeys(actual, newLinkedHashSet(key)));
+    verify(failures).failure(info, shouldNotContainKeys(actual, set(key)));
   }
 
   @Test
@@ -83,6 +90,6 @@ class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
     Throwable error = catchThrowable(() -> maps.assertDoesNotContainKeys(info, actual, new String[] { key1, key2 }));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldNotContainKeys(actual, newLinkedHashSet(key1, key2)));
+    verify(failures).failure(info, shouldNotContainKeys(actual, set(key1, key2)));
   }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertDoesNotContainKeys_Test.java
@@ -12,16 +12,15 @@
  */
 package org.assertj.core.internal.maps;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldNotContainKeys.shouldNotContainKeys;
+import static org.assertj.core.internal.ErrorMessages.keysToLookForIsNull;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Sets.set;
-import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 
@@ -29,14 +28,21 @@ import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.Maps;
 import org.assertj.core.internal.MapsBaseTest;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for <code>{@link Maps#assertDoesNotContainKeys(AssertionInfo, Map, Object[])}</code>.
  *
  * @author dorzey
  */
+@DisplayName("Maps assertDoesNotContainKeys")
 class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
+
+  private static final String ARRAY_OF_KEYS = "array of keys";
 
   @Override
   @BeforeEach
@@ -53,43 +59,43 @@ class Maps_assertDoesNotContainKeys_Test extends MapsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
-    actual = null;
+    String[] keys = { "name" };
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), null,
-                                                                                             array("name", "color")));
+    AssertionError error = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), null, keys));
     // THEN
-    then(assertionError).hasMessage(actualIsNull());
+    then(error).hasMessage(actualIsNull());
   }
 
   @Test
-  void should_fail_if_key_is_null() {
+  void should_fail_if_given_keys_array_is_null() {
+    // GIVEN
+    String[] keys = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), actual,
-                                                                                             new String[] { null }));
+    Throwable thrown = catchThrowable(() -> maps.assertDoesNotContainKeys(someInfo(), actual, keys));
     // THEN
-    then(assertionError).hasMessage(shouldNotContainKeys(actual, set((String) null)).create());
+    then(thrown).isInstanceOf(NullPointerException.class).hasMessage(keysToLookForIsNull(ARRAY_OF_KEYS));
   }
 
-  @Test
-  void should_fail_if_actual_contains_key() {
-    AssertionInfo info = someInfo();
-    String key = "name";
-
-    Throwable error = catchThrowable(() -> maps.assertDoesNotContainKeys(info, actual, new String[] { key }));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldNotContainKeys(actual, set(key)));
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = { "name", "color" })
+  void should_fail_if_actual_contains_key(String key) {
+    // GIVEN
+    String[] keys = { key };
+    // WHEN
+    AssertionError error = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), actual, keys));
+    // THEN
+    then(error).hasMessage(shouldNotContainKeys(actual, set(key)).create());
   }
 
   @Test
   void should_fail_if_actual_contains_keys() {
-    AssertionInfo info = someInfo();
-    String key1 = "name";
-    String key2 = "color";
-
-    Throwable error = catchThrowable(() -> maps.assertDoesNotContainKeys(info, actual, new String[] { key1, key2 }));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldNotContainKeys(actual, set(key1, key2)));
+    // GIVEN
+    String[] keys = { "name", "color" };
+    // WHEN
+    AssertionError error = expectAssertionError(() -> maps.assertDoesNotContainKeys(someInfo(), actual, keys));
+    // THEN
+    then(error).hasMessage(shouldNotContainKeys(actual, set("name", "color")).create());
   }
+
 }

--- a/src/test/java/org/assertj/core/test/Maps.java
+++ b/src/test/java/org/assertj/core/test/Maps.java
@@ -13,7 +13,9 @@
 package org.assertj.core.test;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Supplier;
 
 import org.assertj.core.data.MapEntry;
 
@@ -24,18 +26,19 @@ public final class Maps {
 
   @SafeVarargs
   public static <K, V> LinkedHashMap<K, V> mapOf(MapEntry<K, V>... entries) {
-    LinkedHashMap<K, V> map = new LinkedHashMap<>();
-    for (MapEntry<K, V> entry : entries) {
-      map.put(entry.key, entry.value);
-    }
-    return map;
+    return mapOf(LinkedHashMap::new, entries);
   }
 
   @SafeVarargs
   public static <K extends Comparable<? super K>, V> TreeMap<K, V> treeMapOf(MapEntry<K, V>... entries) {
-    TreeMap<K, V> map = new TreeMap<>();
-    for (MapEntry<K, V> entry : entries) {
-      map.put(entry.key, entry.value);
+    return mapOf(TreeMap::new, entries);
+  }
+
+  @SafeVarargs
+  public static <K, V, M extends Map<K, V>> M mapOf(Supplier<M> supplier, Map.Entry<K, V>... entries) {
+    M map = supplier.get();
+    for (Map.Entry<K, V> entry : entries) {
+      map.put(entry.getKey(), entry.getValue());
     }
     return map;
   }


### PR DESCRIPTION
This affects:
- `assertContainsOnly`
- `assertContainsOnlyKeys`

#### Open points:
- [x] Complete `Maps_assertContainsOnlyKeys_Test`
- [x] Complete `Maps_assertContainsOnly_Test`
- [x] Evaluate refactoring of `assertDoesNotContainKeys(AssertionInfo, Map, Object[])`
- [x] Mention in the javadoc that in some cases the key comparison semantics won't be honored

#### Check List:
* Fixes #2159
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)