### PR TITLE
MatcherAssert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out
 /clover.license
 /actual.txt
 /expected.txt
+**/.DS_Store
 #jEnv configuration
 .java-version
 /bin/

--- a/src/main/java/org/assertj/core/api/AbstractMatcherAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMatcherAssert.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.error.MatcherShouldMatch.shouldMatch;
+
+import java.util.regex.Matcher;
+import org.assertj.core.internal.Failures;
+
+
+/**
+ * Assertions for {@link java.util.regex.Matcher}
+ *
+ * @author Jiashu Zhang
+ */
+public abstract class AbstractMatcherAssert<SELF extends AbstractMatcherAssert<SELF>> extends
+  AbstractAssert<SELF, Matcher> {
+
+  protected AbstractMatcherAssert(Matcher actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  /**
+   * Verifies that the Matcher matches.
+   * <p>
+   * Assertion will pass :
+   * <pre>
+   * <code class='java'>Pattern p = Pattern.compile("a*");
+   * String str = "aaa";
+   * Matcher matcher = p.matcher(str);
+   * assertThat(matcher).matches();</code></pre>
+   * <p>
+   * Assertion will fail :
+   * <pre>
+   * <code class='java'>Pattern p = Pattern.compile("a*");
+   * String str = "abc";
+   * Matcher matcher = p.matcher(str);
+   * assertThat(matcher).matches();</code></pre>
+   *
+   * @return this assertion object.
+   * @throws AssertionError if actual does not match.
+   * @throws AssertionError if actual is null.
+   */
+  public SELF matches() {
+    isNotNull();
+    if (!actual.matches()) {
+      throw Failures.instance().failure(info, shouldMatch(actual));
+    }
+    return myself;
+  }
+}

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -69,6 +69,7 @@ import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -273,6 +274,17 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    */
   public static OptionalLongAssert assertThat(OptionalLong actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+
+  /**
+   * Create assertion for {@link java.util.regex.Matcher}.
+   *
+   * @param actual the actual value.
+   *
+   * @return the created assertion object.
+   */
+  public static MatcherAssert assertThat(Matcher actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -39,6 +39,7 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 
+import java.util.regex.Matcher;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.Filters;
@@ -118,6 +119,17 @@ public class AssertionsForClassTypes {
    */
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return new OptionalIntAssert(actual);
+  }
+
+  /**
+   * Create assertion for {@link java.util.regex.Matcher}
+   *
+   * @param actual the actual value
+   *
+   * @return the created assertion object
+   */
+  public static MatcherAssert assertThat(Matcher actual) {
+    return new MatcherAssert(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -65,6 +65,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -1091,6 +1092,16 @@ public class Assumptions {
    */
   public static OptionalLongAssert assumeThat(OptionalLong actual) {
     return asAssumption(OptionalLongAssert.class, OptionalLong.class, actual);
+  }
+
+  /**
+   * Creates a new instance of {@link MatcherAssert} assumption.
+   *
+   * @param actual the Matcher to test
+   * @return the created assumption for assertion object.
+   */
+  public static MatcherAssert assumeThat(Matcher actual) {
+    return asAssumption(MatcherAssert.class, Matcher.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -64,6 +64,7 @@ import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -262,6 +263,17 @@ public class BDDAssertions extends Assertions {
    */
   public static OptionalLongAssert then(OptionalLong optional) {
     return assertThat(optional);
+  }
+
+  /**
+   * Create assertion for {@link java.util.regex.Matcher}
+   *
+   * @param actual the actual matcher
+   *
+   * @return the created assertion object.
+   */
+  public static MatcherAssert then(Matcher actual) {
+    return assertThat(actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/BDDAssumptions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssumptions.java
@@ -60,6 +60,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -1790,6 +1791,17 @@ public final class BDDAssumptions {
    * @since 3.14.0
    */
   public static OptionalLongAssert given(OptionalLong actual) {
+    return assumeThat(actual);
+  }
+
+  /**
+   * Creates a new assumption's instance for an {@link Matcher}.
+   * <p>
+   *
+   * @param actual the actual {@link Matcher} value to be validated.
+   * @return the {@link Matcher} assertion object to be used for validation.
+   */
+  public static MatcherAssert given(Matcher actual) {
     return assumeThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
@@ -35,6 +35,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -103,6 +104,18 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
   @CheckReturnValue
   default OptionalLongAssert then(OptionalLong actual) {
     return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
+  }
+
+  /**
+   * Create assertion for {@link java.util.regex.Matcher}.
+   *
+   * @param actual the actual matcher
+   *
+   * @return the created assertion object.
+   */
+  @CheckReturnValue
+  default MatcherAssert then(Matcher actual) {
+    return proxy(MatcherAssert.class, Matcher.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -57,6 +57,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -193,6 +194,11 @@ public interface InstanceOfAssertFactories {
    */
   InstanceOfAssertFactory<OptionalLong, OptionalLongAssert> OPTIONAL_LONG = new InstanceOfAssertFactory<>(OptionalLong.class,
                                                                                                           Assertions::assertThat);
+  /**
+   * {@link InstanceOfAssertFactory} for an {@link Matcher}.
+   */
+  InstanceOfAssertFactory<Matcher, MatcherAssert> MATCHER = new InstanceOfAssertFactory<>(Matcher.class,
+                                                                                          Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link BigDecimal}.

--- a/src/main/java/org/assertj/core/api/MatcherAssert.java
+++ b/src/main/java/org/assertj/core/api/MatcherAssert.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import java.util.regex.Matcher;
+
+/**
+ * Assertions for {@link java.util.regex.Matcher}.
+ *
+ * @author Jiashu Zhang
+ */
+public class MatcherAssert extends AbstractMatcherAssert<MatcherAssert>{
+
+  protected MatcherAssert(Matcher actual) {
+    super(actual, MatcherAssert.class);
+  }
+}

--- a/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
@@ -35,6 +35,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -88,6 +89,17 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    */
   default OptionalLongAssert assertThat(OptionalLong actual) {
     return proxy(OptionalLongAssert.class, OptionalLong.class, actual);
+  }
+
+  /**
+   * Create assertion for {@link java.util.regex.Matcher}
+   *
+   * @param actual the actual matcher
+   *
+   * @return the created assertion object.
+   */
+  default MatcherAssert assertThat(Matcher actual) {
+    return proxy(MatcherAssert.class, Matcher.class, actual);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -64,6 +64,7 @@ import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -2343,6 +2344,17 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    */
   default OptionalLongAssert assertThat(final OptionalLong optional) {
     return Assertions.assertThat(optional);
+  }
+
+  /**
+   * Create assertion for {@link java.util.regex.Matcher}
+   *
+   *
+   * @param matcher the actual matcher.
+   * @return the created assertion object.
+   */
+  default MatcherAssert assertThat(final Matcher matcher) {
+    return Assertions.assertThat(matcher);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -59,6 +59,7 @@ import java.util.function.DoublePredicate;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -949,6 +950,16 @@ public interface WithAssumptions {
    */
   default OptionalLongAssert assumeThat(final OptionalLong optionalLong) {
     return Assumptions.assumeThat(optionalLong);
+  }
+
+  /**
+   * Creates a new instance of <code>{@link MatcherAssert}</code> assumption.
+   *
+   * @param matcher the actual Matcher.
+   * @return the created assumption for assertion object.
+   */
+  default MatcherAssert assumeThat(final Matcher matcher) {
+    return Assumptions.assumeThat(matcher);
   }
 
   /**

--- a/src/main/java/org/assertj/core/error/MatcherShouldMatch.java
+++ b/src/main/java/org/assertj/core/error/MatcherShouldMatch.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import java.util.regex.Matcher;
+
+/**
+ * Build error message when an {@link java.util.regex.Matcher} should match.
+ *
+ * @author Jiashu Zhang
+ */
+public class MatcherShouldMatch extends BasicErrorMessageFactory {
+  private MatcherShouldMatch(Matcher matcher) {
+    super("%nExpecting %s to match.", matcher.getClass().getSimpleName());
+  }
+
+  /**
+   * Indicates that the provided {@link java.util.regex.Matcher} should match.
+   *
+   * @param matcher the actual {@link Matcher} to test.
+   * @return an error message factory.
+   */
+  public static MatcherShouldMatch shouldMatch(Matcher matcher) {
+    return new MatcherShouldMatch(matcher);
+  }
+}

--- a/src/test/java/org/assertj/core/api/matcher/MatcherAssert_matches_Test.java
+++ b/src/test/java/org/assertj/core/api/matcher/MatcherAssert_matches_Test.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.matcher;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.error.MatcherShouldMatch.shouldMatch;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class MatcherAssert_matches_Test {
+
+  @Test
+  void should_fail_when_Matcher_is_null() {
+    // GIVEN
+    Matcher nullActual = null;
+    // THEN
+    assertThatAssertionErrorIsThrownBy(() -> assertThat(nullActual).matches()).withMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_Matcher_does_not_match() {
+    // GIVEN
+    Pattern pattern = Pattern.compile("a*");
+    String expectedValue = "abc";
+    Matcher actual = pattern.matcher(expectedValue);
+    // WHEN
+    AssertionError error = catchThrowableOfType(() -> assertThat(actual).matches(), AssertionError.class);
+    // THEN
+    assertThat(error).hasMessage(shouldMatch(actual).create());
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #2081 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES

```matches()``` for ```AbstractMatcherAssert```
