### PR TITLE
Fix containsSubsequence failing when multiple empty subsequence.

### DIFF
--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -1050,6 +1050,8 @@ public class Strings {
   }
 
   private int indexOf(String string, CharSequence toFind) {
+    if (string.equals("") && toFind.toString().equals(""))
+      return 0;
     for (int i = 0; i < string.length(); i++) {
       if (comparisonStrategy.stringStartsWith(string.substring(i), toFind.toString())) return i;
     }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsSubsequence_Test.java
@@ -117,4 +117,12 @@ class Strings_assertContainsSubsequence_Test extends StringsBaseTest {
                                                    .withMessage(shouldContainSubsequence(actual, sequenceValues, 1, comparisonStrategy).create());
   }
 
+  @Test
+  void should_pass_if_empty_string_contains_multiple_empty_subsequence_bug_2158() {
+    strings.assertContainsSubsequence(someInfo(), "", array(""));
+    strings.assertContainsSubsequence(someInfo(), "", array("", ""));
+    strings.assertContainsSubsequence(someInfo(), "", array("", "", ""));
+    strings.assertContainsSubsequence(someInfo(), "", array("", "", "", ""));
+  }
+
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2158 
* Unit tests : YES
* Javadoc with a code example (on API only) : NA


