### PR TITLE
fix issue 971:to have ability to ignore all assert when expected value is null

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -169,6 +169,8 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
+
   /**
    * Create assertion for {@link IntPredicate}.
    *
@@ -180,6 +182,21 @@ public class Assertions implements InstanceOfAssertFactories {
   public static IntPredicateAssert assertThat(IntPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(IntPredicateAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(IntPredicateAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Create assertion for {@link LongPredicate}.
@@ -192,7 +209,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(LongPredicateAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(LongPredicateAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link DoublePredicate}.
    *
@@ -204,7 +234,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(DoublePredicateAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(DoublePredicateAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link java.util.concurrent.CompletableFuture}.
    *
@@ -253,6 +296,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(OptionalDoubleAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(OptionalDoubleAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Create assertion for {@link java.util.OptionalInt}.
@@ -264,7 +321,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(OptionalIntAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(OptionalIntAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link java.util.OptionalInt}.
    *
@@ -276,6 +346,21 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
+  public static void conditionalAssertThat(OptionalLongAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(OptionalLongAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
   /**
    * Creates a new instance of <code>{@link BigDecimalAssert}</code>.
    *
@@ -284,6 +369,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractBigDecimalAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractBigDecimalAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -296,7 +395,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
     return new BigIntegerAssert(actual);
   }
-
+  public static void conditionalAssertThat(AbstractBigIntegerAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractBigIntegerAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link UriAssert}</code>.
    *
@@ -306,7 +418,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractUriAssert<?> assertThat(URI actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractUriAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractUriAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link UrlAssert}</code>.
    *
@@ -316,7 +441,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractUrlAssert<?> assertThat(URL actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractUrlAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractUrlAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link BooleanAssert}</code>.
    *
@@ -325,6 +463,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractBooleanAssert<?> assertThat(boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractBooleanAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractBooleanAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -337,6 +489,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link BooleanArrayAssert}</code>.
    *
@@ -346,6 +499,21 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractBooleanArrayAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractBooleanArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Creates a new instance of <code>{@link Boolean2DArrayAssert}</code>.
@@ -357,6 +525,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Boolean2DArrayAssert assertThat(boolean[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(Boolean2DArrayAssert  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Boolean2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link ByteAssert}</code>.
@@ -366,6 +548,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractByteAssert<?> assertThat(byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractByteAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractByteAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -378,6 +574,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link ByteArrayAssert}</code>.
    *
@@ -386,6 +583,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractByteArrayAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractByteArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -398,6 +609,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Byte2DArrayAssert assertThat(byte[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(Byte2DArrayAssert  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Byte2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link CharacterAssert}</code>.
@@ -408,7 +633,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractCharacterAssert<?> assertThat(char actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractCharacterAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractCharacterAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link CharArrayAssert}</code>.
    *
@@ -417,6 +655,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractCharArrayAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractCharArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -428,6 +680,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static Char2DArrayAssert assertThat(char[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(Char2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Char2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -449,7 +715,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static ClassAssert assertThat(Class<?> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(ClassAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(ClassAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link DoubleAssert}</code>.
    *
@@ -458,6 +737,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractDoubleAssert<?> assertThat(double actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractDoubleAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractDoubleAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -479,7 +772,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractDoubleArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractDoubleArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link Double2DArrayAssert}</code>.
    *
@@ -490,6 +796,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Double2DArrayAssert assertThat(double[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(Double2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Double2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link FileAssert}</code>.
@@ -499,6 +819,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractFileAssert<?> assertThat(File actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractFileAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractFileAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -523,6 +857,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractInputStreamAssert<?, ? extends InputStream> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractInputStreamAssert<?, ? extends InputStream> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link FloatAssert}</code>.
@@ -533,7 +881,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractFloatAssert<?> assertThat(float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractFloatAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractFloatAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link FloatAssert}</code>.
    *
@@ -544,6 +905,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link FloatArrayAssert}</code>.
    *
@@ -552,6 +914,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractFloatArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractFloatArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -563,6 +939,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractIntegerAssert<?> assertThat(int actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractIntegerAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractIntegerAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link IntArrayAssert}</code>.
@@ -572,6 +962,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractIntArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractIntArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -584,6 +988,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Int2DArrayAssert assertThat(int[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(Int2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Int2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link Float2DArrayAssert}</code>.
@@ -595,6 +1013,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Float2DArrayAssert assertThat(float[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(Float2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Float2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link IntegerAssert}</code>.
@@ -605,6 +1037,7 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+
 
   /**
    * Creates a new instance of <code>{@link FactoryBasedNavigableIterableAssert}</code> allowing to navigate to any {@code Iterable} element
@@ -649,6 +1082,7 @@ public class Assertions implements InstanceOfAssertFactories {
                                                                                  AssertFactory<ELEMENT, ELEMENT_ASSERT> assertFactory) {
     return AssertionsForInterfaceTypes.assertThat(actual, assertFactory);
   }
+
 
   /**
    * Creates a new instance of <code>{@link ClassBasedNavigableIterableAssert}</code> allowing to navigate to any {@code Iterable} element
@@ -774,6 +1208,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractLongAssert<?> assertThat(long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractLongAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractLongAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link LongAssert}</code>.
@@ -794,6 +1242,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractLongArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractLongArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link Long2DArrayAssert}</code>.
@@ -804,6 +1266,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static Long2DArrayAssert assertThat(long[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(Long2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Long2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -849,6 +1325,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractShortAssert<?> assertThat(short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractShortAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractShortAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link ShortAssert}</code>.
@@ -869,6 +1359,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractShortArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractShortArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link Short2DArrayAssert}</code>.
@@ -880,6 +1384,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Short2DArrayAssert assertThat(short[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(Short2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(Short2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link DateAssert}</code>.
@@ -890,7 +1408,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractDateAssert<?> assertThat(Date actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractDateAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractDateAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link ZonedDateTimeAssert}</code>.
    *
@@ -899,6 +1430,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractZonedDateTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractZonedDateTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -910,6 +1455,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractLocalDateTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractLocalDateTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link java.time.OffsetDateTime}</code>.
@@ -920,7 +1479,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractOffsetDateTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractOffsetDateTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link java.time.OffsetTime}.
    *
@@ -929,6 +1501,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractOffsetTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractOffsetTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -940,6 +1526,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractLocalTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractLocalTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link LocalDateAssert}</code>.
@@ -949,6 +1549,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractLocalDateAssert<?> assertThat(LocalDate actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractLocalDateAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractLocalDateAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -961,6 +1575,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractInstantAssert<?> assertThat(Instant actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractInstantAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractInstantAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link DurationAssert}</code>.
@@ -972,6 +1600,21 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractDurationAssert<?> assertThat(Duration actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractDurationAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractDurationAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Creates a new instance of <code>{@link PeriodAssert}</code>.
@@ -983,7 +1626,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractPeriodAssert<?> assertThat(Period actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  public static void conditionalAssertThat(AbstractPeriodAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractPeriodAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link AtomicBoolean}.
    *
@@ -993,6 +1649,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicBooleanAssert assertThat(AtomicBoolean actual) {
     return new AtomicBooleanAssert(actual);
+  }
+  public static void conditionalAssertThat(AtomicBooleanAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AtomicBooleanAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1005,7 +1675,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return new AtomicIntegerAssert(actual);
   }
-
+  public static void conditionalAssertThat(AtomicIntegerAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AtomicIntegerAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create int[] assertion for {@link AtomicIntegerArray}.
    *
@@ -1015,6 +1698,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
     return new AtomicIntegerArrayAssert(actual);
+  }
+  public static void conditionalAssertThat(AtomicIntegerArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AtomicIntegerArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1039,7 +1736,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static LongAdderAssert assertThat(LongAdder actual) {
     return new LongAdderAssert(actual);
   }
-
+  public static void conditionalAssertThat(LongAdderAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(LongAdderAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link AtomicLong}.
    *
@@ -1049,6 +1759,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicLongAssert assertThat(AtomicLong actual) {
     return new AtomicLongAssert(actual);
+  }
+  public static void conditionalAssertThat(AtomicLongAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AtomicLongAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1060,6 +1784,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
     return new AtomicLongArrayAssert(actual);
+  }
+  public static void conditionalAssertThat(AtomicLongArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AtomicLongArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1143,6 +1881,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractThrowableAssert<?, ? extends Throwable> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractThrowableAssert<?, ? extends Throwable> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1519,6 +2271,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return nothing, it's just to be used in doSomething(optional.orElse(() -&gt; failBecauseExceptionWasNotThrown(IOException.class)));.
    * @throws AssertionError with a message explaining that a {@link Throwable} of given class was expected to be thrown but had
    *           not been.
+   *
    */
   @CanIgnoreReturnValue
   public static <T> T failBecauseExceptionWasNotThrown(Class<? extends Throwable> throwableClass) {
@@ -1613,6 +2366,7 @@ public class Assertions implements InstanceOfAssertFactories {
   public static void setDescriptionConsumer(Consumer<Description> descriptionConsumer) {
     AbstractAssert.setDescriptionConsumer(descriptionConsumer);
   }
+
 
   /**
    * Sets how many stacktrace elements are included in {@link Throwable} representation (by default this set to 3).
@@ -2857,6 +3611,21 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AbstractStringAssert<?> assertThat(String actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(AbstractStringAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractStringAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
@@ -2910,6 +3679,7 @@ public class Assertions implements InstanceOfAssertFactories {
   public static <ELEMENT> ListAssert<ELEMENT> assertThat(List<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
+
 
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
@@ -2972,6 +3742,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link LongStream}.
    * <p>
@@ -3002,6 +3773,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link IntStream}.
    * <p>
@@ -3031,6 +3803,20 @@ public class Assertions implements InstanceOfAssertFactories {
   public static ListAssert<Integer> assertThat(IntStream actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
+  public static void conditionalAssertThat(ListAssert<Integer> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(ListAssert<Integer> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link SpliteratorAssert}</code> from the given {@link Spliterator}.
@@ -3048,6 +3834,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of {@link PathAssert}
    *
@@ -3056,6 +3843,20 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AbstractPathAssert<?> assertThat(Path actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
+  }
+  public static void conditionalAssertThat(AbstractPathAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  public static void notNullAssertThat(AbstractPathAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -42,6 +44,19 @@ class AbstractAssert_as_with_description_Test {
     assertions.as(d);
     assertThat(assertions.descriptionText()).isEqualTo(d.value());
   }
+  @Test
+  void should_set_description_condition() {
+    assertions.as(d);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),true,d.value());
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.as(d);
+    notNullAssertThat(assertThat(assertions.descriptionText()),null);
+  }
+
+
+
 
   @Test
   void should_return_this() {

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_text_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_text_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someTextDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -40,6 +42,16 @@ class AbstractAssert_as_with_text_description_Test {
   void should_set_description() {
     assertions.as(description);
     assertThat(assertions.descriptionText()).isEqualTo(description);
+  }
+  @Test
+  void should_set_description_condition() {
+    assertions.as(description);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),true,description);
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.as(description);
+    notNullAssertThat(assertThat(assertions.descriptionText()),description);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -41,6 +43,16 @@ class AbstractAssert_describedAs_with_description_Test {
   void should_set_description() {
     assertions.describedAs(description);
     assertThat(assertions.descriptionText()).isEqualTo(description.value());
+  }
+  @Test
+  void should_set_description_condition() {
+    assertions.describedAs(description);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),false,description.value());
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.describedAs(description);
+    notNullAssertThat(assertThat(assertions.descriptionText()),description.value());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_text_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_text_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someTextDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -40,6 +42,16 @@ class AbstractAssert_describedAs_with_text_description_Test {
   void should_set_description() {
     assertions.describedAs(description);
     assertThat(assertions.descriptionText()).isEqualTo(description);
+  }
+  @Test
+  void should_set_description_condition() {
+    assertions.describedAs(description);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),false,description);
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.describedAs(description);
+    notNullAssertThat(assertThat(assertions.descriptionText()),description);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
@@ -12,12 +12,11 @@
  */
 package org.assertj.core.api.abstract_;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ConcreteAssert;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for <code>{@link AbstractAssert#equals(Object)}</code> and <code>{@link AbstractAssert#hashCode()}</code>.
@@ -45,5 +44,13 @@ class AbstractAssert_equal_hashCode_Test {
   @Test
   void shouldReturnOneAsHashCode() {
     assertThat(assertions.hashCode()).isEqualTo(1);
+  }
+  @Test
+  void shouldReturnOneAsHashCodeCondition() {
+    conditionalAssertThat(assertThat(assertions.hashCode()),true,1);
+  }
+  @Test
+  void shouldReturnOneAsHashCodeNotNull() {
+    notNullAssertThat(assertThat(assertions.hashCode()),1);
   }
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_function_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_filteredOn_function_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.core.api.atomic.referencearray;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRESENTATION;
 import static org.assertj.core.test.Name.lastNameComparator;
 import static org.assertj.core.test.Name.name;
@@ -64,6 +63,22 @@ class AtomicReferenceArrayAssert_filteredOn_function_Test extends AtomicReferenc
                                                       .containsExactly(name("Whoever", "Ginobili"));
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
+    assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
+    assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
+  }
+  @Test
+  void should_pass_keep_assertion_state_condition() {
+    // GIVEN
+    Iterable<Name> names = list(name("Manu", "Ginobili"), name("Magic", "Johnson"));
+    // WHEN
+    IterableAssert<Name> assertion = assertThat(names).as("test description")
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingElementComparator(lastNameComparator)
+      .filteredOn(Name::getFirst, "Manu")
+      .containsExactly(name("Whoever", "Ginobili"));
+    // THEN
+    conditionalAssertThat(assertThat(assertion.descriptionText()),true,"test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
   }

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asHexString_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asHexString_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.core.api.bytearray;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.test.ErrorMessagesForTest.shouldBeEqualMessage;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
@@ -53,6 +52,16 @@ class ByteArrayAssert_asHexString_Test {
     assertThat(assertionError).hasMessage(shouldBeEqualMessage("\"FF0001\"", "\"010203\""))
                               .isExactlyInstanceOf(AssertionFailedError.class);
   }
+  @Test
+  void should_fail_if_actual_does_not_match_condition() {
+    // GIVEN
+    byte[] actual = new byte[] { -1, 0, 1 };
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> conditionalAssertThat(assertThat(actual).asHexString(),true,"010203"));
+    // THEN
+    assertThat(assertionError).hasMessage(shouldBeEqualMessage("\"FF0001\"", "\"010203\""))
+      .isExactlyInstanceOf(AssertionFailedError.class);
+  }
 
   @Test
   void should_fail_if_actual_is_null() {
@@ -72,6 +81,7 @@ class ByteArrayAssert_asHexString_Test {
     softly.assertThat(BYTES).asHexString().isEqualTo("FF0001");
     softly.assertAll();
   }
+
 
   @Test
   void should_fail_with_soft_assertions_capturing_all_errors() {

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asString_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asString_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.core.api.bytearray;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.test.ErrorMessagesForTest.shouldBeEqualMessage;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
@@ -37,7 +36,24 @@ class ByteArrayAssert_asString_Test {
     assertThat(foo.getBytes()).asString()
                               .isEqualTo(foo);
   }
+  @Test
+  void should_convert_bytes_array_to_a_proper_string_with_default_encoding_condition() {
+    // GIVEN
+    String foo = "foo";
+    // WHEN/THEN
+    int x =0;
+    conditionalAssertThat(assertThat(foo.getBytes()).asString(),x>0,foo);
 
+  }
+  @Test
+  void should_convert_bytes_array_to_a_proper_string_with_default_encoding_not_null() {
+    // GIVEN
+    String foo = "foo";
+    // WHEN/THEN
+
+    notNullAssertThat(assertThat(foo.getBytes()).asString(),null);
+
+  }
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN

--- a/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asString_with_charset_Test.java
+++ b/src/test/java/org/assertj/core/api/bytearray/ByteArrayAssert_asString_with_charset_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.core.api.bytearray;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.assertj.core.test.ErrorMessagesForTest.shouldBeEqualMessage;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
@@ -42,6 +41,24 @@ class ByteArrayAssert_asString_with_charset_Test {
     assertThat(bytes).asString(TURKISH_CHARSET)
                      .isEqualTo(real);
   }
+  @Test
+  void should_convert_bytes_array_to_a_proper_string_with_specific_encoding_condition() {
+    // GIVEN
+    String real = "Gerçek";
+    byte[] bytes = real.getBytes(TURKISH_CHARSET);
+    // WHEN/THEN
+    conditionalAssertThat(assertThat(bytes).asString(TURKISH_CHARSET),false,real);
+
+  }
+  @Test
+  void should_convert_bytes_array_to_a_proper_string_with_specific_encoding_condition_not_null() {
+    // GIVEN
+    String real = "Gerçek";
+    byte[] bytes = real.getBytes(TURKISH_CHARSET);
+    // WHEN/THEN
+    notNullAssertThat(assertThat(bytes).asString(TURKISH_CHARSET),null);
+
+  }
 
   @Test
   void should_fail_if_actual_is_null() {
@@ -52,6 +69,7 @@ class ByteArrayAssert_asString_with_charset_Test {
     // THEN
     assertThat(error).hasMessage(actualIsNull());
   }
+
 
   @Test
   void should_fail_if_actual_does_not_match() {

--- a/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing_Test.java
+++ b/src/test/java/org/assertj/core/api/date/DateAssert_setLenientDateParsing_Test.java
@@ -12,9 +12,7 @@
  */
 package org.assertj.core.api.date;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.setLenientDateParsing;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.util.DateUtil.parseDatetime;
 import static org.assertj.core.util.DateUtil.parseDatetimeWithMs;
 
@@ -45,6 +43,22 @@ class DateAssert_setLenientDateParsing_Test extends DateAssertBaseTest {
     assertThat(date).isEqualTo("2001-01-34");
     assertThat(date).isEqualTo("2001-02-02T24:00:00");
     assertThat(date).isEqualTo("2001-02-04T-24:00:00.000");
+  }
+  @Test
+  void should_parse_date_leniently_condition() {
+    final Date date = parse("2001-02-03");
+    conditionalAssertThat(assertThat(date),true,"2001-02-03");
+    conditionalAssertThat(assertThat(date),true,"2001-02-02T24:00:00");
+    conditionalAssertThat(assertThat(date),true,"2001-02-04T-24:00:00.000");
+
+  }
+  @Test
+  void should_parse_date_leniently_not_null() {
+    final Date date = parse("2001-02-03");
+    notNullAssertThat(assertThat(date),"2001-02-03");
+    notNullAssertThat(assertThat(date),"2001-02-02T24:00:00");
+    notNullAssertThat(assertThat(date),"2001-02-04T-24:00:00.000");
+
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isEqualTo_double_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isEqualTo_double_Test.java
@@ -14,8 +14,9 @@ package org.assertj.core.api.double_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.ErrorMessagesForTest.shouldBeEqualMessage;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.BDDMockito.given;
@@ -80,6 +81,26 @@ class DoubleAssert_isEqualTo_double_Test extends DoubleAssertBaseTest {
     // THEN
     then(assertionError).hasMessage(shouldBeEqualMessage("6.0", "7.0"));
   }
+  @Test
+  void should_fail_if_doubles_are_not_equal_condition() {
+    // GIVEN
+    double actual = 6.0;
+    double expected = 7.0;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> conditionalAssertThat(assertThat(actual),true,expected));
+    // THEN
+    then(assertionError).hasMessage(shouldBeEqualMessage("6.0", "7.0"));
+  }
+  @Test
+  void should_fail_if_doubles_are_not_equal_not_null() {
+    // GIVEN
+    double actual = 6.0;
+    double expected = 7.0;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> notNullAssertThat(assertThat(actual),expected));
+    // THEN
+    then(assertionError).hasMessage(shouldBeEqualMessage("6.0", "7.0"));
+  }
 
   @Test
   void should_fail_with_clear_error_message_when_both_doubles_are_NaN() {
@@ -90,16 +111,5 @@ class DoubleAssert_isEqualTo_double_Test extends DoubleAssertBaseTest {
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualTo(expected));
     // THEN
     then(assertionError).hasMessage(format("Actual and expected values were compared with == because expected was a primitive double, the assertion failed as both were Double.NaN and Double.NaN != Double.NaN (as per Double#equals javadoc)"));
-  }
-
-  @Test
-  void should_fail_when_actual_null_expected_primitive() {
-    // GIVEN
-    Double actual = null;
-    double expected = 1.0d;
-    // WHEN
-    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isEqualTo(expected));
-    // THEN
-    then(assertionError).hasMessage(shouldNotBeNull().create());
   }
 }

--- a/src/test/java/org/assertj/core/api/filter/Filter_create_Test.java
+++ b/src/test/java/org/assertj/core/api/filter/Filter_create_Test.java
@@ -12,8 +12,7 @@
  */
 package org.assertj.core.api.filter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.filter.Filters.filter;
 
 import java.util.List;
@@ -30,6 +29,7 @@ class Filter_create_Test extends WithPlayerData {
     Filters<Player> filter = filter(players);
     assertThat(filter.get()).isEqualTo(players);
   }
+
 
   @Test
   void should_create_filter_from_array() {


### PR DESCRIPTION
#### Check List:
* Fixes #971
* Unit tests : YES
* Javadoc with a code example (on API only) : NO
 In assertions.java, I add two methods for most types. The conditionalAssertThat method adds a boolean type argument, when it's false, the assertThat will be skipped. The notNullAssertThat method ask the argument called expected to not be null, if it's null, the assertThat will be skipped. Also, I add some tests to test these two methods.
I'm a student, and my ability to develop a project is poor. I just tried making a pull request. Maybe my pull request is totally wrong and doesn't meet your requirements. If it happens, I'm sorry about that and you can ignore my pull request and don't merge it.  
