### PR TITLE
Align return types across assertions / assumptions / soft assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -282,7 +282,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
+  public static BigDecimalAssert assertThat(BigDecimal actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -293,7 +293,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public static AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
+  public static BigIntegerAssert assertThat(BigInteger actual) {
     return new BigIntegerAssert(actual);
   }
 
@@ -303,7 +303,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUriAssert<?> assertThat(URI actual) {
+  public static UriAssert assertThat(URI actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -313,7 +313,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUrlAssert<?> assertThat(URL actual) {
+  public static UrlAssert assertThat(URL actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -323,7 +323,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> assertThat(boolean actual) {
+  public static BooleanAssert assertThat(boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -333,7 +333,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
+  public static BooleanAssert assertThat(Boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -343,7 +343,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
+  public static BooleanArrayAssert assertThat(boolean[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -364,7 +364,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> assertThat(byte actual) {
+  public static ByteAssert assertThat(byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -374,7 +374,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> assertThat(Byte actual) {
+  public static ByteAssert assertThat(Byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -384,7 +384,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
+  public static ByteArrayAssert assertThat(byte[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -405,7 +405,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> assertThat(char actual) {
+  public static CharacterAssert assertThat(char actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -415,7 +415,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
+  public static CharArrayAssert assertThat(char[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -436,7 +436,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> assertThat(Character actual) {
+  public static CharacterAssert assertThat(Character actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -456,7 +456,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> assertThat(double actual) {
+  public static DoubleAssert assertThat(double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -466,7 +466,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> assertThat(Double actual) {
+  public static DoubleAssert assertThat(Double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -476,7 +476,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
+  public static DoubleArrayAssert assertThat(double[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -497,7 +497,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFileAssert<?> assertThat(File actual) {
+  public static FileAssert assertThat(File actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -520,7 +520,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
+  public static InputStreamAssert assertThat(InputStream actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -530,7 +530,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> assertThat(float actual) {
+  public static FloatAssert assertThat(float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -540,7 +540,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> assertThat(Float actual) {
+  public static FloatAssert assertThat(Float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -550,7 +550,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
+  public static FloatArrayAssert assertThat(float[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -560,7 +560,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> assertThat(int actual) {
+  public static IntegerAssert assertThat(int actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -570,7 +570,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
+  public static IntArrayAssert assertThat(int[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -602,7 +602,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> assertThat(Integer actual) {
+  public static IntegerAssert assertThat(Integer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -611,9 +611,9 @@ public class Assertions implements InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -655,9 +655,9 @@ public class Assertions implements InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -690,9 +690,9 @@ public class Assertions implements InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -733,9 +733,9 @@ public class Assertions implements InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -771,7 +771,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> assertThat(long actual) {
+  public static LongAssert assertThat(long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -781,7 +781,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> assertThat(Long actual) {
+  public static LongAssert assertThat(Long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -791,7 +791,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
+  public static LongArrayAssert assertThat(long[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -846,7 +846,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> assertThat(short actual) {
+  public static ShortAssert assertThat(short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -856,7 +856,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> assertThat(Short actual) {
+  public static ShortAssert assertThat(Short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -866,7 +866,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
+  public static ShortArrayAssert assertThat(short[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -887,7 +887,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDateAssert<?> assertThat(Date actual) {
+  public static DateAssert assertThat(Date actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -897,7 +897,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
+  public static ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -907,7 +907,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
+  public static LocalDateTimeAssert assertThat(LocalDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -917,7 +917,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
+  public static OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -927,7 +927,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
+  public static OffsetTimeAssert assertThat(OffsetTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -937,7 +937,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
+  public static LocalTimeAssert assertThat(LocalTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -947,7 +947,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalDateAssert<?> assertThat(LocalDate actual) {
+  public static LocalDateAssert assertThat(LocalDate actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -958,7 +958,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  public static AbstractInstantAssert<?> assertThat(Instant actual) {
+  public static InstantAssert assertThat(Instant actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -969,7 +969,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.15.0
    */
-  public static AbstractDurationAssert<?> assertThat(Duration actual) {
+  public static DurationAssert assertThat(Duration actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -980,7 +980,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.17.0
    */
-  public static AbstractPeriodAssert<?> assertThat(Period actual) {
+  public static PeriodAssert assertThat(Period actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -1141,7 +1141,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
+  public static ThrowableAssert assertThat(Throwable actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -1174,7 +1174,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -1211,7 +1211,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -1251,7 +1251,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    * @since 3.7.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public static ThrowableAssert assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return AssertionsForClassTypes.assertThatCode(shouldRaiseOrNotThrowable);
   }
 
@@ -2822,7 +2822,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
+  public static CharSequenceAssert assertThat(CharSequence actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
@@ -2833,7 +2833,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
+  public static CharSequenceAssert assertThat(StringBuilder actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -2844,7 +2844,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
+  public static CharSequenceAssert assertThat(StringBuffer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -2854,7 +2854,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractStringAssert<?> assertThat(String actual) {
+  public static StringAssert assertThat(String actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -3054,7 +3054,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the path to test
    * @return the created assertion object
    */
-  public static AbstractPathAssert<?> assertThat(Path actual) {
+  public static PathAssert assertThat(Path actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
@@ -3081,7 +3081,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> assertThat(T actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -137,7 +137,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
+  public static BigDecimalAssert assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
 
@@ -147,7 +147,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUriAssert<?> assertThat(URI actual) {
+  public static UriAssert assertThat(URI actual) {
     return new UriAssert(actual);
   }
 
@@ -157,7 +157,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUrlAssert<?> assertThat(URL actual) {
+  public static UrlAssert assertThat(URL actual) {
     return new UrlAssert(actual);
   }
 
@@ -167,7 +167,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> assertThat(boolean actual) {
+  public static BooleanAssert assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
 
@@ -177,7 +177,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
+  public static BooleanAssert assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
 
@@ -187,7 +187,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
+  public static BooleanArrayAssert assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
 
@@ -208,7 +208,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> assertThat(byte actual) {
+  public static ByteAssert assertThat(byte actual) {
     return new ByteAssert(actual);
   }
 
@@ -218,7 +218,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> assertThat(Byte actual) {
+  public static ByteAssert assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
 
@@ -228,7 +228,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
+  public static ByteArrayAssert assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
 
@@ -249,7 +249,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> assertThat(char actual) {
+  public static CharacterAssert assertThat(char actual) {
     return new CharacterAssert(actual);
   }
 
@@ -259,7 +259,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
+  public static CharArrayAssert assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
 
@@ -280,7 +280,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> assertThat(Character actual) {
+  public static CharacterAssert assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
 
@@ -300,7 +300,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> assertThat(double actual) {
+  public static DoubleAssert assertThat(double actual) {
     return new DoubleAssert(actual);
   }
 
@@ -310,7 +310,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> assertThat(Double actual) {
+  public static DoubleAssert assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
 
@@ -320,7 +320,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
+  public static DoubleArrayAssert assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
 
@@ -341,7 +341,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFileAssert<?> assertThat(File actual) {
+  public static FileAssert assertThat(File actual) {
     return new FileAssert(actual);
   }
 
@@ -351,7 +351,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
+  public static InputStreamAssert assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
 
@@ -361,7 +361,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> assertThat(float actual) {
+  public static FloatAssert assertThat(float actual) {
     return new FloatAssert(actual);
   }
 
@@ -371,7 +371,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> assertThat(Float actual) {
+  public static FloatAssert assertThat(Float actual) {
     return new FloatAssert(actual);
   }
 
@@ -381,7 +381,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
+  public static FloatArrayAssert assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
 
@@ -402,7 +402,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> assertThat(int actual) {
+  public static IntegerAssert assertThat(int actual) {
     return new IntegerAssert(actual);
   }
 
@@ -412,7 +412,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
+  public static IntArrayAssert assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
 
@@ -433,7 +433,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> assertThat(Integer actual) {
+  public static IntegerAssert assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
 
@@ -443,7 +443,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> assertThat(long actual) {
+  public static LongAssert assertThat(long actual) {
     return new LongAssert(actual);
   }
 
@@ -453,7 +453,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> assertThat(Long actual) {
+  public static LongAssert assertThat(Long actual) {
     return new LongAssert(actual);
   }
 
@@ -463,7 +463,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
+  public static LongArrayAssert assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
 
@@ -518,7 +518,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> assertThat(short actual) {
+  public static ShortAssert assertThat(short actual) {
     return new ShortAssert(actual);
   }
 
@@ -528,7 +528,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> assertThat(Short actual) {
+  public static ShortAssert assertThat(Short actual) {
     return new ShortAssert(actual);
   }
 
@@ -538,7 +538,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
+  public static ShortArrayAssert assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
 
@@ -560,7 +560,7 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
+  public static CharSequenceAssert assertThat(StringBuilder actual) {
     return new CharSequenceAssert(actual);
   }
 
@@ -571,7 +571,7 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
+  public static CharSequenceAssert assertThat(StringBuffer actual) {
     return new CharSequenceAssert(actual);
   }
 
@@ -581,7 +581,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractStringAssert<?> assertThat(String actual) {
+  public static StringAssert assertThat(String actual) {
     return new StringAssert(actual);
   }
 
@@ -591,7 +591,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDateAssert<?> assertThat(Date actual) {
+  public static DateAssert assertThat(Date actual) {
     return new DateAssert(actual);
   }
 
@@ -601,7 +601,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
+  public static ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
     return new ZonedDateTimeAssert(actual);
   }
 
@@ -611,7 +611,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
+  public static LocalDateTimeAssert assertThat(LocalDateTime actual) {
     return new LocalDateTimeAssert(actual);
   }
 
@@ -621,7 +621,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
+  public static OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
     return new OffsetDateTimeAssert(actual);
   }
 
@@ -631,7 +631,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
+  public static OffsetTimeAssert assertThat(OffsetTime actual) {
     return new OffsetTimeAssert(actual);
   }
 
@@ -641,7 +641,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
+  public static LocalTimeAssert assertThat(LocalTime actual) {
     return new LocalTimeAssert(actual);
   }
 
@@ -651,7 +651,7 @@ public class AssertionsForClassTypes {
    * @param localDate the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalDateAssert<?> assertThat(LocalDate localDate) {
+  public static LocalDateAssert assertThat(LocalDate localDate) {
     return new LocalDateAssert(localDate);
   }
 
@@ -662,7 +662,7 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  public static AbstractInstantAssert<?> assertThat(Instant instant) {
+  public static InstantAssert assertThat(Instant instant) {
     return new InstantAssert(instant);
   }
 
@@ -673,7 +673,7 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.15.0
    */
-  public static AbstractDurationAssert<?> assertThat(Duration duration) {
+  public static DurationAssert assertThat(Duration duration) {
     return new DurationAssert(duration);
   }
 
@@ -684,7 +684,7 @@ public class AssertionsForClassTypes {
    * @return the created assertion object.
    * @since 3.17.0
    */
-  public static AbstractPeriodAssert<?> assertThat(Period period) {
+  public static PeriodAssert assertThat(Period period) {
     return new PeriodAssert(period);
   }
 
@@ -694,7 +694,7 @@ public class AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
+  public static ThrowableAssert assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
 
@@ -727,7 +727,7 @@ public class AssertionsForClassTypes {
    * @return the created {@link ThrowableAssert}.
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -764,7 +764,7 @@ public class AssertionsForClassTypes {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -844,7 +844,7 @@ public class AssertionsForClassTypes {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public static ThrowableAssert assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -1088,9 +1088,9 @@ public class AssertionsForClassTypes {
 
   /**
    * Globally sets whether
-   * <code>{@link org.assertj.core.api.AbstractIterableAssert#extracting(String) IterableAssert#extracting(String)}</code>
+   * <code>{@link org.assertj.core.api.IterableAssert#extracting(String) IterableAssert#extracting(String)}</code>
    * and
-   * <code>{@link org.assertj.core.api.AbstractObjectArrayAssert#extracting(String) ObjectArrayAssert#extracting(String)}</code>
+   * <code>{@link org.assertj.core.api.ObjectArrayAssert#extracting(String) ObjectArrayAssert#extracting(String)}</code>
    * should be allowed to extract private fields, if not and they try it fails with exception.
    *
    * @param allowExtractingPrivateFields allow private fields extraction. Default {@code true}.
@@ -1103,8 +1103,8 @@ public class AssertionsForClassTypes {
    * Globally sets whether the use of private fields is allowed for comparison.
    * The following (incomplete) list of methods will be impacted by this change :
    * <ul>
-   * <li><code>{@link org.assertj.core.api.AbstractIterableAssert#usingElementComparatorOnFields(java.lang.String...)}</code></li>
-   * <li><code>{@link org.assertj.core.api.AbstractObjectAssert#isEqualToComparingFieldByField(Object)}</code></li>
+   * <li><code>{@link org.assertj.core.api.IterableAssert#usingElementComparatorOnFields(java.lang.String...)}</code></li>
+   * <li><code>{@link org.assertj.core.api.ObjectAssert#isEqualToComparingFieldByField(Object)}</code></li>
    * </ul>
    *
    * If the value is <code>false</code> and these methods try to compare private fields, it will fail with an exception.
@@ -1472,7 +1472,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Create a {@link FilterOperator} to use in {@link AbstractIterableAssert#filteredOn(String, FilterOperator)
+   * Create a {@link FilterOperator} to use in {@link IterableAssert#filteredOn(String, FilterOperator)
    * filteredOn(String, FilterOperation)} to express a filter keeping all Iterable elements whose property/field
    * value matches one of the given values.
    * <p>
@@ -1496,7 +1496,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Create a {@link FilterOperator} to use in {@link AbstractIterableAssert#filteredOn(String, FilterOperator)
+   * Create a {@link FilterOperator} to use in {@link IterableAssert#filteredOn(String, FilterOperator)
    * filteredOn(String, FilterOperation)} to express a filter keeping all Iterable elements whose property/field
    * value matches does not match any of the given values.
    * <p>
@@ -1520,7 +1520,7 @@ public class AssertionsForClassTypes {
   }
 
   /**
-   * Create a {@link FilterOperator} to use in {@link AbstractIterableAssert#filteredOn(String, FilterOperator)
+   * Create a {@link FilterOperator} to use in {@link IterableAssert#filteredOn(String, FilterOperator)
    * filteredOn(String, FilterOperation)} to express a filter keeping all Iterable elements whose property/field
    * value matches does not match the given value.
    * <p>
@@ -1774,7 +1774,7 @@ public class AssertionsForClassTypes {
 
   /**
    * Add the given date format to the ones used to parse date String in String based Date assertions like
-   * {@link org.assertj.core.api.AbstractDateAssert#isEqualTo(String)}.
+   * {@link org.assertj.core.api.DateAssert#isEqualTo(String)}.
    * <p>
    * User date formats are used before default ones in the order they have been registered (first registered, first
    * used).
@@ -1790,7 +1790,7 @@ public class AssertionsForClassTypes {
    * Beware that AssertJ will use the newly registered format for <b>all remaining Date assertions in the test suite</b>
    * <p>
    * To revert to default formats only, call {@link #useDefaultDateFormatsOnly()} or
-   * {@link org.assertj.core.api.AbstractDateAssert#withDefaultDateFormatsOnly()}.
+   * {@link org.assertj.core.api.DateAssert#withDefaultDateFormatsOnly()}.
    * <p>
    * Code examples:
    *
@@ -1820,7 +1820,7 @@ public class AssertionsForClassTypes {
 
   /**
    * Add the given date format to the ones used to parse date String in String based Date assertions like
-   * {@link org.assertj.core.api.AbstractDateAssert#isEqualTo(String)}.
+   * {@link org.assertj.core.api.DateAssert#isEqualTo(String)}.
    * <p>
    * User date formats are used before default ones in the order they have been registered (first registered, first
    * used).

--- a/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForInterfaceTypes.java
@@ -92,7 +92,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
+  public static CharSequenceAssert assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
 
@@ -296,7 +296,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the path to test
    * @return the created assertion object
    */
-  public static AbstractPathAssert<?> assertThat(Path actual) {
+  public static PathAssert assertThat(Path actual) {
     return new PathAssert(actual);
   }
 
@@ -323,7 +323,7 @@ public class AssertionsForInterfaceTypes extends AssertionsForClassTypes {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -141,7 +141,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractStringAssert<?> assumeThat(String actual) {
+  public static StringAssert assumeThat(String actual) {
     return asAssumption(StringAssert.class, String.class, actual);
   }
 
@@ -152,7 +152,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractBigDecimalAssert<?> assumeThat(BigDecimal actual) {
+  public static BigDecimalAssert assumeThat(BigDecimal actual) {
     return asAssumption(BigDecimalAssert.class, BigDecimal.class, actual);
   }
 
@@ -163,7 +163,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractBigIntegerAssert<?> assumeThat(BigInteger actual) {
+  public static BigIntegerAssert assumeThat(BigInteger actual) {
     return asAssumption(BigIntegerAssert.class, BigInteger.class, actual);
   }
 
@@ -174,7 +174,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractUriAssert<?> assumeThat(URI actual) {
+  public static UriAssert assumeThat(URI actual) {
     return asAssumption(UriAssert.class, URI.class, actual);
   }
 
@@ -185,7 +185,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractUrlAssert<?> assumeThat(URL actual) {
+  public static UrlAssert assumeThat(URL actual) {
     return asAssumption(UrlAssert.class, URL.class, actual);
   }
 
@@ -196,7 +196,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractBooleanAssert<?> assumeThat(boolean actual) {
+  public static BooleanAssert assumeThat(boolean actual) {
     return asAssumption(BooleanAssert.class, Boolean.class, actual);
   }
 
@@ -207,7 +207,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractBooleanAssert<?> assumeThat(Boolean actual) {
+  public static BooleanAssert assumeThat(Boolean actual) {
     return asAssumption(BooleanAssert.class, Boolean.class, actual);
   }
 
@@ -218,7 +218,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractBooleanArrayAssert<?> assumeThat(boolean[] actual) {
+  public static BooleanArrayAssert assumeThat(boolean[] actual) {
     return asAssumption(BooleanArrayAssert.class, boolean[].class, actual);
   }
 
@@ -240,7 +240,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractByteAssert<?> assumeThat(byte actual) {
+  public static ByteAssert assumeThat(byte actual) {
     return asAssumption(ByteAssert.class, Byte.class, actual);
   }
 
@@ -251,7 +251,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractByteAssert<?> assumeThat(Byte actual) {
+  public static ByteAssert assumeThat(Byte actual) {
     return asAssumption(ByteAssert.class, Byte.class, actual);
   }
 
@@ -262,7 +262,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractByteArrayAssert<?> assumeThat(byte[] actual) {
+  public static ByteArrayAssert assumeThat(byte[] actual) {
     return asAssumption(ByteArrayAssert.class, byte[].class, actual);
   }
 
@@ -284,7 +284,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractCharacterAssert<?> assumeThat(char actual) {
+  public static CharacterAssert assumeThat(char actual) {
     return asAssumption(CharacterAssert.class, Character.class, actual);
   }
 
@@ -295,7 +295,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractCharacterAssert<?> assumeThat(Character actual) {
+  public static CharacterAssert assumeThat(Character actual) {
     return asAssumption(CharacterAssert.class, Character.class, actual);
   }
 
@@ -306,7 +306,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractCharArrayAssert<?> assumeThat(char[] actual) {
+  public static CharArrayAssert assumeThat(char[] actual) {
     return asAssumption(CharArrayAssert.class, char[].class, actual);
   }
 
@@ -328,7 +328,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(CharSequence actual) {
+  public static CharSequenceAssert assumeThat(CharSequence actual) {
     return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -339,7 +339,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(StringBuilder actual) {
+  public static CharSequenceAssert assumeThat(StringBuilder actual) {
     return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -350,7 +350,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(StringBuffer actual) {
+  public static CharSequenceAssert assumeThat(StringBuffer actual) {
     return asAssumption(CharSequenceAssert.class, CharSequence.class, actual);
   }
 
@@ -361,7 +361,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractShortAssert<?> assumeThat(short actual) {
+  public static ShortAssert assumeThat(short actual) {
     return asAssumption(ShortAssert.class, Short.class, actual);
   }
 
@@ -372,7 +372,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractShortAssert<?> assumeThat(Short actual) {
+  public static ShortAssert assumeThat(Short actual) {
     return asAssumption(ShortAssert.class, Short.class, actual);
   }
 
@@ -383,7 +383,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractShortArrayAssert<?> assumeThat(short[] actual) {
+  public static ShortArrayAssert assumeThat(short[] actual) {
     return asAssumption(ShortArrayAssert.class, short[].class, actual);
   }
 
@@ -405,7 +405,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractIntegerAssert<?> assumeThat(int actual) {
+  public static IntegerAssert assumeThat(int actual) {
     return asAssumption(IntegerAssert.class, Integer.class, actual);
   }
 
@@ -416,7 +416,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractIntegerAssert<?> assumeThat(Integer actual) {
+  public static IntegerAssert assumeThat(Integer actual) {
     return asAssumption(IntegerAssert.class, Integer.class, actual);
   }
 
@@ -427,7 +427,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractIntArrayAssert<?> assumeThat(int[] actual) {
+  public static IntArrayAssert assumeThat(int[] actual) {
     return asAssumption(IntArrayAssert.class, int[].class, actual);
   }
 
@@ -449,7 +449,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractLongAssert<?> assumeThat(long actual) {
+  public static LongAssert assumeThat(long actual) {
     return asAssumption(LongAssert.class, Long.class, actual);
   }
 
@@ -460,7 +460,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractLongAssert<?> assumeThat(Long actual) {
+  public static LongAssert assumeThat(Long actual) {
     return asAssumption(LongAssert.class, Long.class, actual);
   }
 
@@ -471,7 +471,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractLongArrayAssert<?> assumeThat(long[] actual) {
+  public static LongArrayAssert assumeThat(long[] actual) {
     return asAssumption(LongArrayAssert.class, long[].class, actual);
   }
 
@@ -493,7 +493,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractFloatAssert<?> assumeThat(float actual) {
+  public static FloatAssert assumeThat(float actual) {
     return asAssumption(FloatAssert.class, Float.class, actual);
   }
 
@@ -504,7 +504,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractFloatAssert<?> assumeThat(Float actual) {
+  public static FloatAssert assumeThat(Float actual) {
     return asAssumption(FloatAssert.class, Float.class, actual);
   }
 
@@ -515,7 +515,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractFloatArrayAssert<?> assumeThat(float[] actual) {
+  public static FloatArrayAssert assumeThat(float[] actual) {
     return asAssumption(FloatArrayAssert.class, float[].class, actual);
   }
 
@@ -537,7 +537,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractDoubleAssert<?> assumeThat(double actual) {
+  public static DoubleAssert assumeThat(double actual) {
     return asAssumption(DoubleAssert.class, Double.class, actual);
   }
 
@@ -548,7 +548,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractDoubleAssert<?> assumeThat(Double actual) {
+  public static DoubleAssert assumeThat(Double actual) {
     return asAssumption(DoubleAssert.class, Double.class, actual);
   }
 
@@ -559,7 +559,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractDoubleArrayAssert<?> assumeThat(double[] actual) {
+  public static DoubleArrayAssert assumeThat(double[] actual) {
     return asAssumption(DoubleArrayAssert.class, double[].class, actual);
   }
 
@@ -751,7 +751,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractDateAssert<?> assumeThat(Date actual) {
+  public static DateAssert assumeThat(Date actual) {
     return asAssumption(DateAssert.class, Date.class, actual);
   }
 
@@ -762,7 +762,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractFileAssert<?> assumeThat(File actual) {
+  public static FileAssert assumeThat(File actual) {
     return asAssumption(FileAssert.class, File.class, actual);
   }
 
@@ -773,7 +773,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractPathAssert<?> assumeThat(Path actual) {
+  public static PathAssert assumeThat(Path actual) {
     return asAssumption(PathAssert.class, Path.class, actual);
   }
 
@@ -784,7 +784,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> assumeThat(InputStream actual) {
+  public static InputStreamAssert assumeThat(InputStream actual) {
     return asAssumption(InputStreamAssert.class, InputStream.class, actual);
   }
 
@@ -798,7 +798,7 @@ public class Assumptions {
    * @since 2.9.0 / 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> assumeThat(Future<RESULT> future) {
+  public static <RESULT> FutureAssert<RESULT> assumeThat(Future<RESULT> future) {
     return asAssumption(FutureAssert.class, Future.class, future);
   }
 
@@ -837,7 +837,7 @@ public class Assumptions {
    * @since 2.9.0 / 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static <ELEMENT> FactoryBasedNavigableListAssert<ListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(List<? extends ELEMENT> actual) {
+  public static <ELEMENT> ListAssert<ELEMENT> assumeThat(List<? extends ELEMENT> actual) {
     return asAssumption(ListAssert.class, List.class, actual);
   }
 
@@ -890,7 +890,7 @@ public class Assumptions {
    * @since 2.9.0 / 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assumeThat(T actual) {
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> assumeThat(T actual) {
     return asAssumption(GenericComparableAssert.class, Comparable.class, actual);
   }
 
@@ -901,7 +901,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assumeThat(Throwable actual) {
+  public static ThrowableAssert assumeThat(Throwable actual) {
     return asAssumption(ThrowableAssert.class, Throwable.class, actual);
   }
 
@@ -919,7 +919,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assumeThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static ThrowableAssert assumeThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return asAssumption(ThrowableAssert.class, Throwable.class, catchThrowable(shouldRaiseThrowable));
   }
 
@@ -946,7 +946,7 @@ public class Assumptions {
    * @return the created {@link ThrowableAssert}.
    * @since 3.9.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assumeThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public static ThrowableAssert assumeThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assumeThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -1100,7 +1100,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractZonedDateTimeAssert<?> assumeThat(ZonedDateTime actual) {
+  public static ZonedDateTimeAssert assumeThat(ZonedDateTime actual) {
     return asAssumption(ZonedDateTimeAssert.class, ZonedDateTime.class, actual);
   }
 
@@ -1111,7 +1111,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractLocalDateTimeAssert<?> assumeThat(LocalDateTime actual) {
+  public static LocalDateTimeAssert assumeThat(LocalDateTime actual) {
     return asAssumption(LocalDateTimeAssert.class, LocalDateTime.class, actual);
   }
 
@@ -1122,7 +1122,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractOffsetDateTimeAssert<?> assumeThat(OffsetDateTime actual) {
+  public static OffsetDateTimeAssert assumeThat(OffsetDateTime actual) {
     return asAssumption(OffsetDateTimeAssert.class, OffsetDateTime.class, actual);
   }
 
@@ -1133,7 +1133,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractOffsetTimeAssert<?> assumeThat(OffsetTime actual) {
+  public static OffsetTimeAssert assumeThat(OffsetTime actual) {
     return asAssumption(OffsetTimeAssert.class, OffsetTime.class, actual);
   }
 
@@ -1144,7 +1144,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractLocalTimeAssert<?> assumeThat(LocalTime actual) {
+  public static LocalTimeAssert assumeThat(LocalTime actual) {
     return asAssumption(LocalTimeAssert.class, LocalTime.class, actual);
   }
 
@@ -1155,7 +1155,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractLocalDateAssert<?> assumeThat(LocalDate actual) {
+  public static LocalDateAssert assumeThat(LocalDate actual) {
     return asAssumption(LocalDateAssert.class, LocalDate.class, actual);
   }
 
@@ -1166,7 +1166,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  public static AbstractInstantAssert<?> assumeThat(Instant actual) {
+  public static InstantAssert assumeThat(Instant actual) {
     return asAssumption(InstantAssert.class, Instant.class, actual);
   }
 
@@ -1177,7 +1177,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.15.0
    */
-  public static AbstractDurationAssert<?> assumeThat(Duration actual) {
+  public static DurationAssert assumeThat(Duration actual) {
     return asAssumption(DurationAssert.class, Duration.class, actual);
   }
 
@@ -1188,7 +1188,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    * @since 3.17.0
    */
-  public static AbstractPeriodAssert<?> assumeThat(Period actual) {
+  public static PeriodAssert assumeThat(Period actual) {
     return asAssumption(PeriodAssert.class, Period.class, actual);
   }
 
@@ -1201,7 +1201,7 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(Stream<? extends ELEMENT> actual) {
+  public static <ELEMENT> ListAssert<ELEMENT> assumeThat(Stream<? extends ELEMENT> actual) {
     return asAssumption(ListAssert.class, Stream.class, actual);
   }
 
@@ -1213,7 +1213,7 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assumeThat(DoubleStream actual) {
+  public static ListAssert<Double> assumeThat(DoubleStream actual) {
     return asAssumption(ListAssert.class, DoubleStream.class, actual);
   }
 
@@ -1225,7 +1225,7 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assumeThat(LongStream actual) {
+  public static ListAssert<Long> assumeThat(LongStream actual) {
     return asAssumption(ListAssert.class, LongStream.class, actual);
   }
 
@@ -1237,7 +1237,7 @@ public class Assumptions {
    * @since 3.9.0
    */
   @SuppressWarnings("unchecked")
-  public static AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assumeThat(IntStream actual) {
+  public static ListAssert<Integer> assumeThat(IntStream actual) {
     return asAssumption(ListAssert.class, IntStream.class, actual);
   }
 
@@ -1249,7 +1249,7 @@ public class Assumptions {
    * @return the created assumption for assertion object.
    */
   @SuppressWarnings("unchecked")
-  public static <ELEMENT> AbstractSpliteratorAssert<?, ELEMENT> assumeThat(Spliterator<ELEMENT> actual) {
+  public static <ELEMENT> SpliteratorAssert<ELEMENT> assumeThat(Spliterator<ELEMENT> actual) {
     return asAssumption(SpliteratorAssert.class, Spliterator.class, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -281,7 +281,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBigDecimalAssert<?> then(BigDecimal actual) {
+  public static BigDecimalAssert then(BigDecimal actual) {
     return assertThat(actual);
   }
 
@@ -292,7 +292,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public static AbstractBigIntegerAssert<?> then(BigInteger actual) {
+  public static BigIntegerAssert then(BigInteger actual) {
     return assertThat(actual);
   }
 
@@ -302,7 +302,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> then(boolean actual) {
+  public static BooleanAssert then(boolean actual) {
     return assertThat(actual);
   }
 
@@ -312,7 +312,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> then(Boolean actual) {
+  public static BooleanAssert then(Boolean actual) {
     return assertThat(actual);
   }
 
@@ -322,7 +322,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanArrayAssert<?> then(boolean[] actual) {
+  public static BooleanArrayAssert then(boolean[] actual) {
     return assertThat(actual);
   }
 
@@ -343,7 +343,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> then(byte actual) {
+  public static ByteAssert then(byte actual) {
     return assertThat(actual);
   }
 
@@ -353,7 +353,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> then(Byte actual) {
+  public static ByteAssert then(Byte actual) {
     return assertThat(actual);
   }
 
@@ -363,7 +363,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteArrayAssert<?> then(byte[] actual) {
+  public static ByteArrayAssert then(byte[] actual) {
     return assertThat(actual);
   }
 
@@ -384,7 +384,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> then(char actual) {
+  public static CharacterAssert then(char actual) {
     return assertThat(actual);
   }
 
@@ -394,7 +394,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharArrayAssert<?> then(char[] actual) {
+  public static CharArrayAssert then(char[] actual) {
     return assertThat(actual);
   }
 
@@ -415,7 +415,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> then(Character actual) {
+  public static CharacterAssert then(Character actual) {
     return assertThat(actual);
   }
 
@@ -437,7 +437,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> then(T actual) {
     return assertThat(actual);
   }
 
@@ -481,9 +481,9 @@ public class BDDAssertions extends Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -524,9 +524,9 @@ public class BDDAssertions extends Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -558,9 +558,9 @@ public class BDDAssertions extends Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -600,9 +600,9 @@ public class BDDAssertions extends Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -637,7 +637,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> then(double actual) {
+  public static DoubleAssert then(double actual) {
     return assertThat(actual);
   }
 
@@ -647,7 +647,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> then(Double actual) {
+  public static DoubleAssert then(Double actual) {
     return assertThat(actual);
   }
 
@@ -657,7 +657,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleArrayAssert<?> then(double[] actual) {
+  public static DoubleArrayAssert then(double[] actual) {
     return assertThat(actual);
   }
 
@@ -678,7 +678,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFileAssert<?> then(File actual) {
+  public static FileAssert then(File actual) {
     return assertThat(actual);
   }
 
@@ -688,7 +688,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the path to test
    * @return the created assertion object
    */
-  public static AbstractPathAssert<?> then(Path actual) {
+  public static PathAssert then(Path actual) {
     return assertThat(actual);
   }
 
@@ -710,7 +710,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> then(InputStream actual) {
+  public static InputStreamAssert then(InputStream actual) {
     return assertThat(actual);
   }
 
@@ -720,7 +720,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> then(float actual) {
+  public static FloatAssert then(float actual) {
     return assertThat(actual);
   }
 
@@ -730,7 +730,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> then(Float actual) {
+  public static FloatAssert then(Float actual) {
     return assertThat(actual);
   }
 
@@ -740,7 +740,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatArrayAssert<?> then(float[] actual) {
+  public static FloatArrayAssert then(float[] actual) {
     return assertThat(actual);
   }
 
@@ -761,7 +761,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> then(int actual) {
+  public static IntegerAssert then(int actual) {
     return assertThat(actual);
   }
 
@@ -771,7 +771,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntArrayAssert<?> then(int[] actual) {
+  public static IntArrayAssert then(int[] actual) {
     return assertThat(actual);
   }
 
@@ -792,7 +792,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> then(Integer actual) {
+  public static IntegerAssert then(Integer actual) {
     return assertThat(actual);
   }
 
@@ -813,7 +813,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> then(long actual) {
+  public static LongAssert then(long actual) {
     return assertThat(actual);
   }
 
@@ -823,7 +823,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> then(Long actual) {
+  public static LongAssert then(Long actual) {
     return assertThat(actual);
   }
 
@@ -833,7 +833,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongArrayAssert<?> then(long[] actual) {
+  public static LongArrayAssert then(long[] actual) {
     return assertThat(actual);
   }
 
@@ -900,7 +900,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> then(short actual) {
+  public static ShortAssert then(short actual) {
     return assertThat(actual);
   }
 
@@ -910,7 +910,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> then(Short actual) {
+  public static ShortAssert then(Short actual) {
     return assertThat(actual);
   }
 
@@ -920,7 +920,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortArrayAssert<?> then(short[] actual) {
+  public static ShortArrayAssert then(short[] actual) {
     return assertThat(actual);
   }
 
@@ -941,7 +941,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
+  public static CharSequenceAssert then(CharSequence actual) {
     return assertThat(actual);
   }
 
@@ -952,7 +952,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuilder actual) {
+  public static CharSequenceAssert then(StringBuilder actual) {
     return assertThat(actual);
   }
 
@@ -963,7 +963,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuffer actual) {
+  public static CharSequenceAssert then(StringBuffer actual) {
     return assertThat(actual);
   }
 
@@ -973,7 +973,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractStringAssert<?> then(String actual) {
+  public static StringAssert then(String actual) {
     return assertThat(actual);
   }
 
@@ -983,7 +983,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDateAssert<?> then(Date actual) {
+  public static DateAssert then(Date actual) {
     return assertThat(actual);
   }
 
@@ -1144,7 +1144,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actual) {
+  public static ThrowableAssert then(Throwable actual) {
     return assertThat(actual);
   }
 
@@ -1177,7 +1177,7 @@ public class BDDAssertions extends Assertions {
    * @return the created {@link ThrowableAssert}.
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static ThrowableAssert thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -1213,7 +1213,7 @@ public class BDDAssertions extends Assertions {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
+  public static ThrowableAssert thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -1259,7 +1259,7 @@ public class BDDAssertions extends Assertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public static ThrowableAssert thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -1316,7 +1316,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalDateAssert<?> then(LocalDate actual) {
+  public static LocalDateAssert then(LocalDate actual) {
     return assertThat(actual);
   }
 
@@ -1326,7 +1326,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalDateTimeAssert<?> then(LocalDateTime actual) {
+  public static LocalDateTimeAssert then(LocalDateTime actual) {
     return assertThat(actual);
   }
 
@@ -1336,7 +1336,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractZonedDateTimeAssert<?> then(ZonedDateTime actual) {
+  public static ZonedDateTimeAssert then(ZonedDateTime actual) {
     return assertThat(actual);
   }
 
@@ -1346,7 +1346,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLocalTimeAssert<?> then(LocalTime actual) {
+  public static LocalTimeAssert then(LocalTime actual) {
     return assertThat(actual);
   }
 
@@ -1356,7 +1356,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractOffsetTimeAssert<?> then(OffsetTime actual) {
+  public static OffsetTimeAssert then(OffsetTime actual) {
     return assertThat(actual);
   }
 
@@ -1367,7 +1367,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  public static AbstractInstantAssert<?> then(Instant actual) {
+  public static InstantAssert then(Instant actual) {
     return assertThat(actual);
   }
 
@@ -1378,7 +1378,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.15.0
    */
-  public static AbstractDurationAssert<?> then(Duration actual) {
+  public static DurationAssert then(Duration actual) {
     return assertThat(actual);
   }
 
@@ -1389,7 +1389,7 @@ public class BDDAssertions extends Assertions {
    * @return the created assertion object.
    * @since 3.17.0
    */
-  public static AbstractPeriodAssert<?> then(Period actual) {
+  public static PeriodAssert then(Period actual) {
     return assertThat(actual);
   }
 
@@ -1399,7 +1399,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUriAssert<?> then(URI actual) {
+  public static UriAssert then(URI actual) {
     return assertThat(actual);
   }
 
@@ -1409,7 +1409,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUrlAssert<?> then(URL actual) {
+  public static UrlAssert then(URL actual) {
     return assertThat(actual);
   }
 
@@ -1419,7 +1419,7 @@ public class BDDAssertions extends Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractOffsetDateTimeAssert<?> then(OffsetDateTime actual) {
+  public static OffsetDateTimeAssert then(OffsetDateTime actual) {
     return assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/BDDAssumptions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssumptions.java
@@ -124,10 +124,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>boolean</code> value to be validated.
-   * @return the {@link AbstractBooleanAssert} assertion object to be used for validation.
+   * @return the {@link BooleanAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractBooleanAssert<?> given(boolean actual) {
+  public static BooleanAssert given(boolean actual) {
     return assumeThat(actual);
   }
 
@@ -153,10 +153,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Boolean} value to be validated.
-   * @return the {@link AbstractBooleanAssert} assertion object to be used for validation.
+   * @return the {@link BooleanAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractBooleanAssert<?> given(Boolean actual) {
+  public static BooleanAssert given(Boolean actual) {
     return assumeThat(actual);
   }
 
@@ -182,10 +182,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>boolean</code>s' array to be validated.
-   * @return the {@link AbstractBooleanArrayAssert} assertion object to be used for validation.
+   * @return the {@link BooleanArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractBooleanArrayAssert<?> given(boolean[] actual) {
+  public static BooleanArrayAssert given(boolean[] actual) {
     return assumeThat(actual);
   }
 
@@ -240,10 +240,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>byte</code> value to be validated.
-   * @return the {@link AbstractByteAssert} assertion object to be used for validation.
+   * @return the {@link ByteAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractByteAssert<?> given(byte actual) {
+  public static ByteAssert given(byte actual) {
     return assumeThat(actual);
   }
 
@@ -269,10 +269,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Byte} value to be validated.
-   * @return the {@link AbstractByteAssert} assertion object to be used for validation.
+   * @return the {@link ByteAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractByteAssert<?> given(Byte actual) {
+  public static ByteAssert given(Byte actual) {
     return assumeThat(actual);
   }
 
@@ -298,10 +298,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual bytes' array to be validated.
-   * @return the {@link AbstractByteArrayAssert} assertion object to be used for validation.
+   * @return the {@link ByteArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractByteArrayAssert<?> given(byte[] actual) {
+  public static ByteArrayAssert given(byte[] actual) {
     return assumeThat(actual);
   }
 
@@ -356,10 +356,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>short</code> value to be validated.
-   * @return the {@link AbstractShortAssert} assertion object to be used for validation.
+   * @return the {@link ShortAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractShortAssert<?> given(short actual) {
+  public static ShortAssert given(short actual) {
     return assumeThat(actual);
   }
 
@@ -385,10 +385,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Short} value to be validated.
-   * @return the {@link AbstractShortAssert} assertion object to be used for validation.
+   * @return the {@link ShortAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractShortAssert<?> given(Short actual) {
+  public static ShortAssert given(Short actual) {
     return assumeThat(actual);
   }
 
@@ -414,10 +414,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>short</code>s' array to be validated.
-   * @return the {@link AbstractShortArrayAssert} assertion object to be used for validation.
+   * @return the {@link ShortArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractShortArrayAssert<?> given(short[] actual) {
+  public static ShortArrayAssert given(short[] actual) {
     return assumeThat(actual);
   }
 
@@ -472,10 +472,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>int</code> value to be validated.
-   * @return the {@link AbstractIntegerAssert} assertion object to be used for validation.
+   * @return the {@link IntegerAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractIntegerAssert<?> given(int actual) {
+  public static IntegerAssert given(int actual) {
     return assumeThat(actual);
   }
 
@@ -501,10 +501,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Integer} value to be validated.
-   * @return the {@link AbstractIntegerAssert} assertion object to be used for validation.
+   * @return the {@link IntegerAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractIntegerAssert<?> given(Integer actual) {
+  public static IntegerAssert given(Integer actual) {
     return assumeThat(actual);
   }
 
@@ -530,10 +530,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>int</code>s' array to be validated.
-   * @return the {@link AbstractIntArrayAssert} assertion object to be used for validation.
+   * @return the {@link IntArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractIntArrayAssert<?> given(int[] actual) {
+  public static IntArrayAssert given(int[] actual) {
     return assumeThat(actual);
   }
 
@@ -588,10 +588,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link BigInteger} value to be validated.
-   * @return the {@link AbstractBigIntegerAssert} assertion object to be used for validation.
+   * @return the {@link BigIntegerAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractBigIntegerAssert<?> given(BigInteger actual) {
+  public static BigIntegerAssert given(BigInteger actual) {
     return assumeThat(actual);
   }
 
@@ -617,10 +617,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>long</code> value to be validated.
-   * @return the {@link AbstractLongAssert} assertion object to be used for validation.
+   * @return the {@link LongAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractLongAssert<?> given(long actual) {
+  public static LongAssert given(long actual) {
     return assumeThat(actual);
   }
 
@@ -646,10 +646,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Long} value to be validated.
-   * @return the {@link AbstractLongAssert} assertion object to be used for validation.
+   * @return the {@link LongAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractLongAssert<?> given(Long actual) {
+  public static LongAssert given(Long actual) {
     return assumeThat(actual);
   }
 
@@ -675,10 +675,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>long</code>s' array to be validated.
-   * @return the {@link AbstractLongArrayAssert} assertion object to be used for validation.
+   * @return the {@link LongArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractLongArrayAssert<?> given(long[] actual) {
+  public static LongArrayAssert given(long[] actual) {
     return assumeThat(actual);
   }
 
@@ -733,10 +733,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>float</code> value to be validated.
-   * @return the {@link AbstractFloatAssert} assertion object to be used for validation.
+   * @return the {@link FloatAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractFloatAssert<?> given(float actual) {
+  public static FloatAssert given(float actual) {
     return assumeThat(actual);
   }
 
@@ -762,10 +762,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Float} value to be validated.
-   * @return the {@link AbstractFloatAssert} assertion object to be used for validation.
+   * @return the {@link FloatAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractFloatAssert<?> given(Float actual) {
+  public static FloatAssert given(Float actual) {
     return assumeThat(actual);
   }
 
@@ -791,10 +791,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>float</code>s' array to be validated.
-   * @return the {@link AbstractFloatArrayAssert} assertion object to be used for validation.
+   * @return the {@link FloatArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractFloatArrayAssert<?> given(float[] actual) {
+  public static FloatArrayAssert given(float[] actual) {
     return assumeThat(actual);
   }
 
@@ -849,10 +849,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>double</code> value to be validated.
-   * @return the {@link AbstractDoubleAssert} assertion object to be used for validation.
+   * @return the {@link DoubleAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractDoubleAssert<?> given(double actual) {
+  public static DoubleAssert given(double actual) {
     return assumeThat(actual);
   }
 
@@ -878,10 +878,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Double} value to be validated.
-   * @return the {@link AbstractDoubleAssert} assertion object to be used for validation.
+   * @return the {@link DoubleAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractDoubleAssert<?> given(Double actual) {
+  public static DoubleAssert given(Double actual) {
     return assumeThat(actual);
   }
 
@@ -907,10 +907,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>double</code>s' array to be validated.
-   * @return the {@link AbstractDoubleArrayAssert} assertion object to be used for validation.
+   * @return the {@link DoubleArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractDoubleArrayAssert<?> given(double[] actual) {
+  public static DoubleArrayAssert given(double[] actual) {
     return assumeThat(actual);
   }
 
@@ -965,10 +965,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link BigDecimal} value to be validated.
-   * @return the {@link AbstractBigDecimalAssert} assertion object to be used for validation.
+   * @return the {@link BigDecimalAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractBigDecimalAssert<?> given(BigDecimal actual) {
+  public static BigDecimalAssert given(BigDecimal actual) {
     return assumeThat(actual);
   }
 
@@ -994,10 +994,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>char</code> value to be validated.
-   * @return the {@link AbstractCharacterAssert} assertion object to be used for validation.
+   * @return the {@link CharacterAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractCharacterAssert<?> given(char actual) {
+  public static CharacterAssert given(char actual) {
     return assumeThat(actual);
   }
 
@@ -1023,10 +1023,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Character} value to be validated.
-   * @return the {@link AbstractCharacterAssert} assertion object to be used for validation.
+   * @return the {@link CharacterAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractCharacterAssert<?> given(Character actual) {
+  public static CharacterAssert given(Character actual) {
     return assumeThat(actual);
   }
 
@@ -1052,10 +1052,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual <code>char</code>s' array to be validated.
-   * @return the {@link AbstractCharacterAssert} assertion object to be used for validation.
+   * @return the {@link CharacterAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractCharArrayAssert<?> given(char[] actual) {
+  public static CharArrayAssert given(char[] actual) {
     return assumeThat(actual);
   }
 
@@ -1110,10 +1110,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link CharSequence} value to be validated.
-   * @return the {@link AbstractCharSequenceAssert} assertion object to be used for validation.
+   * @return the {@link CharSequenceAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> given(CharSequence actual) {
+  public static CharSequenceAssert given(CharSequence actual) {
     return assumeThat(actual);
   }
 
@@ -1139,10 +1139,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link String} value to be validated.
-   * @return the {@link AbstractStringAssert} assertion object to be used for validation.
+   * @return the {@link StringAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractStringAssert<?> given(String actual) {
+  public static StringAssert given(String actual) {
     return assumeThat(actual);
   }
 
@@ -1168,10 +1168,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link StringBuilder} value to be validated.
-   * @return the {@link AbstractCharSequenceAssert} assertion object to be used for validation.
+   * @return the {@link CharSequenceAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> given(StringBuilder actual) {
+  public static CharSequenceAssert given(StringBuilder actual) {
     return assumeThat(actual);
   }
 
@@ -1197,10 +1197,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link StringBuffer} value to be validated.
-   * @return the {@link AbstractCharSequenceAssert} assertion object to be used for validation.
+   * @return the {@link CharSequenceAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> given(StringBuffer actual) {
+  public static CharSequenceAssert given(StringBuffer actual) {
     return assumeThat(actual);
   }
 
@@ -1226,7 +1226,7 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Class} value to be validated.
-   * @return the {@link AbstractClassAssert} assertion object to be used for validation.
+   * @return the {@link ClassAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static ClassAssert given(Class<?> actual) {
@@ -1260,7 +1260,7 @@ public final class BDDAssumptions {
    *
    * @param <T> the type of the actual object.
    * @param actual the actual object to be validated.
-   * @return the {@link AbstractObjectAssert} assertion object to be used for validation.
+   * @return the {@link ObjectAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <T> ObjectAssert<T> given(T actual) {
@@ -1290,7 +1290,7 @@ public final class BDDAssumptions {
    *
    * @param <T> the type of elements of the actual objects' array.
    * @param actual the actual objects' array to be validated..
-   * @return the {@link AbstractObjectArrayAssert} assertion object to be used for validation.
+   * @return the {@link ObjectArrayAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <T> ObjectArrayAssert<T> given(T[] actual) {
@@ -1343,7 +1343,7 @@ public final class BDDAssumptions {
    *
    * @param <T> the type of the actual object.
    * @param actual the actual object to be validated.
-   * @return the {@link AbstractObjectAssert} assertion object to be used for validation.
+   * @return the {@link ObjectAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <T> ObjectAssert<T> givenObject(T actual) {
@@ -1380,12 +1380,11 @@ public final class BDDAssumptions {
    *
    * @param <T> the type of the actual comparable value.
    * @param actual the actual {@link Comparable} value to be validated.
-   * @return the {@link AbstractComparableAssert} assertion object to be used for validation.
+   * @return the {@link GenericComparableAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  @SuppressWarnings("unchecked")
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> given(Comparable<? super T> actual) {
-    // cast needed to call AbstractComparableAssert<?, T> assumeThat(T actual)
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> given(T actual) {
+    // cast needed to call GenericComparableAssert<T> assumeThat(T actual)
     return assumeThat((T) actual);
   }
 
@@ -1411,10 +1410,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Throwable} value to be validated.
-   * @return the {@link AbstractThrowableAssert} assertion object to be used for validation.
+   * @return the {@link ThrowableAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> given(Throwable actual) {
+  public static ThrowableAssert given(Throwable actual) {
     return assumeThat(actual);
   }
 
@@ -1460,10 +1459,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param lambda the {@link ThrowingCallable} or lambda with the code that may raise a throwable to be validated.
-   * @return the {@link AbstractThrowableAssert} assertion object to be used for validation.
+   * @return the {@link ThrowableAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> givenCode(ThrowingCallable lambda) {
+  public static ThrowableAssert givenCode(ThrowingCallable lambda) {
     return assumeThatCode(lambda);
   }
 
@@ -1490,7 +1489,7 @@ public final class BDDAssumptions {
    *
    * @param <ELEMENT> the type of elements of actual iterable value.
    * @param actual the actual {@link Iterable} value to be validated.
-   * @return the {@link AbstractIterableAssert} assertion object to be used for validation.
+   * @return the {@link IterableAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <ELEMENT> IterableAssert<ELEMENT> given(Iterable<? extends ELEMENT> actual) {
@@ -1520,7 +1519,7 @@ public final class BDDAssumptions {
    *
    * @param <ELEMENT> the type of elements of actual iterator value.
    * @param actual the actual {@link Iterator} value to be validated.
-   * @return the {@link AbstractIteratorAssert} assertion object to be used for validation.
+   * @return the {@link IteratorAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <ELEMENT> IteratorAssert<ELEMENT> given(Iterator<? extends ELEMENT> actual) {
@@ -1550,10 +1549,10 @@ public final class BDDAssumptions {
    *
    * @param <ELEMENT> the type of elements of actual list value.
    * @param actual the actual {@link List} value to be validated.
-   * @return the {@link AbstractListAssert} assertion object to be used for validation.
+   * @return the {@link ListAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static <ELEMENT> FactoryBasedNavigableListAssert<ListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> given(List<? extends ELEMENT> actual) {
+  public static <ELEMENT> ListAssert<ELEMENT> given(List<? extends ELEMENT> actual) {
     return assumeThat(actual);
   }
 
@@ -1581,7 +1580,7 @@ public final class BDDAssumptions {
    * @param <K> the type of keys in the actual map value.
    * @param <V> the type of values in the actual map value.
    * @param actual the actual {@link Map} value to be validated.
-   * @return the {@link AbstractMapAssert} assertion object to be used for validation.
+   * @return the {@link MapAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <K, V> MapAssert<K, V> given(Map<K, V> actual) {
@@ -1611,7 +1610,7 @@ public final class BDDAssumptions {
    *
    * @param <T> the type of the value contained in the actual predicate value.
    * @param actual the actual {@link Predicate} value to be validated.
-   * @return the {@link AbstractPredicateAssert} assertion object to be used for validation.
+   * @return the {@link PredicateAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <T> PredicateAssert<T> given(Predicate<T> actual) {
@@ -1845,10 +1844,10 @@ public final class BDDAssumptions {
    *
    * @param <ELEMENT> the type of the value contained in the actual stream value.
    * @param actual the actual {@link Stream} value to be validated.
-   * @return the {@link AbstractListAssert} assertion object to be used for validation.
+   * @return the {@link ListAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> given(Stream<? extends ELEMENT> actual) {
+  public static <ELEMENT> ListAssert<ELEMENT> given(Stream<? extends ELEMENT> actual) {
     return assumeThat(actual);
   }
 
@@ -1874,10 +1873,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link IntStream} value to be validated.
-   * @return the {@link AbstractListAssert} assertion object to be used for validation.
+   * @return the {@link ListAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> given(IntStream actual) {
+  public static ListAssert<Integer> given(IntStream actual) {
     return assumeThat(actual);
   }
 
@@ -1903,10 +1902,10 @@ public final class BDDAssumptions {
    *
    * @param <ELEMENT> the type of the elements
    * @param actual the actual {@link Spliterator} value to be validated.
-   * @return the {@link AbstractSpliteratorAssert} assertion object to be used for validation.
+   * @return the {@link SpliteratorAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static <ELEMENT> AbstractSpliteratorAssert<?, ELEMENT> given(Spliterator<ELEMENT> actual) {
+  public static <ELEMENT> SpliteratorAssert<ELEMENT> given(Spliterator<ELEMENT> actual) {
     return assumeThat(actual);
   }
 
@@ -1932,10 +1931,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link LongStream} value to be validated.
-   * @return the {@link AbstractListAssert} assertion object to be used for validation.
+   * @return the {@link ListAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> given(LongStream actual) {
+  public static ListAssert<Long> given(LongStream actual) {
     return assumeThat(actual);
   }
 
@@ -1961,10 +1960,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link DoubleStream} value to be validated.
-   * @return the {@link AbstractListAssert} assertion object to be used for validation.
+   * @return the {@link ListAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> given(DoubleStream actual) {
+  public static ListAssert<Double> given(DoubleStream actual) {
     return assumeThat(actual);
   }
 
@@ -1991,10 +1990,10 @@ public final class BDDAssumptions {
    *
    * @param <RESULT> the type of the value contained in the actual future value.
    * @param future the {@link Future} value to be validated.
-   * @return the {@link AbstractFutureAssert} assertion object to be used for validation.
+   * @return the {@link FutureAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> given(Future<RESULT> future) {
+  public static <RESULT> FutureAssert<RESULT> given(Future<RESULT> future) {
     return assumeThat(future);
   }
 
@@ -2021,7 +2020,7 @@ public final class BDDAssumptions {
    *
    * @param <RESULT> the type of the value contained in the actual future value.
    * @param future the {@link CompletableFuture} value to be validated.
-   * @return the {@link AbstractCompletableFutureAssert} assertion object to be used for validation.
+   * @return the {@link CompletableFutureAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <RESULT> CompletableFutureAssert<RESULT> given(CompletableFuture<RESULT> future) {
@@ -2054,7 +2053,7 @@ public final class BDDAssumptions {
    *
    * @param <RESULT> the type of the value contained in the actual future value.
    * @param stage the {@link CompletionStage} value to be validated.
-   * @return the {@link AbstractCompletableFutureAssert} assertion object to be used for validation.
+   * @return the {@link CompletableFutureAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
   public static <RESULT> CompletableFutureAssert<RESULT> given(CompletionStage<RESULT> stage) {
@@ -2498,10 +2497,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Date} value to be validated.
-   * @return the {@link AbstractDateAssert} assertion object to be used for validation.
+   * @return the {@link DateAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractDateAssert<?> given(Date actual) {
+  public static DateAssert given(Date actual) {
     return assumeThat(actual);
   }
 
@@ -2527,10 +2526,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link LocalDate} value to be validated.
-   * @return the {@link AbstractLocalDateAssert} assertion object to be used for validation.
+   * @return the {@link LocalDateAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractLocalDateAssert<?> given(LocalDate actual) {
+  public static LocalDateAssert given(LocalDate actual) {
     return assumeThat(actual);
   }
 
@@ -2556,10 +2555,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link LocalTime} value to be validated.
-   * @return the {@link AbstractLocalTimeAssert} assertion object to be used for validation.
+   * @return the {@link LocalTimeAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractLocalTimeAssert<?> given(LocalTime actual) {
+  public static LocalTimeAssert given(LocalTime actual) {
     return assumeThat(actual);
   }
 
@@ -2585,10 +2584,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link OffsetTime} value to be validated.
-   * @return the {@link AbstractOffsetTimeAssert} assertion object to be used for validation.
+   * @return the {@link OffsetTimeAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractOffsetTimeAssert<?> given(OffsetTime actual) {
+  public static OffsetTimeAssert given(OffsetTime actual) {
     return assumeThat(actual);
   }
 
@@ -2614,10 +2613,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link LocalDateTime} value to be validated.
-   * @return the {@link AbstractLocalDateTimeAssert} assertion object to be used for validation.
+   * @return the {@link LocalDateTimeAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractLocalDateTimeAssert<?> given(LocalDateTime actual) {
+  public static LocalDateTimeAssert given(LocalDateTime actual) {
     return assumeThat(actual);
   }
 
@@ -2643,10 +2642,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Instant} value to be validated.
-   * @return the {@link AbstractInstantAssert} assertion object to be used for validation.
+   * @return the {@link InstantAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractInstantAssert<?> given(Instant actual) {
+  public static InstantAssert given(Instant actual) {
     return assumeThat(actual);
   }
 
@@ -2657,7 +2656,7 @@ public final class BDDAssumptions {
    * @return the created assertion object.
    * @since 3.15.0
    */
-  public static AbstractDurationAssert<?> given(Duration actual) {
+  public static DurationAssert given(Duration actual) {
     return assumeThat(actual);
   }
 
@@ -2668,7 +2667,7 @@ public final class BDDAssumptions {
    * @return the created assertion object.
    * @since 3.17.0
    */
-  public static AbstractPeriodAssert<?> given(Period actual) {
+  public static PeriodAssert given(Period actual) {
     return assumeThat(actual);
   }
 
@@ -2694,10 +2693,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link OffsetDateTime} value to be validated.
-   * @return the {@link AbstractOffsetDateTimeAssert} assertion object to be used for validation.
+   * @return the {@link OffsetDateTimeAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractOffsetDateTimeAssert<?> given(OffsetDateTime actual) {
+  public static OffsetDateTimeAssert given(OffsetDateTime actual) {
     return assumeThat(actual);
   }
 
@@ -2723,10 +2722,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link ZonedDateTime} value to be validated.
-   * @return the {@link AbstractZonedDateTimeAssert} assertion object to be used for validation.
+   * @return the {@link ZonedDateTimeAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractZonedDateTimeAssert<?> given(ZonedDateTime actual) {
+  public static ZonedDateTimeAssert given(ZonedDateTime actual) {
     return assumeThat(actual);
   }
 
@@ -2752,10 +2751,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link InputStream} value to be validated.
-   * @return the {@link AbstractInputStreamAssert} assertion object to be used for validation.
+   * @return the {@link InputStreamAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> given(InputStream actual) {
+  public static InputStreamAssert given(InputStream actual) {
     return assumeThat(actual);
   }
 
@@ -2781,10 +2780,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link File} value to be validated.
-   * @return the {@link AbstractFileAssert} assertion object to be used for validation.
+   * @return the {@link FileAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractFileAssert<?> given(File actual) {
+  public static FileAssert given(File actual) {
     return assumeThat(actual);
   }
 
@@ -2810,10 +2809,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link Path} value to be validated.
-   * @return the {@link AbstractPathAssert} assertion object to be used for validation.
+   * @return the {@link PathAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractPathAssert<?> given(Path actual) {
+  public static PathAssert given(Path actual) {
     return assumeThat(actual);
   }
 
@@ -2839,10 +2838,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link URI} value to be validated.
-   * @return the {@link AbstractUriAssert} assertion object to be used for validation.
+   * @return the {@link UriAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractUriAssert<?> given(URI actual) {
+  public static UriAssert given(URI actual) {
     return assumeThat(actual);
   }
 
@@ -2868,10 +2867,10 @@ public final class BDDAssumptions {
    *}</code></pre>
    *
    * @param actual the actual {@link URL} value to be validated.
-   * @return the {@link AbstractUrlAssert} assertion object to be used for validation.
+   * @return the {@link UrlAssert} assertion object to be used for validation.
    * @since 3.14.0
    */
-  public static AbstractUrlAssert<?> given(URL actual) {
+  public static UrlAssert given(URL actual) {
     return assumeThat(actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/BDDSoftAssertionsProvider.java
@@ -302,7 +302,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  default <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> then(Stream<? extends ELEMENT> actual) {
+  default <ELEMENT> ListAssert<ELEMENT> then(Stream<? extends ELEMENT> actual) {
     return proxy(ListAssert.class, Stream.class, actual);
   }
 
@@ -318,7 +318,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  default AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> then(DoubleStream actual) {
+  default ListAssert<Double> then(DoubleStream actual) {
     return proxy(ListAssert.class, DoubleStream.class, actual);
   }
 
@@ -334,7 +334,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  default AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> then(LongStream actual) {
+  default ListAssert<Long> then(LongStream actual) {
     return proxy(ListAssert.class, LongStream.class, actual);
   }
 
@@ -350,7 +350,7 @@ public interface BDDSoftAssertionsProvider extends Java6BDDSoftAssertionsProvide
    */
   @SuppressWarnings("unchecked")
   @CheckReturnValue
-  default AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> then(IntStream actual) {
+  default ListAssert<Integer> then(IntStream actual) {
     return proxy(ListAssert.class, IntStream.class, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -197,13 +197,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link BigDecimal}.
    */
-  InstanceOfAssertFactory<BigDecimal, AbstractBigDecimalAssert<?>> BIG_DECIMAL = new InstanceOfAssertFactory<>(BigDecimal.class,
+  InstanceOfAssertFactory<BigDecimal, BigDecimalAssert> BIG_DECIMAL = new InstanceOfAssertFactory<>(BigDecimal.class,
                                                                                                                Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link BigInteger}.
    */
-  InstanceOfAssertFactory<BigInteger, AbstractBigIntegerAssert<?>> BIG_INTEGER = new InstanceOfAssertFactory<>(BigInteger.class,
+  InstanceOfAssertFactory<BigInteger, BigIntegerAssert> BIG_INTEGER = new InstanceOfAssertFactory<>(BigInteger.class,
                                                                                                                Assertions::assertThat);
 
   /**
@@ -214,7 +214,7 @@ public interface InstanceOfAssertFactories {
    *
    * @since 3.13.2
    */
-  InstanceOfAssertFactory<URI, AbstractUriAssert<?>> URI_TYPE = new InstanceOfAssertFactory<>(URI.class,
+  InstanceOfAssertFactory<URI, UriAssert> URI_TYPE = new InstanceOfAssertFactory<>(URI.class,
                                                                                               Assertions::assertThat);
 
   /**
@@ -225,19 +225,19 @@ public interface InstanceOfAssertFactories {
    *
    * @since 3.13.2
    */
-  InstanceOfAssertFactory<URL, AbstractUrlAssert<?>> URL_TYPE = new InstanceOfAssertFactory<>(URL.class,
+  InstanceOfAssertFactory<URL, UrlAssert> URL_TYPE = new InstanceOfAssertFactory<>(URL.class,
                                                                                               Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code boolean} or its corresponding boxed type {@link Boolean}.
    */
-  InstanceOfAssertFactory<Boolean, AbstractBooleanAssert<?>> BOOLEAN = new InstanceOfAssertFactory<>(Boolean.class,
+  InstanceOfAssertFactory<Boolean, BooleanAssert> BOOLEAN = new InstanceOfAssertFactory<>(Boolean.class,
                                                                                                      Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code boolean} array.
    */
-  InstanceOfAssertFactory<boolean[], AbstractBooleanArrayAssert<?>> BOOLEAN_ARRAY = new InstanceOfAssertFactory<>(boolean[].class,
+  InstanceOfAssertFactory<boolean[], BooleanArrayAssert> BOOLEAN_ARRAY = new InstanceOfAssertFactory<>(boolean[].class,
                                                                                                                   Assertions::assertThat);
 
   /**
@@ -249,13 +249,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@code byte} or its corresponding boxed type {@link Byte}.
    */
-  InstanceOfAssertFactory<Byte, AbstractByteAssert<?>> BYTE = new InstanceOfAssertFactory<>(Byte.class,
+  InstanceOfAssertFactory<Byte, ByteAssert> BYTE = new InstanceOfAssertFactory<>(Byte.class,
                                                                                             Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code byte} array.
    */
-  InstanceOfAssertFactory<byte[], AbstractByteArrayAssert<?>> BYTE_ARRAY = new InstanceOfAssertFactory<>(byte[].class,
+  InstanceOfAssertFactory<byte[], ByteArrayAssert> BYTE_ARRAY = new InstanceOfAssertFactory<>(byte[].class,
                                                                                                          Assertions::assertThat);
 
   /**
@@ -267,13 +267,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@code char} or its corresponding boxed type {@link Character}.
    */
-  InstanceOfAssertFactory<Character, AbstractCharacterAssert<?>> CHARACTER = new InstanceOfAssertFactory<>(Character.class,
+  InstanceOfAssertFactory<Character, CharacterAssert> CHARACTER = new InstanceOfAssertFactory<>(Character.class,
                                                                                                            Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code char} array.
    */
-  InstanceOfAssertFactory<char[], AbstractCharArrayAssert<?>> CHAR_ARRAY = new InstanceOfAssertFactory<>(char[].class,
+  InstanceOfAssertFactory<char[], CharArrayAssert> CHAR_ARRAY = new InstanceOfAssertFactory<>(char[].class,
                                                                                                          Assertions::assertThat);
 
   /**
@@ -292,13 +292,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@code double} or its corresponding boxed type {@link Double}.
    */
-  InstanceOfAssertFactory<Double, AbstractDoubleAssert<?>> DOUBLE = new InstanceOfAssertFactory<>(Double.class,
+  InstanceOfAssertFactory<Double, DoubleAssert> DOUBLE = new InstanceOfAssertFactory<>(Double.class,
                                                                                                   Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code double} array.
    */
-  InstanceOfAssertFactory<double[], AbstractDoubleArrayAssert<?>> DOUBLE_ARRAY = new InstanceOfAssertFactory<>(double[].class,
+  InstanceOfAssertFactory<double[], DoubleArrayAssert> DOUBLE_ARRAY = new InstanceOfAssertFactory<>(double[].class,
                                                                                                                Assertions::assertThat);
 
   /**
@@ -310,7 +310,7 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link File}.
    */
-  InstanceOfAssertFactory<File, AbstractFileAssert<?>> FILE = new InstanceOfAssertFactory<>(File.class,
+  InstanceOfAssertFactory<File, FileAssert> FILE = new InstanceOfAssertFactory<>(File.class,
                                                                                             Assertions::assertThat);
 
   /**
@@ -338,19 +338,19 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@link InputStream}.
    */
-  InstanceOfAssertFactory<InputStream, AbstractInputStreamAssert<?, ?>> INPUT_STREAM = new InstanceOfAssertFactory<>(InputStream.class,
+  InstanceOfAssertFactory<InputStream, InputStreamAssert> INPUT_STREAM = new InstanceOfAssertFactory<>(InputStream.class,
                                                                                                                      Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code float} or its corresponding boxed type {@link Float}.
    */
-  InstanceOfAssertFactory<Float, AbstractFloatAssert<?>> FLOAT = new InstanceOfAssertFactory<>(Float.class,
+  InstanceOfAssertFactory<Float, FloatAssert> FLOAT = new InstanceOfAssertFactory<>(Float.class,
                                                                                                Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code float} array.
    */
-  InstanceOfAssertFactory<float[], AbstractFloatArrayAssert<?>> FLOAT_ARRAY = new InstanceOfAssertFactory<>(float[].class,
+  InstanceOfAssertFactory<float[], FloatArrayAssert> FLOAT_ARRAY = new InstanceOfAssertFactory<>(float[].class,
                                                                                                             Assertions::assertThat);
 
   /**
@@ -362,13 +362,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for an {@code integer} or its corresponding boxed type {@link Integer}.
    */
-  InstanceOfAssertFactory<Integer, AbstractIntegerAssert<?>> INTEGER = new InstanceOfAssertFactory<>(Integer.class,
+  InstanceOfAssertFactory<Integer, IntegerAssert> INTEGER = new InstanceOfAssertFactory<>(Integer.class,
                                                                                                      Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@code int} array.
    */
-  InstanceOfAssertFactory<int[], AbstractIntArrayAssert<?>> INT_ARRAY = new InstanceOfAssertFactory<>(int[].class,
+  InstanceOfAssertFactory<int[], IntArrayAssert> INT_ARRAY = new InstanceOfAssertFactory<>(int[].class,
                                                                                                       Assertions::assertThat);
 
   /**
@@ -380,13 +380,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@code long} or its corresponding boxed type {@link Long}.
    */
-  InstanceOfAssertFactory<Long, AbstractLongAssert<?>> LONG = new InstanceOfAssertFactory<>(Long.class,
+  InstanceOfAssertFactory<Long, LongAssert> LONG = new InstanceOfAssertFactory<>(Long.class,
                                                                                             Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code long} array.
    */
-  InstanceOfAssertFactory<long[], AbstractLongArrayAssert<?>> LONG_ARRAY = new InstanceOfAssertFactory<>(long[].class,
+  InstanceOfAssertFactory<long[], LongArrayAssert> LONG_ARRAY = new InstanceOfAssertFactory<>(long[].class,
                                                                                                          Assertions::assertThat);
 
   /**
@@ -452,13 +452,13 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@code short} or its corresponding boxed type {@link Short}.
    */
-  InstanceOfAssertFactory<Short, AbstractShortAssert<?>> SHORT = new InstanceOfAssertFactory<>(Short.class,
+  InstanceOfAssertFactory<Short, ShortAssert> SHORT = new InstanceOfAssertFactory<>(Short.class,
                                                                                                Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@code short} array.
    */
-  InstanceOfAssertFactory<short[], AbstractShortArrayAssert<?>> SHORT_ARRAY = new InstanceOfAssertFactory<>(short[].class,
+  InstanceOfAssertFactory<short[], ShortArrayAssert> SHORT_ARRAY = new InstanceOfAssertFactory<>(short[].class,
                                                                                                             Assertions::assertThat);
 
   /**
@@ -470,49 +470,49 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Date}.
    */
-  InstanceOfAssertFactory<Date, AbstractDateAssert<?>> DATE = new InstanceOfAssertFactory<>(Date.class,
+  InstanceOfAssertFactory<Date, DateAssert> DATE = new InstanceOfAssertFactory<>(Date.class,
                                                                                             Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link ZonedDateTime}.
    */
-  InstanceOfAssertFactory<ZonedDateTime, AbstractZonedDateTimeAssert<?>> ZONED_DATE_TIME = new InstanceOfAssertFactory<>(ZonedDateTime.class,
+  InstanceOfAssertFactory<ZonedDateTime, ZonedDateTimeAssert> ZONED_DATE_TIME = new InstanceOfAssertFactory<>(ZonedDateTime.class,
                                                                                                                          Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link LocalDateTime}.
    */
-  InstanceOfAssertFactory<LocalDateTime, AbstractLocalDateTimeAssert<?>> LOCAL_DATE_TIME = new InstanceOfAssertFactory<>(LocalDateTime.class,
+  InstanceOfAssertFactory<LocalDateTime, LocalDateTimeAssert> LOCAL_DATE_TIME = new InstanceOfAssertFactory<>(LocalDateTime.class,
                                                                                                                          Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link OffsetDateTime}.
    */
-  InstanceOfAssertFactory<OffsetDateTime, AbstractOffsetDateTimeAssert<?>> OFFSET_DATE_TIME = new InstanceOfAssertFactory<>(OffsetDateTime.class,
+  InstanceOfAssertFactory<OffsetDateTime, OffsetDateTimeAssert> OFFSET_DATE_TIME = new InstanceOfAssertFactory<>(OffsetDateTime.class,
                                                                                                                             Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link OffsetTime}.
    */
-  InstanceOfAssertFactory<OffsetTime, AbstractOffsetTimeAssert<?>> OFFSET_TIME = new InstanceOfAssertFactory<>(OffsetTime.class,
+  InstanceOfAssertFactory<OffsetTime, OffsetTimeAssert> OFFSET_TIME = new InstanceOfAssertFactory<>(OffsetTime.class,
                                                                                                                Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link LocalTime}.
    */
-  InstanceOfAssertFactory<LocalTime, AbstractLocalTimeAssert<?>> LOCAL_TIME = new InstanceOfAssertFactory<>(LocalTime.class,
+  InstanceOfAssertFactory<LocalTime, LocalTimeAssert> LOCAL_TIME = new InstanceOfAssertFactory<>(LocalTime.class,
                                                                                                             Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link LocalDate}.
    */
-  InstanceOfAssertFactory<LocalDate, AbstractLocalDateAssert<?>> LOCAL_DATE = new InstanceOfAssertFactory<>(LocalDate.class,
+  InstanceOfAssertFactory<LocalDate, LocalDateAssert> LOCAL_DATE = new InstanceOfAssertFactory<>(LocalDate.class,
                                                                                                             Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link Instant}.
    */
-  InstanceOfAssertFactory<Instant, AbstractInstantAssert<?>> INSTANT = new InstanceOfAssertFactory<>(Instant.class,
+  InstanceOfAssertFactory<Instant, InstantAssert> INSTANT = new InstanceOfAssertFactory<>(Instant.class,
                                                                                                      Assertions::assertThat);
 
   /**
@@ -520,7 +520,7 @@ public interface InstanceOfAssertFactories {
    *
    * @since 3.15.0
    */
-  InstanceOfAssertFactory<Duration, AbstractDurationAssert<?>> DURATION = new InstanceOfAssertFactory<>(Duration.class,
+  InstanceOfAssertFactory<Duration, DurationAssert> DURATION = new InstanceOfAssertFactory<>(Duration.class,
                                                                                                         Assertions::assertThat);
 
   /**
@@ -528,7 +528,7 @@ public interface InstanceOfAssertFactories {
    *
    * @since 3.17.0
    */
-  InstanceOfAssertFactory<Period, AbstractPeriodAssert<?>> PERIOD = new InstanceOfAssertFactory<>(Period.class, Assertions::assertThat);
+  InstanceOfAssertFactory<Period, PeriodAssert> PERIOD = new InstanceOfAssertFactory<>(Period.class, Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for an {@link AtomicBoolean}.
@@ -727,31 +727,31 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Throwable}.
    */
-  InstanceOfAssertFactory<Throwable, AbstractThrowableAssert<?, ? extends Throwable>> THROWABLE = new InstanceOfAssertFactory<>(Throwable.class,
+  InstanceOfAssertFactory<Throwable, ThrowableAssert> THROWABLE = new InstanceOfAssertFactory<>(Throwable.class,
                                                                                                                                 Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link CharSequence}.
    */
-  InstanceOfAssertFactory<CharSequence, AbstractCharSequenceAssert<?, ? extends CharSequence>> CHAR_SEQUENCE = new InstanceOfAssertFactory<>(CharSequence.class,
+  InstanceOfAssertFactory<CharSequence, CharSequenceAssert> CHAR_SEQUENCE = new InstanceOfAssertFactory<>(CharSequence.class,
                                                                                                                                              Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link StringBuilder}.
    */
-  InstanceOfAssertFactory<StringBuilder, AbstractCharSequenceAssert<?, ? extends CharSequence>> STRING_BUILDER = new InstanceOfAssertFactory<>(StringBuilder.class,
+  InstanceOfAssertFactory<StringBuilder, CharSequenceAssert> STRING_BUILDER = new InstanceOfAssertFactory<>(StringBuilder.class,
                                                                                                                                                Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link StringBuffer}.
    */
-  InstanceOfAssertFactory<StringBuffer, AbstractCharSequenceAssert<?, ? extends CharSequence>> STRING_BUFFER = new InstanceOfAssertFactory<>(StringBuffer.class,
+  InstanceOfAssertFactory<StringBuffer, CharSequenceAssert> STRING_BUFFER = new InstanceOfAssertFactory<>(StringBuffer.class,
                                                                                                                                              Assertions::assertThat);
 
   /**
    * {@link InstanceOfAssertFactory} for a {@link String}.
    */
-  InstanceOfAssertFactory<String, AbstractStringAssert<?>> STRING = new InstanceOfAssertFactory<>(String.class,
+  InstanceOfAssertFactory<String, StringAssert> STRING = new InstanceOfAssertFactory<>(String.class,
                                                                                                   Assertions::assertThat);
 
   /**
@@ -863,7 +863,7 @@ public interface InstanceOfAssertFactories {
   /**
    * {@link InstanceOfAssertFactory} for a {@link Path}.
    */
-  InstanceOfAssertFactory<Path, AbstractPathAssert<?>> PATH = new InstanceOfAssertFactory<>(Path.class,
+  InstanceOfAssertFactory<Path, PathAssert> PATH = new InstanceOfAssertFactory<>(Path.class,
                                                                                             Assertions::assertThat);
 
   /**
@@ -919,7 +919,7 @@ public interface InstanceOfAssertFactories {
    * @param comparableType the comparable type instance.
    * @return the factory instance.
    */
-  static <T extends Comparable<? super T>> InstanceOfAssertFactory<T, AbstractComparableAssert<?, T>> comparable(Class<T> comparableType) {
+  static <T extends Comparable<? super T>> InstanceOfAssertFactory<T, GenericComparableAssert<T>> comparable(Class<T> comparableType) {
     return new InstanceOfAssertFactory<>(comparableType, Assertions::assertThat);
   }
 

--- a/src/main/java/org/assertj/core/api/Java6Assertions.java
+++ b/src/main/java/org/assertj/core/api/Java6Assertions.java
@@ -234,7 +234,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
+  public static BigDecimalAssert assertThat(BigDecimal actual) {
     return new BigDecimalAssert(actual);
   }
 
@@ -245,7 +245,7 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public static AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
+  public static BigIntegerAssert assertThat(BigInteger actual) {
     return new BigIntegerAssert(actual);
   }
 
@@ -255,7 +255,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUriAssert<?> assertThat(URI actual) {
+  public static UriAssert assertThat(URI actual) {
     return new UriAssert(actual);
   }
 
@@ -265,7 +265,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUrlAssert<?> assertThat(URL actual) {
+  public static UrlAssert assertThat(URL actual) {
     return new UrlAssert(actual);
   }
 
@@ -275,7 +275,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> assertThat(boolean actual) {
+  public static BooleanAssert assertThat(boolean actual) {
     return new BooleanAssert(actual);
   }
 
@@ -285,7 +285,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
+  public static BooleanAssert assertThat(Boolean actual) {
     return new BooleanAssert(actual);
   }
 
@@ -295,7 +295,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
+  public static BooleanArrayAssert assertThat(boolean[] actual) {
     return new BooleanArrayAssert(actual);
   }
 
@@ -316,7 +316,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> assertThat(byte actual) {
+  public static ByteAssert assertThat(byte actual) {
     return new ByteAssert(actual);
   }
 
@@ -326,7 +326,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> assertThat(Byte actual) {
+  public static ByteAssert assertThat(Byte actual) {
     return new ByteAssert(actual);
   }
 
@@ -336,7 +336,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
+  public static ByteArrayAssert assertThat(byte[] actual) {
     return new ByteArrayAssert(actual);
   }
 
@@ -357,7 +357,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> assertThat(char actual) {
+  public static CharacterAssert assertThat(char actual) {
     return new CharacterAssert(actual);
   }
 
@@ -367,7 +367,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
+  public static CharArrayAssert assertThat(char[] actual) {
     return new CharArrayAssert(actual);
   }
 
@@ -388,7 +388,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> assertThat(Character actual) {
+  public static CharacterAssert assertThat(Character actual) {
     return new CharacterAssert(actual);
   }
 
@@ -398,7 +398,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractClassAssert<?> assertThat(Class<?> actual) {
+  public static ClassAssert assertThat(Class<?> actual) {
     return new ClassAssert(actual);
   }
 
@@ -410,7 +410,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> assertThat(T actual) {
     return new GenericComparableAssert<>(actual);
   }
 
@@ -421,7 +421,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> assertThat(Iterable<? extends T> actual) {
+  public static <T> IterableAssert<T> assertThat(Iterable<? extends T> actual) {
     return new IterableAssert<>(actual);
   }
 
@@ -444,7 +444,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractIteratorAssert<?, T> assertThat(Iterator<? extends T> actual) {
+  public static <T> IteratorAssert<T> assertThat(Iterator<? extends T> actual) {
     return new IteratorAssert<>(actual);
   }
 
@@ -454,7 +454,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> assertThat(double actual) {
+  public static DoubleAssert assertThat(double actual) {
     return new DoubleAssert(actual);
   }
 
@@ -464,7 +464,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> assertThat(Double actual) {
+  public static DoubleAssert assertThat(Double actual) {
     return new DoubleAssert(actual);
   }
 
@@ -474,7 +474,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
+  public static DoubleArrayAssert assertThat(double[] actual) {
     return new DoubleArrayAssert(actual);
   }
 
@@ -495,7 +495,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFileAssert<?> assertThat(File actual) {
+  public static FileAssert assertThat(File actual) {
     return new FileAssert(actual);
   }
 
@@ -508,7 +508,7 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> assertThat(Future<RESULT> actual) {
+  public static <RESULT> FutureAssert<RESULT> assertThat(Future<RESULT> actual) {
     return new FutureAssert<>(actual);
   }
 
@@ -518,7 +518,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
+  public static InputStreamAssert assertThat(InputStream actual) {
     return new InputStreamAssert(actual);
   }
 
@@ -528,7 +528,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> assertThat(float actual) {
+  public static FloatAssert assertThat(float actual) {
     return new FloatAssert(actual);
   }
 
@@ -538,7 +538,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> assertThat(Float actual) {
+  public static FloatAssert assertThat(Float actual) {
     return new FloatAssert(actual);
   }
 
@@ -548,7 +548,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
+  public static FloatArrayAssert assertThat(float[] actual) {
     return new FloatArrayAssert(actual);
   }
 
@@ -569,7 +569,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> assertThat(int actual) {
+  public static IntegerAssert assertThat(int actual) {
     return new IntegerAssert(actual);
   }
 
@@ -579,7 +579,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
+  public static IntArrayAssert assertThat(int[] actual) {
     return new IntArrayAssert(actual);
   }
 
@@ -600,7 +600,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> assertThat(Integer actual) {
+  public static IntegerAssert assertThat(Integer actual) {
     return new IntegerAssert(actual);
   }
 
@@ -611,7 +611,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> assertThat(List<? extends T> actual) {
+  public static <T> ListAssert<T> assertThat(List<? extends T> actual) {
     return new ListAssert<>(actual);
   }
 
@@ -620,9 +620,9 @@ public class Java6Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -664,9 +664,9 @@ public class Java6Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -699,9 +699,9 @@ public class Java6Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -742,9 +742,9 @@ public class Java6Assertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -778,7 +778,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> assertThat(long actual) {
+  public static LongAssert assertThat(long actual) {
     return new LongAssert(actual);
   }
 
@@ -788,7 +788,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> assertThat(Long actual) {
+  public static LongAssert assertThat(Long actual) {
     return new LongAssert(actual);
   }
 
@@ -798,7 +798,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
+  public static LongArrayAssert assertThat(long[] actual) {
     return new LongArrayAssert(actual);
   }
 
@@ -820,7 +820,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractObjectAssert<?, T> assertThat(T actual) {
+  public static <T> ObjectAssert<T> assertThat(T actual) {
     return new ObjectAssert<>(actual);
   }
 
@@ -902,7 +902,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractObjectArrayAssert<?, T> assertThat(T[] actual) {
+  public static <T> ObjectArrayAssert<T> assertThat(T[] actual) {
     return new ObjectArrayAssert<>(actual);
   }
 
@@ -939,7 +939,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> assertThat(short actual) {
+  public static ShortAssert assertThat(short actual) {
     return new ShortAssert(actual);
   }
 
@@ -949,7 +949,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> assertThat(Short actual) {
+  public static ShortAssert assertThat(Short actual) {
     return new ShortAssert(actual);
   }
 
@@ -959,7 +959,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
+  public static ShortArrayAssert assertThat(short[] actual) {
     return new ShortArrayAssert(actual);
   }
 
@@ -980,7 +980,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
+  public static CharSequenceAssert assertThat(CharSequence actual) {
     return new CharSequenceAssert(actual);
   }
 
@@ -991,7 +991,7 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
+  public static CharSequenceAssert assertThat(StringBuilder actual) {
     return new CharSequenceAssert(actual);
   }
 
@@ -1002,7 +1002,7 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
+  public static CharSequenceAssert assertThat(StringBuffer actual) {
     return new CharSequenceAssert(actual);
   }
 
@@ -1012,7 +1012,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractStringAssert<?> assertThat(String actual) {
+  public static StringAssert assertThat(String actual) {
     return new StringAssert(actual);
   }
 
@@ -1022,7 +1022,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDateAssert<?> assertThat(Date actual) {
+  public static DateAssert assertThat(Date actual) {
     return new DateAssert(actual);
   }
 
@@ -1032,7 +1032,7 @@ public class Java6Assertions {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
+  public static ThrowableAssert assertThat(Throwable actual) {
     return new ThrowableAssert(actual);
   }
 
@@ -1075,7 +1075,7 @@ public class Java6Assertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return new ThrowableAssert(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -1112,7 +1112,7 @@ public class Java6Assertions {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -1164,7 +1164,7 @@ public class Java6Assertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public static ThrowableAssert assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -1185,7 +1185,7 @@ public class Java6Assertions {
    * @return the created assertion object.
    * @since 3.12.0
    */
-  public <T> AbstractObjectAssert<?, T> assertThatObject(T actual) {
+  public <T> ObjectAssert<T> assertThatObject(T actual) {
     return assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
@@ -202,7 +202,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBigDecimalAssert<?> then(BigDecimal actual) {
+  public static BigDecimalAssert then(BigDecimal actual) {
     return assertThat(actual);
   }
 
@@ -213,7 +213,7 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public static AbstractBigIntegerAssert<?> then(BigInteger actual) {
+  public static BigIntegerAssert then(BigInteger actual) {
     return assertThat(actual);
   }
 
@@ -223,7 +223,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> then(boolean actual) {
+  public static BooleanAssert then(boolean actual) {
     return assertThat(actual);
   }
 
@@ -233,7 +233,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanAssert<?> then(Boolean actual) {
+  public static BooleanAssert then(Boolean actual) {
     return assertThat(actual);
   }
 
@@ -243,7 +243,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractBooleanArrayAssert<?> then(boolean[] actual) {
+  public static BooleanArrayAssert then(boolean[] actual) {
     return assertThat(actual);
   }
 
@@ -264,7 +264,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> then(byte actual) {
+  public static ByteAssert then(byte actual) {
     return assertThat(actual);
   }
 
@@ -274,7 +274,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteAssert<?> then(Byte actual) {
+  public static ByteAssert then(Byte actual) {
     return assertThat(actual);
   }
 
@@ -284,7 +284,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractByteArrayAssert<?> then(byte[] actual) {
+  public static ByteArrayAssert then(byte[] actual) {
     return assertThat(actual);
   }
 
@@ -305,7 +305,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> then(char actual) {
+  public static CharacterAssert then(char actual) {
     return assertThat(actual);
   }
 
@@ -315,7 +315,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharArrayAssert<?> then(char[] actual) {
+  public static CharArrayAssert then(char[] actual) {
     return assertThat(actual);
   }
 
@@ -336,7 +336,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharacterAssert<?> then(Character actual) {
+  public static CharacterAssert then(Character actual) {
     return assertThat(actual);
   }
 
@@ -346,7 +346,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractClassAssert<?> then(Class<?> actual) {
+  public static ClassAssert then(Class<?> actual) {
     return assertThat(actual);
   }
 
@@ -358,7 +358,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
+  public static <T extends Comparable<? super T>> GenericComparableAssert<T> then(T actual) {
     return assertThat(actual);
   }
 
@@ -369,7 +369,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractIterableAssert<?, Iterable<? extends T>, T, ObjectAssert<T>> then(Iterable<? extends T> actual) {
+  public static <T> IterableAssert<T> then(Iterable<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -392,7 +392,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractIteratorAssert<?, T> then(Iterator<? extends T> actual) {
+  public static <T> IteratorAssert<T> then(Iterator<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -401,9 +401,9 @@ public class Java6BDDAssertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -444,9 +444,9 @@ public class Java6BDDAssertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -478,9 +478,9 @@ public class Java6BDDAssertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -520,9 +520,9 @@ public class Java6BDDAssertions {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -557,7 +557,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> then(double actual) {
+  public static DoubleAssert then(double actual) {
     return assertThat(actual);
   }
 
@@ -567,7 +567,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleAssert<?> then(Double actual) {
+  public static DoubleAssert then(Double actual) {
     return assertThat(actual);
   }
 
@@ -577,7 +577,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDoubleArrayAssert<?> then(double[] actual) {
+  public static DoubleArrayAssert then(double[] actual) {
     return assertThat(actual);
   }
 
@@ -598,7 +598,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFileAssert<?> then(File actual) {
+  public static FileAssert then(File actual) {
     return assertThat(actual);
   }
 
@@ -610,7 +610,7 @@ public class Java6BDDAssertions {
    * @return the created assertion object
    * @since 2.7.0 / 3.7.0
    */
-  public static <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> then(Future<RESULT> actual) {
+  public static <RESULT> FutureAssert<RESULT> then(Future<RESULT> actual) {
     return assertThat(actual);
   }
 
@@ -620,7 +620,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractInputStreamAssert<?, ? extends InputStream> then(InputStream actual) {
+  public static InputStreamAssert then(InputStream actual) {
     return assertThat(actual);
   }
 
@@ -630,7 +630,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> then(float actual) {
+  public static FloatAssert then(float actual) {
     return assertThat(actual);
   }
 
@@ -640,7 +640,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatAssert<?> then(Float actual) {
+  public static FloatAssert then(Float actual) {
     return assertThat(actual);
   }
 
@@ -650,7 +650,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractFloatArrayAssert<?> then(float[] actual) {
+  public static FloatArrayAssert then(float[] actual) {
     return assertThat(actual);
   }
 
@@ -660,7 +660,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> then(int actual) {
+  public static IntegerAssert then(int actual) {
     return assertThat(actual);
   }
 
@@ -670,7 +670,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntArrayAssert<?> then(int[] actual) {
+  public static IntArrayAssert then(int[] actual) {
     return assertThat(actual);
   }
 
@@ -701,7 +701,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractIntegerAssert<?> then(Integer actual) {
+  public static IntegerAssert then(Integer actual) {
     return assertThat(actual);
   }
 
@@ -712,7 +712,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractListAssert<?, List<? extends T>, T, ObjectAssert<T>> then(List<? extends T> actual) {
+  public static <T> ListAssert<T> then(List<? extends T> actual) {
     return assertThat(actual);
   }
 
@@ -722,7 +722,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> then(long actual) {
+  public static LongAssert then(long actual) {
     return assertThat(actual);
   }
 
@@ -732,7 +732,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongAssert<?> then(Long actual) {
+  public static LongAssert then(Long actual) {
     return assertThat(actual);
   }
 
@@ -742,7 +742,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractLongArrayAssert<?> then(long[] actual) {
+  public static LongArrayAssert then(long[] actual) {
     return assertThat(actual);
   }
 
@@ -764,7 +764,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractObjectAssert<?, T> then(T actual) {
+  public static <T> ObjectAssert<T> then(T actual) {
     return assertThat(actual);
   }
 
@@ -775,7 +775,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T> AbstractObjectArrayAssert<?, T> then(T[] actual) {
+  public static <T> ObjectArrayAssert<T> then(T[] actual) {
     return assertThat(actual);
   }
 
@@ -809,7 +809,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> then(short actual) {
+  public static ShortAssert then(short actual) {
     return assertThat(actual);
   }
 
@@ -819,7 +819,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortAssert<?> then(Short actual) {
+  public static ShortAssert then(Short actual) {
     return assertThat(actual);
   }
 
@@ -829,7 +829,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractShortArrayAssert<?> then(short[] actual) {
+  public static ShortArrayAssert then(short[] actual) {
     return assertThat(actual);
   }
 
@@ -850,7 +850,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(CharSequence actual) {
+  public static CharSequenceAssert then(CharSequence actual) {
     return assertThat(actual);
   }
 
@@ -861,7 +861,7 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuilder actual) {
+  public static CharSequenceAssert then(StringBuilder actual) {
     return assertThat(actual);
   }
 
@@ -872,7 +872,7 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static AbstractCharSequenceAssert<?, ? extends CharSequence> then(StringBuffer actual) {
+  public static CharSequenceAssert then(StringBuffer actual) {
     return assertThat(actual);
   }
 
@@ -882,7 +882,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractStringAssert<?> then(String actual) {
+  public static StringAssert then(String actual) {
     return assertThat(actual);
   }
 
@@ -892,7 +892,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractDateAssert<?> then(Date actual) {
+  public static DateAssert then(Date actual) {
     return assertThat(actual);
   }
 
@@ -902,7 +902,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion Throwable.
    */
-  public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actual) {
+  public static ThrowableAssert then(Throwable actual) {
     return assertThat(actual);
   }
 
@@ -947,7 +947,7 @@ public class Java6BDDAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static ThrowableAssert thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return Assertions.assertThatThrownBy(shouldRaiseThrowable);
   }
 
@@ -984,7 +984,7 @@ public class Java6BDDAssertions {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public static AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
+  public static ThrowableAssert thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -1024,7 +1024,7 @@ public class Java6BDDAssertions {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  public AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public ThrowableAssert thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return then(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -1034,7 +1034,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUriAssert<?> then(URI actual) {
+  public static UriAssert then(URI actual) {
     return assertThat(actual);
   }
 
@@ -1044,7 +1044,7 @@ public class Java6BDDAssertions {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static AbstractUrlAssert<?> then(URL actual) {
+  public static UrlAssert then(URL actual) {
     return assertThat(actual);
   }
 
@@ -1140,7 +1140,7 @@ public class Java6BDDAssertions {
    * @return the created assertion object.
    * @since 3.12.0
    */
-  public static <T> AbstractObjectAssert<?, T> thenObject(T actual) {
+  public static <T> ObjectAssert<T> thenObject(T actual) {
     return then(actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/Java6BDDSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/Java6BDDSoftAssertionsProvider.java
@@ -218,7 +218,7 @@ public interface Java6BDDSoftAssertionsProvider extends SoftAssertionsProvider {
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
-  default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> then(T actual) {
+  default <T extends Comparable<? super T>> GenericComparableAssert<T> then(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
 
@@ -802,7 +802,7 @@ public interface Java6BDDSoftAssertionsProvider extends SoftAssertionsProvider {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
   @CanIgnoreReturnValue
-  default AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  default ThrowableAssert thenThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return then(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -840,7 +840,7 @@ public interface Java6BDDSoftAssertionsProvider extends SoftAssertionsProvider {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  default AbstractThrowableAssert<?, ? extends Throwable> thenThrownBy(ThrowingCallable shouldRaiseThrowable,
+  default ThrowableAssert thenThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                        String description, Object... args) {
     return then(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -880,7 +880,7 @@ public interface Java6BDDSoftAssertionsProvider extends SoftAssertionsProvider {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  default ThrowableAssert thenCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return then(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -925,7 +925,7 @@ public interface Java6BDDSoftAssertionsProvider extends SoftAssertionsProvider {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractUrlAssert<?> then(URL actual) {
+  default UrlAssert then(URL actual) {
     return proxy(UrlAssert.class, URL.class, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/Java6StandardSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/Java6StandardSoftAssertionsProvider.java
@@ -216,7 +216,7 @@ public interface Java6StandardSoftAssertionsProvider extends SoftAssertionsProvi
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
-  default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
+  default <T extends Comparable<? super T>> GenericComparableAssert<T> assertThat(T actual) {
     return proxy(GenericComparableAssert.class, Comparable.class, actual);
   }
 
@@ -784,7 +784,7 @@ public interface Java6StandardSoftAssertionsProvider extends SoftAssertionsProvi
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    */
   @CanIgnoreReturnValue
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  default ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -822,7 +822,7 @@ public interface Java6StandardSoftAssertionsProvider extends SoftAssertionsProvi
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  default ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -868,7 +868,7 @@ public interface Java6StandardSoftAssertionsProvider extends SoftAssertionsProvi
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  default ThrowableAssert assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -913,7 +913,7 @@ public interface Java6StandardSoftAssertionsProvider extends SoftAssertionsProvi
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractUrlAssert<?> assertThat(URL actual) {
+  default UrlAssert assertThat(URL actual) {
     return proxy(UrlAssert.class, URL.class, actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
+++ b/src/main/java/org/assertj/core/api/StandardSoftAssertionsProvider.java
@@ -282,7 +282,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
-  default <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assertThat(Stream<? extends ELEMENT> actual) {
+  default <ELEMENT> ListAssert<ELEMENT> assertThat(Stream<? extends ELEMENT> actual) {
     return proxy(ListAssert.class, Stream.class, actual);
   }
 
@@ -297,7 +297,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
-  default AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assertThat(DoubleStream actual) {
+  default ListAssert<Double> assertThat(DoubleStream actual) {
     return proxy(ListAssert.class, DoubleStream.class, actual);
   }
 
@@ -312,7 +312,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
-  default AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assertThat(LongStream actual) {
+  default ListAssert<Long> assertThat(LongStream actual) {
     return proxy(ListAssert.class, LongStream.class, actual);
   }
 
@@ -327,7 +327,7 @@ public interface StandardSoftAssertionsProvider extends Java6StandardSoftAsserti
    * @return the created assertion object.
    */
   @SuppressWarnings("unchecked")
-  default AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assertThat(IntStream actual) {
+  default ListAssert<Integer> assertThat(IntStream actual) {
     return proxy(ListAssert.class, IntStream.class, actual);
   }
 

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -334,7 +334,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractShortAssert<?> assertThat(final short actual) {
+  default ShortAssert assertThat(final short actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -344,7 +344,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractLongAssert<?> assertThat(final long actual) {
+  default LongAssert assertThat(final long actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -354,7 +354,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractLongAssert<?> assertThat(final Long actual) {
+  default LongAssert assertThat(final Long actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -364,7 +364,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractLongArrayAssert<?> assertThat(final long[] actual) {
+  default LongArrayAssert assertThat(final long[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -396,7 +396,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractStringAssert<?> assertThat(final String actual) {
+  default StringAssert assertThat(final String actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -406,7 +406,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractDateAssert<?> assertThat(final Date actual) {
+  default DateAssert assertThat(final Date actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -416,7 +416,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThat(final Throwable actual) {
+  default ThrowableAssert assertThat(final Throwable actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -426,7 +426,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractBigDecimalAssert<?> assertThat(final BigDecimal actual) {
+  default BigDecimalAssert assertThat(final BigDecimal actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -437,7 +437,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  default AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
+  default BigIntegerAssert assertThat(BigInteger actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -598,7 +598,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final CharSequence actual) {
+  default CharSequenceAssert assertThat(final CharSequence actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -609,7 +609,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final StringBuilder actual) {
+  default CharSequenceAssert assertThat(final StringBuilder actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -620,7 +620,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  default AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(final StringBuffer actual) {
+  default CharSequenceAssert assertThat(final StringBuffer actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -630,7 +630,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractShortArrayAssert<?> assertThat(final short[] actual) {
+  default ShortArrayAssert assertThat(final short[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -651,7 +651,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractShortAssert<?> assertThat(final Short actual) {
+  default ShortAssert assertThat(final Short actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -671,7 +671,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractCharacterAssert<?> assertThat(final Character actual) {
+  default CharacterAssert assertThat(final Character actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -681,7 +681,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractCharArrayAssert<?> assertThat(final char[] actual) {
+  default CharArrayAssert assertThat(final char[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -702,7 +702,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractCharacterAssert<?> assertThat(final char actual) {
+  default CharacterAssert assertThat(final char actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -714,7 +714,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(final T actual) {
+  default <T extends Comparable<? super T>> GenericComparableAssert<T> assertThat(final T actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -734,9 +734,9 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -798,9 +798,9 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -832,7 +832,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractBooleanAssert<?> assertThat(final Boolean actual) {
+  default BooleanAssert assertThat(final Boolean actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -842,7 +842,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractBooleanArrayAssert<?> assertThat(final boolean[] actual) {
+  default BooleanArrayAssert assertThat(final boolean[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -863,7 +863,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractByteAssert<?> assertThat(final byte actual) {
+  default ByteAssert assertThat(final byte actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -873,7 +873,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractByteAssert<?> assertThat(final Byte actual) {
+  default ByteAssert assertThat(final Byte actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -883,7 +883,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractByteArrayAssert<?> assertThat(final byte[] actual) {
+  default ByteArrayAssert assertThat(final byte[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -904,7 +904,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractBooleanAssert<?> assertThat(final boolean actual) {
+  default BooleanAssert assertThat(final boolean actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -914,7 +914,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractFloatAssert<?> assertThat(final float actual) {
+  default FloatAssert assertThat(final float actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -924,7 +924,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractInputStreamAssert<?, ? extends InputStream> assertThat(final InputStream actual) {
+  default InputStreamAssert assertThat(final InputStream actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -934,7 +934,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractFileAssert<?> assertThat(final File actual) {
+  default FileAssert assertThat(final File actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -957,7 +957,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the path to test
    * @return the created assertion object
    */
-  default AbstractPathAssert<?> assertThat(final Path actual) {
+  default PathAssert assertThat(final Path actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -967,7 +967,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractIntArrayAssert<?> assertThat(final int[] actual) {
+  default IntArrayAssert assertThat(final int[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -988,7 +988,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractFloatAssert<?> assertThat(final Float actual) {
+  default FloatAssert assertThat(final Float actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -1009,7 +1009,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractIntegerAssert<?> assertThat(final int actual) {
+  default IntegerAssert assertThat(final int actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -1019,7 +1019,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractFloatArrayAssert<?> assertThat(final float[] actual) {
+  default FloatArrayAssert assertThat(final float[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -1029,7 +1029,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractIntegerAssert<?> assertThat(final Integer actual) {
+  default IntegerAssert assertThat(final Integer actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -1039,7 +1039,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractDoubleAssert<?> assertThat(final double actual) {
+  default DoubleAssert assertThat(final double actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -1049,7 +1049,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractDoubleAssert<?> assertThat(final Double actual) {
+  default DoubleAssert assertThat(final Double actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -1069,9 +1069,9 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -1102,9 +1102,9 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link AbstractIterableAssert#first() first()}</li>
-   * <li>{@link AbstractIterableAssert#last() last()}</li>
-   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
+   * <li>{@link IterableAssert#first() first()}</li>
+   * <li>{@link IterableAssert#last() last()}</li>
+   * <li>{@link IterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -1265,7 +1265,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractDoubleArrayAssert<?> assertThat(final double[] actual) {
+  default DoubleArrayAssert assertThat(final double[] actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -2270,7 +2270,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractZonedDateTimeAssert<?> assertThat(final ZonedDateTime actual) {
+  default ZonedDateTimeAssert assertThat(final ZonedDateTime actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -2351,7 +2351,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param localDateTime the actual value.
    * @return the created assertion object.
    */
-  default AbstractLocalDateTimeAssert<?> assertThat(final LocalDateTime localDateTime) {
+  default LocalDateTimeAssert assertThat(final LocalDateTime localDateTime) {
     return Assertions.assertThat(localDateTime);
   }
 
@@ -2361,7 +2361,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param localDate the actual value.
    * @return the created assertion object.
    */
-  default AbstractLocalDateAssert<?> assertThat(final LocalDate localDate) {
+  default LocalDateAssert assertThat(final LocalDate localDate) {
     return Assertions.assertThat(localDate);
   }
 
@@ -2371,7 +2371,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param localTime the actual value.
    * @return the created assertion object.
    */
-  default AbstractLocalTimeAssert<?> assertThat(final LocalTime localTime) {
+  default LocalTimeAssert assertThat(final LocalTime localTime) {
     return Assertions.assertThat(localTime);
   }
 
@@ -2382,7 +2382,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  default AbstractInstantAssert<?> assertThat(final Instant actual) {
+  default InstantAssert assertThat(final Instant actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -2393,7 +2393,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.15.0
    */
-  default AbstractDurationAssert<?> assertThat(final Duration actual) {
+  default DurationAssert assertThat(final Duration actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -2404,7 +2404,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.17.0
    */
-  default AbstractPeriodAssert<?> assertThat(final Period actual) {
+  default PeriodAssert assertThat(final Period actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -2414,7 +2414,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param offsetTime the actual value.
    * @return the created assertion object.
    */
-  default AbstractOffsetTimeAssert<?> assertThat(final OffsetTime offsetTime) {
+  default OffsetTimeAssert assertThat(final OffsetTime offsetTime) {
     return Assertions.assertThat(offsetTime);
   }
 
@@ -2424,7 +2424,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param offsetDateTime the actual value.
    * @return the created assertion object.
    */
-  default AbstractOffsetDateTimeAssert<?> assertThat(final OffsetDateTime offsetDateTime) {
+  default OffsetDateTimeAssert assertThat(final OffsetDateTime offsetDateTime) {
     return Assertions.assertThat(offsetDateTime);
   }
 
@@ -2457,7 +2457,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    */
   @CanIgnoreReturnValue
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(final ThrowingCallable shouldRaiseThrowable) {
+  default ThrowableAssert assertThatThrownBy(final ThrowingCallable shouldRaiseThrowable) {
     return Assertions.assertThatThrownBy(shouldRaiseThrowable);
   }
 
@@ -2494,7 +2494,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  default ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                              String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -2540,7 +2540,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return The captured exception or <code>null</code> if none was raised by the callable.
    * @since 3.7.0
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  default ThrowableAssert assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assertThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -2788,7 +2788,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractUrlAssert<?> assertThat(final URL actual) {
+  default UrlAssert assertThat(final URL actual) {
     return Assertions.assertThat(actual);
   }
 
@@ -2798,7 +2798,7 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  default AbstractUriAssert<?> assertThat(final URI actual) {
+  default UriAssert assertThat(final URI actual) {
     return Assertions.assertThat(actual);
   }
 

--- a/src/main/java/org/assertj/core/api/WithAssumptions.java
+++ b/src/main/java/org/assertj/core/api/WithAssumptions.java
@@ -120,7 +120,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractShortAssert<?> assumeThat(final short actual) {
+  default ShortAssert assumeThat(final short actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -131,7 +131,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractLongAssert<?> assumeThat(final long actual) {
+  default LongAssert assumeThat(final long actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -142,7 +142,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractLongAssert<?> assumeThat(final Long actual) {
+  default LongAssert assumeThat(final Long actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -153,7 +153,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractLongArrayAssert<?> assumeThat(final long[] actual) {
+  default LongArrayAssert assumeThat(final long[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -187,7 +187,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractStringAssert<?> assumeThat(final String actual) {
+  default StringAssert assumeThat(final String actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -198,7 +198,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractDateAssert<?> assumeThat(final Date actual) {
+  default DateAssert assumeThat(final Date actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -209,7 +209,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> assumeThat(final Throwable actual) {
+  default ThrowableAssert assumeThat(final Throwable actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -220,7 +220,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractBigDecimalAssert<?> assumeThat(final BigDecimal actual) {
+  default BigDecimalAssert assumeThat(final BigDecimal actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -231,7 +231,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractBigIntegerAssert<?> assumeThat(BigInteger actual) {
+  default BigIntegerAssert assumeThat(BigInteger actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -393,7 +393,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final CharSequence actual) {
+  default CharSequenceAssert assumeThat(final CharSequence actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -404,7 +404,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final StringBuilder actual) {
+  default CharSequenceAssert assumeThat(final StringBuilder actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -415,7 +415,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.11.0
    */
-  default AbstractCharSequenceAssert<?, ? extends CharSequence> assumeThat(final StringBuffer actual) {
+  default CharSequenceAssert assumeThat(final StringBuffer actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -426,7 +426,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractShortArrayAssert<?> assumeThat(final short[] actual) {
+  default ShortArrayAssert assumeThat(final short[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -448,7 +448,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractShortAssert<?> assumeThat(final Short actual) {
+  default ShortAssert assumeThat(final Short actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -470,7 +470,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractCharacterAssert<?> assumeThat(final Character actual) {
+  default CharacterAssert assumeThat(final Character actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -481,7 +481,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractCharArrayAssert<?> assumeThat(final char[] actual) {
+  default CharArrayAssert assumeThat(final char[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -503,7 +503,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractCharacterAssert<?> assumeThat(final char actual) {
+  default CharacterAssert assumeThat(final char actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -515,7 +515,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assumeThat(final T actual) {
+  default <T extends Comparable<? super T>> GenericComparableAssert<T> assumeThat(final T actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -552,7 +552,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractBooleanAssert<?> assumeThat(final Boolean actual) {
+  default BooleanAssert assumeThat(final Boolean actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -563,7 +563,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractBooleanArrayAssert<?> assumeThat(final boolean[] actual) {
+  default BooleanArrayAssert assumeThat(final boolean[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -585,7 +585,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractByteAssert<?> assumeThat(final byte actual) {
+  default ByteAssert assumeThat(final byte actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -596,7 +596,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractByteAssert<?> assumeThat(final Byte actual) {
+  default ByteAssert assumeThat(final Byte actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -607,7 +607,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractByteArrayAssert<?> assumeThat(final byte[] actual) {
+  default ByteArrayAssert assumeThat(final byte[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -629,7 +629,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractBooleanAssert<?> assumeThat(final boolean actual) {
+  default BooleanAssert assumeThat(final boolean actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -640,7 +640,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractFloatAssert<?> assumeThat(final float actual) {
+  default FloatAssert assumeThat(final float actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -651,7 +651,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractInputStreamAssert<?, ? extends InputStream> assumeThat(final InputStream actual) {
+  default InputStreamAssert assumeThat(final InputStream actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -662,7 +662,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractFileAssert<?> assumeThat(final File actual) {
+  default FileAssert assumeThat(final File actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -675,7 +675,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default <RESULT> AbstractFutureAssert<?, ? extends Future<? extends RESULT>, RESULT> assumeThat(Future<RESULT> actual) {
+  default <RESULT> FutureAssert<RESULT> assumeThat(Future<RESULT> actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -686,7 +686,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractPathAssert<?> assumeThat(final Path actual) {
+  default PathAssert assumeThat(final Path actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -697,7 +697,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractIntArrayAssert<?> assumeThat(final int[] actual) {
+  default IntArrayAssert assumeThat(final int[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -719,7 +719,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractFloatAssert<?> assumeThat(final Float actual) {
+  default FloatAssert assumeThat(final Float actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -741,7 +741,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractIntegerAssert<?> assumeThat(final int actual) {
+  default IntegerAssert assumeThat(final int actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -752,7 +752,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractFloatArrayAssert<?> assumeThat(final float[] actual) {
+  default FloatArrayAssert assumeThat(final float[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -763,7 +763,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractIntegerAssert<?> assumeThat(final Integer actual) {
+  default IntegerAssert assumeThat(final Integer actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -774,7 +774,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractDoubleAssert<?> assumeThat(final double actual) {
+  default DoubleAssert assumeThat(final double actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -785,7 +785,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractDoubleAssert<?> assumeThat(final Double actual) {
+  default DoubleAssert assumeThat(final Double actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -797,7 +797,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default <ELEMENT> FactoryBasedNavigableListAssert<ListAssert<ELEMENT>, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(List<? extends ELEMENT> list) {
+  default <ELEMENT> ListAssert<ELEMENT> assumeThat(List<? extends ELEMENT> list) {
     return Assumptions.assumeThat(list);
   }
 
@@ -809,7 +809,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  default <ELEMENT> AbstractListAssert<?, List<? extends ELEMENT>, ELEMENT, ObjectAssert<ELEMENT>> assumeThat(Stream<? extends ELEMENT> stream) {
+  default <ELEMENT> ListAssert<ELEMENT> assumeThat(Stream<? extends ELEMENT> stream) {
     return Assumptions.assumeThat(stream);
   }
 
@@ -820,7 +820,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractListAssert<?, List<? extends Double>, Double, ObjectAssert<Double>> assumeThat(DoubleStream doubleStream) {
+  default ListAssert<Double> assumeThat(DoubleStream doubleStream) {
     return Assumptions.assumeThat(doubleStream);
   }
 
@@ -831,7 +831,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractListAssert<?, List<? extends Long>, Long, ObjectAssert<Long>> assumeThat(LongStream longStream) {
+  default ListAssert<Long> assumeThat(LongStream longStream) {
     return Assumptions.assumeThat(longStream);
   }
 
@@ -842,7 +842,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractListAssert<?, List<? extends Integer>, Integer, ObjectAssert<Integer>> assumeThat(IntStream intStream) {
+  default ListAssert<Integer> assumeThat(IntStream intStream) {
     return Assumptions.assumeThat(intStream);
   }
 
@@ -853,7 +853,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractDoubleArrayAssert<?> assumeThat(final double[] actual) {
+  default DoubleArrayAssert assumeThat(final double[] actual) {
     return Assumptions.assumeThat(actual);
   }
 
@@ -875,7 +875,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.9.0
    */
-  default AbstractZonedDateTimeAssert<?> assumeThat(final ZonedDateTime zonedDateTime) {
+  default ZonedDateTimeAssert assumeThat(final ZonedDateTime zonedDateTime) {
     return Assumptions.assumeThat(zonedDateTime);
   }
 
@@ -958,7 +958,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractLocalDateTimeAssert<?> assumeThat(final LocalDateTime localDateTime) {
+  default LocalDateTimeAssert assumeThat(final LocalDateTime localDateTime) {
     return Assumptions.assumeThat(localDateTime);
   }
 
@@ -969,7 +969,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractLocalDateAssert<?> assumeThat(final LocalDate localDate) {
+  default LocalDateAssert assumeThat(final LocalDate localDate) {
     return Assumptions.assumeThat(localDate);
   }
 
@@ -980,7 +980,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractLocalTimeAssert<?> assumeThat(final LocalTime localTime) {
+  default LocalTimeAssert assumeThat(final LocalTime localTime) {
     return Assumptions.assumeThat(localTime);
   }
 
@@ -991,7 +991,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractInstantAssert<?> assumeThat(final Instant instant) {
+  default InstantAssert assumeThat(final Instant instant) {
     return Assumptions.assumeThat(instant);
   }
 
@@ -1002,7 +1002,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.15.0
    */
-  default AbstractDurationAssert<?> assumeThat(final Duration duration) {
+  default DurationAssert assumeThat(final Duration duration) {
     return Assumptions.assumeThat(duration);
   }
 
@@ -1013,7 +1013,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.17.0
    */
-  default AbstractPeriodAssert<?> assumeThat(final Period period) {
+  default PeriodAssert assumeThat(final Period period) {
     return Assumptions.assumeThat(period);
   }
 
@@ -1024,7 +1024,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractOffsetTimeAssert<?> assumeThat(final OffsetTime offsetTime) {
+  default OffsetTimeAssert assumeThat(final OffsetTime offsetTime) {
     return Assumptions.assumeThat(offsetTime);
   }
 
@@ -1035,7 +1035,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractOffsetDateTimeAssert<?> assumeThat(final OffsetDateTime offsetDateTime) {
+  default OffsetDateTimeAssert assumeThat(final OffsetDateTime offsetDateTime) {
     return Assumptions.assumeThat(offsetDateTime);
   }
 
@@ -1053,7 +1053,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> assumeThatThrownBy(final ThrowingCallable shouldRaiseThrowable) {
+  default ThrowableAssert assumeThatThrownBy(final ThrowingCallable shouldRaiseThrowable) {
     return Assumptions.assumeThatThrownBy(shouldRaiseThrowable);
   }
 
@@ -1078,7 +1078,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractThrowableAssert<?, ? extends Throwable> assumeThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  default ThrowableAssert assumeThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return assumeThat(catchThrowable(shouldRaiseOrNotThrowable));
   }
 
@@ -1156,7 +1156,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractUrlAssert<?> assumeThat(final URL url) {
+  default UrlAssert assumeThat(final URL url) {
     return Assumptions.assumeThat(url);
   }
 
@@ -1167,7 +1167,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 2.9.0 / 3.9.0
    */
-  default AbstractUriAssert<?> assumeThat(final URI uri) {
+  default UriAssert assumeThat(final URI uri) {
     return Assumptions.assumeThat(uri);
   }
 
@@ -1179,7 +1179,7 @@ public interface WithAssumptions {
    * @return the created assumption for assertion object.
    * @since 3.14.0
    */
-  default <ELEMENT> AbstractSpliteratorAssert<?, ELEMENT> assumeThat(final Spliterator<ELEMENT> spliterator) {
+  default <ELEMENT> SpliteratorAssert<ELEMENT> assumeThat(final Spliterator<ELEMENT> spliterator) {
     return Assumptions.assumeThat(spliterator);
   }
 }

--- a/src/test/java/org/assertj/core/api/Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test.java
@@ -83,7 +83,7 @@ class Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test extends BaseAss
     Method[] assertThat_SoftAssertions_methods = findMethodsWithName(StandardSoftAssertionsProvider.class, "assertThat");
 
     // ignore the return type of soft assertions until they have the same as the Assertions
-    assertThat(assertThat_Assertions_methods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_RETURN_TYPE)
+    assertThat(assertThat_Assertions_methods).usingElementComparator(IGNORING_DECLARING_CLASS_ONLY)
                                              .containsExactlyInAnyOrder(assertThat_SoftAssertions_methods);
   }
 
@@ -95,7 +95,7 @@ class Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test extends BaseAss
     Method[] then_BDDSoftAssertions_methods = findMethodsWithName(BDDSoftAssertionsProvider.class, "then");
 
     // ignore the return type of soft assertions until they have the same as the Assertions
-    assertThat(then_Assertions_methods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_RETURN_TYPE)
+    assertThat(then_Assertions_methods).usingElementComparator(IGNORING_DECLARING_CLASS_ONLY)
                                        .containsExactlyInAnyOrder(then_BDDSoftAssertions_methods);
   }
 

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_Assumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_Assumptions_Test.java
@@ -25,7 +25,7 @@ class Assertions_sync_with_Assumptions_Test extends BaseAssertionsTest {
     Method[] assertThatMethods = findMethodsWithName(Assertions.class, "assertThat", SPECIAL_IGNORED_RETURN_TYPES);
     Method[] assumeThatMethods = findMethodsWithName(Assumptions.class, "assumeThat");
 
-    assertThat(assertThatMethods).usingElementComparator(IGNORING_DECLARING_CLASS_RETURN_TYPE_AND_METHOD_NAME)
+    assertThat(assertThatMethods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_METHOD_NAME)
                                  .containsExactlyInAnyOrder(assumeThatMethods);
   }
 

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_BDDAssumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_BDDAssumptions_Test.java
@@ -25,7 +25,7 @@ class Assertions_sync_with_BDDAssumptions_Test extends BaseAssertionsTest {
     Method[] assertThatMethods = findMethodsWithName(Assertions.class, "assertThat", SPECIAL_IGNORED_RETURN_TYPES);
     Method[] givenMethods = findMethodsWithName(BDDAssumptions.class, "given");
 
-    assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_RETURN_TYPE_AND_METHOD_NAME)
+    assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_METHOD_NAME)
                             .contains(assertThatMethods);
   }
 
@@ -34,7 +34,7 @@ class Assertions_sync_with_BDDAssumptions_Test extends BaseAssertionsTest {
     Method[] assertThatMethods = findMethodsWithName(Assertions.class, "assertThatObject", SPECIAL_IGNORED_RETURN_TYPES);
     Method[] givenMethods = findMethodsWithName(BDDAssumptions.class, "givenObject");
 
-    assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_RETURN_TYPE_AND_METHOD_NAME)
+    assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_METHOD_NAME)
                             .contains(assertThatMethods);
   }
 
@@ -43,7 +43,7 @@ class Assertions_sync_with_BDDAssumptions_Test extends BaseAssertionsTest {
     Method[] assertThatMethods = findMethodsWithName(Assertions.class, "assertThatCode", SPECIAL_IGNORED_RETURN_TYPES);
     Method[] givenMethods = findMethodsWithName(BDDAssumptions.class, "givenCode");
 
-    assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_RETURN_TYPE_AND_METHOD_NAME)
+    assertThat(givenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_METHOD_NAME)
                             .contains(assertThatMethods);
   }
 

--- a/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_sync_with_InstanceOfAssertFactories_Test.java
@@ -36,7 +36,7 @@ class Assertions_sync_with_InstanceOfAssertFactories_Test extends BaseAssertions
 
   private static final Class<?>[] FIELD_FACTORIES_IGNORED_TYPES = {
       // There can be no Comparable field factory with a base type.
-      AbstractComparableAssert.class,
+      GenericComparableAssert.class,
       // The comparison of the input GenericArrayTypes will always fail, since it verifies the inner TypeVariable which
       // returns the defining Method as result of TypeVariable#getGenericDeclaration().
       ObjectArrayAssert.class,

--- a/src/test/java/org/assertj/core/api/BaseAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BaseAssertionsTest.java
@@ -37,13 +37,8 @@ public abstract class BaseAssertionsTest {
 
   static final Comparator<Method> IGNORING_DECLARING_CLASS_AND_METHOD_NAME = internalMethodComparator(false, true);
 
-  static final Comparator<Method> IGNORING_DECLARING_CLASS_AND_RETURN_TYPE = internalMethodComparator(true, false);
-
   static final Comparator<Method> IGNORING_DECLARING_CLASS_ONLY = internalMethodComparator(false, false);
 
-  static final Comparator<Method> IGNORING_DECLARING_CLASS_RETURN_TYPE_AND_METHOD_NAME = internalMethodComparator(true,
-                                                                                                                  true);
-  // Object is ignored because of the AssertProvider
   static final Class<?>[] SPECIAL_IGNORED_RETURN_TYPES = array(AssertDelegateTarget.class,
                                                                FactoryBasedNavigableListAssert.class,
                                                                FactoryBasedNavigableIterableAssert.class,

--- a/src/test/java/org/assertj/core/api/Java6Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test.java
+++ b/src/test/java/org/assertj/core/api/Java6Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test.java
@@ -41,7 +41,7 @@ class Java6Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test extends Ba
     Method[] assertThatSoftMethods = findMethodsWithName(Java6StandardSoftAssertionsProvider.class, "assertThat");
 
     // ignore the return type of soft assertions until they have the same as the Assertions
-    assertThat(assertThatMethods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_RETURN_TYPE)
+    assertThat(assertThatMethods).usingElementComparator(IGNORING_DECLARING_CLASS_ONLY)
                                  .containsExactlyInAnyOrder(assertThatSoftMethods);
 
   }
@@ -54,7 +54,7 @@ class Java6Assertions_sync_assertThat_with_BDD_and_Soft_variants_Test extends Ba
     Method[] thenSoftMethods = findMethodsWithName(Java6BDDSoftAssertionsProvider.class, "then");
 
     // ignore the return type of soft assertions until they have the same as the Assertions
-    assertThat(thenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_AND_RETURN_TYPE)
+    assertThat(thenMethods).usingElementComparator(IGNORING_DECLARING_CLASS_ONLY)
                            .containsExactlyInAnyOrder(thenSoftMethods);
 
   }


### PR DESCRIPTION
With 3d5841fa110c029fc2104fd7425e02dd1ed19384 there is no longer the need for some assertions to have different return types. I think that going forward the same approach can be used for other places were `@SafeVarargs` is needed.

In this PR I've applied all the backwards compatible fixes (returning a more specific type, i.e. from `AbstractXXXAssert` to `XXXAssert`).  However, there are some inconsistencies between `SoftAssertions` and `Assertions`. The `SoftAssertions` are mostly returning `XXXAssert` whereas the `Assertions` are returning `AbstractXXXAssert`. I think that going forward we should return the most specific assertion, i.e. `XXXAssert`? What do you think?

If you don't agree with this PR and would like everything to stay the same, then feel free to close it.