### PR TITLE
CompositeRepresentation and CompositeRepresentation_Test draft.

### DIFF
--- a/src/main/java/org/assertj/core/presentation/CompositeRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/CompositeRepresentation.java
@@ -1,0 +1,76 @@
+package org.assertj.core.presentation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+public class CompositeRepresentation implements Representation {
+  protected Map<String, Representation> representations;
+
+  /*Initialize the CompositeRepresentation according to a certain correspondence of the "name of representation" and "representation" itself.*/
+  public CompositeRepresentation(Map<String, Representation> representations) {
+    this.representations = representations;
+  }
+
+  /*Initialize the CompositeRepresentation when the user does not have the correspondence of the "name of representation" and "representation" itself yet.*/
+  public CompositeRepresentation() {
+    representations = new HashMap<>();
+  }
+
+  /*Implementation of the `toString` method.*/
+  @Override
+  public String toStringOf(Object object) {
+    for (Map.Entry<String, Representation> entry : representations.entrySet()) {
+      String value = entry.getValue().toStringOf(object);
+      if (value != null)
+        return value;
+    }
+    return STANDARD_REPRESENTATION.toStringOf(object);
+  }
+
+  /*Implementation of the `toString` method when a specific representation is desired.*/
+  public String toStringOf(Object object, String representationName) {
+    if (representations.containsKey(representationName))
+      return representations.get(representationName).toStringOf(object);
+    return null;
+  }
+
+  /*Change the correspondence of the "name of representation" and "representation"*/
+  public void setRepresentations(Map<String, Representation> representations) {
+    this.representations = representations;
+  }
+
+  /*Get the "representation"*/
+  public Map<String, Representation> getRepresentations() {
+    return representations;
+  }
+
+  /*Add an entry of the correspondence of the "name of representation" and "representation"*/
+  public boolean addRepresentation(String representationName, Representation representation) {
+    if (representations.containsKey(representationName))
+      return false;
+    representations.put(representationName, representation);
+    return true;
+  }
+
+  /*Delete an entry of the correspondence of the "name of representation" and "representation"*/
+  public boolean deleteRepresentation(String representationName) {
+    if (representations.containsKey(representationName)) {
+      representations.remove(representationName);
+      return true;
+    }
+    return false;
+  }
+
+  /*Maybe the method is redundant here.*/
+  @Override
+  public String unambiguousToStringOf(Object object) {
+    for (Map.Entry<String, Representation> entry : representations.entrySet()) {
+      String value = entry.getValue().unambiguousToStringOf(object);
+      if (value != null)
+        return value;
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/assertj/core/presentation/CompositeRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/CompositeRepresentation.java
@@ -1,72 +1,28 @@
 package org.assertj.core.presentation;
 
-import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.Map;
 
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 
 public class CompositeRepresentation implements Representation {
-  protected Map<String, Representation> representations;
+  protected final Map<String, Representation> representationsByName;
 
-  /*Initialize the CompositeRepresentation according to a certain correspondence of the "name of representation" and "representation" itself.*/
   public CompositeRepresentation(Map<String, Representation> representations) {
-    this.representations = representations;
+    if (representations == null) throw new IllegalArgumentException();
+    this.representationsByName = representations;
   }
 
-  /*Initialize the CompositeRepresentation when the user does not have the correspondence of the "name of representation" and "representation" itself yet.*/
-  public CompositeRepresentation() {
-    representations = new HashMap<>();
-  }
-
-  /*Implementation of the `toString` method.*/
   @Override
   public String toStringOf(Object object) {
-    for (Map.Entry<String, Representation> entry : representations.entrySet()) {
-      String value = entry.getValue().toStringOf(object);
-      if (value != null)
-        return value;
-    }
-    return STANDARD_REPRESENTATION.toStringOf(object);
-  }
-
-  /*Implementation of the `toString` method when a specific representation is desired.*/
-  public String toStringOf(Object object, String representationName) {
-    if (representations.containsKey(representationName))
-      return representations.get(representationName).toStringOf(object);
-    return null;
-  }
-
-  /*Change the correspondence of the "name of representation" and "representation"*/
-  public void setRepresentations(Map<String, Representation> representations) {
-    this.representations = representations;
-  }
-
-  /*Get the "representation"*/
-  public Map<String, Representation> getRepresentations() {
-    return representations;
-  }
-
-  /*Add an entry of the correspondence of the "name of representation" and "representation"*/
-  public boolean addRepresentation(String representationName, Representation representation) {
-    if (representations.containsKey(representationName))
-      return false;
-    representations.put(representationName, representation);
-    return true;
-  }
-
-  /*Delete an entry of the correspondence of the "name of representation" and "representation"*/
-  public boolean deleteRepresentation(String representationName) {
-    if (representations.containsKey(representationName)) {
-      representations.remove(representationName);
-      return true;
-    }
-    return false;
+    return (new ArrayList<Representation>(this.representationsByName.values()))
+      .stream().map(x -> x.toStringOf(object)).findAny().orElse(STANDARD_REPRESENTATION.toStringOf(object));
   }
 
   /*Maybe the method is redundant here.*/
   @Override
   public String unambiguousToStringOf(Object object) {
-    for (Map.Entry<String, Representation> entry : representations.entrySet()) {
+    for (Map.Entry<String, Representation> entry : representationsByName.entrySet()) {
       String value = entry.getValue().unambiguousToStringOf(object);
       if (value != null)
         return value;

--- a/src/test/java/org/assertj/core/presentation/CompositeRepresentation_Test.java
+++ b/src/test/java/org/assertj/core/presentation/CompositeRepresentation_Test.java
@@ -1,0 +1,62 @@
+package org.assertj.core.presentation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.presentation.BinaryRepresentation.BINARY_REPRESENTATION;
+import static org.assertj.core.presentation.HexadecimalRepresentation.HEXA_REPRESENTATION;
+import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+
+public class CompositeRepresentation_Test extends AbstractBaseRepresentationTest {
+  @Test
+  void should_return_toString_of_default_representation() {
+    CompositeRepresentation composite = new CompositeRepresentation();
+    Object longNumber = 123L;
+    assertThat(composite.toStringOf(longNumber)).isEqualTo("123L");
+  }
+
+  @Test
+  void should_return_toString_of_specific_representation() {
+    CompositeRepresentation composite = new CompositeRepresentation();
+    Object longNumber = 123L;
+    composite.addRepresentation("hex", HEXA_REPRESENTATION);
+    assertThat(composite.toStringOf(longNumber, "hex")).isEqualTo("0x0000_0000_0000_007B");
+    assertThat(composite.toStringOf(longNumber, "standard")).isNull();
+  }
+
+  @Test
+  void should_return_null() {
+    CompositeRepresentation composite = new CompositeRepresentation();
+    Object nullObject = null;
+    assertThat(composite.toStringOf(nullObject)).isNull();
+  }
+
+
+  @Test
+  void should_represent_differently_according_to_the_representation() {
+    Map<String, Representation> representations = new HashMap<>();
+    representations.put("binary", BINARY_REPRESENTATION);
+    representations.put("unicode", UNICODE_REPRESENTATION);
+    CompositeRepresentation composite = new CompositeRepresentation(representations);
+    Object string = "你好！";
+    Object longNumber = 123L;
+    assertThat(composite.toStringOf(longNumber)).isEqualTo("0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_01111011");
+    assertThat(composite.toStringOf(string, "unicode")).isEqualTo("\\u4f60\\u597d\\uff01");
+  }
+
+  @Test
+  void should_be_able_to_add_or_delete_representations() {
+    Map<String, Representation> representations = new HashMap<>();
+    representations.put("binary", BINARY_REPRESENTATION);
+    representations.put("unicode", UNICODE_REPRESENTATION);
+    CompositeRepresentation composite = new CompositeRepresentation(representations);
+    Object longNumber = 123L;
+    composite.addRepresentation("hex", HEXA_REPRESENTATION);
+    assertThat(composite.getRepresentations().size()).isEqualTo(3);
+    composite.deleteRepresentation("binary");
+    assertThat(composite.toStringOf(longNumber, "binary")).isNull();
+  }
+}

--- a/src/test/java/org/assertj/core/presentation/CompositeRepresentation_Test.java
+++ b/src/test/java/org/assertj/core/presentation/CompositeRepresentation_Test.java
@@ -1,62 +1,46 @@
 package org.assertj.core.presentation;
 
+import org.assertj.core.api.BDDAssertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.presentation.BinaryRepresentation.BINARY_REPRESENTATION;
-import static org.assertj.core.presentation.HexadecimalRepresentation.HEXA_REPRESENTATION;
-import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class CompositeRepresentation_Test extends AbstractBaseRepresentationTest {
   @Test
-  void should_return_toString_of_default_representation() {
-    CompositeRepresentation composite = new CompositeRepresentation();
+  void should_return_toString_of_Standard_representation() {
+    // GIVEN
+    Map<String, Representation> representations = new HashMap<>();
+    representations.put("std", new StandardRepresentation());
+    representations.put("hex", new HexadecimalRepresentation());
+    CompositeRepresentation composite = new CompositeRepresentation(representations);
+    // WHEN
     Object longNumber = 123L;
-    assertThat(composite.toStringOf(longNumber)).isEqualTo("123L");
-  }
-
-  @Test
-  void should_return_toString_of_specific_representation() {
-    CompositeRepresentation composite = new CompositeRepresentation();
-    Object longNumber = 123L;
-    composite.addRepresentation("hex", HEXA_REPRESENTATION);
-    assertThat(composite.toStringOf(longNumber, "hex")).isEqualTo("0x0000_0000_0000_007B");
-    assertThat(composite.toStringOf(longNumber, "standard")).isNull();
+    // THEN
+    then(composite.toStringOf(longNumber)).isEqualTo("123L");
   }
 
   @Test
   void should_return_null() {
-    CompositeRepresentation composite = new CompositeRepresentation();
+    // GIVEN
+    Map<String, Representation> representations = new HashMap<>();
+    CompositeRepresentation composite = new CompositeRepresentation(representations);
+    // WHEN
     Object nullObject = null;
-    assertThat(composite.toStringOf(nullObject)).isNull();
-  }
-
-
-  @Test
-  void should_represent_differently_according_to_the_representation() {
-    Map<String, Representation> representations = new HashMap<>();
-    representations.put("binary", BINARY_REPRESENTATION);
-    representations.put("unicode", UNICODE_REPRESENTATION);
-    CompositeRepresentation composite = new CompositeRepresentation(representations);
-    Object string = "你好！";
-    Object longNumber = 123L;
-    assertThat(composite.toStringOf(longNumber)).isEqualTo("0b00000000_00000000_00000000_00000000_00000000_00000000_00000000_01111011");
-    assertThat(composite.toStringOf(string, "unicode")).isEqualTo("\\u4f60\\u597d\\uff01");
+    // THEN
+    then(composite.toStringOf(nullObject)).isNull();
   }
 
   @Test
-  void should_be_able_to_add_or_delete_representations() {
-    Map<String, Representation> representations = new HashMap<>();
-    representations.put("binary", BINARY_REPRESENTATION);
-    representations.put("unicode", UNICODE_REPRESENTATION);
-    CompositeRepresentation composite = new CompositeRepresentation(representations);
-    Object longNumber = 123L;
-    composite.addRepresentation("hex", HEXA_REPRESENTATION);
-    assertThat(composite.getRepresentations().size()).isEqualTo(3);
-    composite.deleteRepresentation("binary");
-    assertThat(composite.toStringOf(longNumber, "binary")).isNull();
+  void should_throw_IllegalArgumentException() {
+    // GIVEN
+    Map<String, Representation> representations = null;
+    // WHEN and THEN
+    assertThrows(IllegalArgumentException.class, () -> {
+      new CompositeRepresentation(null);
+    });
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2048
* Unit tests : YES 
* Javadoc with a code example (on API only) : NO

Maybe the method `String unambiguousToStringOf(Object object)` from the ''org.assertj.core.presentation.Representation.java'' is no longer needed since multiple `Representation` can be implemented in the class `CompositeRepresentation`.
