### PR TITLE
Implementing `hasExactlyElementsOfTypes` mentioned in issue #1907

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -861,6 +861,11 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return myself;
   }
 
+  public SELF hasExactlyElementsOfTypes(Class<?>... types) {
+    ObjectArrays.instance().assertHasExactlyElementsOfTypes(info, toArray(actual), types);
+    return myself;
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -861,6 +861,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return myself;
   }
 
+  @Override
   public SELF hasExactlyElementsOfTypes(Class<?>... types) {
     ObjectArrays.instance().assertHasExactlyElementsOfTypes(info, toArray(actual), types);
     return myself;

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -986,7 +986,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * Verifies that all elements of actual group are instances of given types{@code Iterable}, in given order.
+   * Verifies that the elements are of the given types (in the given order).
    * <p>
    * Example:
    * <pre><code class='java'> Object[] objects = {1, "a", 1.00};

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -985,6 +985,13 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
     return myself;
   }
 
+  @Override
+  public SELF hasExactlyElementsOfTypes(Class<?>... types)
+  {
+    arrays.assertHasExactlyElementsOfTypes(info, actual, types);
+    return myself;
+  }
+
   /**
    * Verifies that the actual array does not contain the given object at the given index.
    * <p>

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -986,7 +986,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * Verifies that all elements of actual group are instances of given {@code Iterable}, in given order.
+   * Verifies that all elements of actual group are instances of given types{@code Iterable}, in given order.
    * <p>
    * Example:
    * <pre><code class='java'> Object[] objects = {1, "a", 1.00};

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -986,12 +986,12 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * Verifies that the actual group contains all the elements of given {@code Iterable}, in given order.
+   * Verifies that all elements of actual group are instances of given {@code Iterable}, in given order.
    * <p>
    * Example:
-   * <pre><code class='java'> Iterable&lt;String&gt; Object[] objects = {1, "a", 1.00};
+   * <pre><code class='java'> Object[] objects = {1, "a", 1.00};
    *
-   * // assertions will pass
+   * // assertion succeeds
    * assertThat(abc).hasExactlyElementsOfTypes(Integer.class, String.class, Double.class);
    *
    * // assertions will fail
@@ -999,7 +999,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * assertThat(abc).hasExactlyElementsOfTypes(String.class);</code></pre>
    * <p>
    *
-   * @param types the given {@code Iterable} we will get elements from.
+   * @param types the given {@code Iterable} we will get the types of elements from.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given argument is {@code null}.
    * @throws AssertionError if the actual group is {@code null}.

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -992,12 +992,12 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * Verifies that the actual group contains all the elements of given {@code Iterable}, in given order.
+   * Verifies that all elements of actual group are instances of given {@code Iterable}, in given order.
    * <p>
    * Example:
    * <pre><code class='java'> AtomicReferenceArray&lt;Object&gt; elvesRings = new AtomicReferenceArray&lt;&gt;(new Object[]{1, "a", 1.00});
    *
-   * // assertions will pass
+   * // assertion succeeds
    * assertThat(abc).hasExactlyElementsOfTypes(Integer.class, String.class, Double.class);
    *
    * // assertions will fail
@@ -1005,7 +1005,7 @@ public class AtomicReferenceArrayAssert<T>
    * assertThat(abc).hasExactlyElementsOfTypes(String.class);</code></pre>
    * <p>
    *
-   * @param types the given {@code Iterable} we will get elements from.
+   * @param types the given {@code Iterable} we will get the types of elements from.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given argument is {@code null}.
    * @throws AssertionError if the actual group is {@code null}.

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -991,6 +991,14 @@ public class AtomicReferenceArrayAssert<T>
     return myself;
   }
 
+  @Override
+  public AtomicReferenceArrayAssert<T> hasExactlyElementsOfTypes(Class<?>... types)
+  {
+    arrays.assertHasExactlyElementsOfTypes(info, array, types);
+    return myself;
+  }
+
+
   /**
    * Verifies that the actual AtomicReferenceArray does not contain the given object at the given index.
    * <p>

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -992,7 +992,7 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * Verifies that all elements of actual group are instances of given types{@code Iterable}, in given order.
+   * Verifies that the elements are of the given types (in the given order).
    * <p>
    * Example:
    * <pre><code class='java'> AtomicReferenceArray&lt;Object&gt; elvesRings = new AtomicReferenceArray&lt;&gt;(new Object[]{1, "a", 1.00});

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -992,7 +992,7 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * Verifies that all elements of actual group are instances of given {@code Iterable}, in given order.
+   * Verifies that all elements of actual group are instances of given types{@code Iterable}, in given order.
    * <p>
    * Example:
    * <pre><code class='java'> AtomicReferenceArray&lt;Object&gt; elvesRings = new AtomicReferenceArray&lt;&gt;(new Object[]{1, "a", 1.00});

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -963,7 +963,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
   SELF hasOnlyElementsOfTypes(Class<?>... types);
 
   /**
-   * Verifies that all elements of actual group are instances of given {@code Iterable}, in given order.
+   * Verifies that all elements of actual group are instances of given types{@code Iterable}, in given order.
    * <p>
    * Example:
    * <pre><code class='java'> Iterable&lt;Object&gt; list = asList(1, "a", 1.00);

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -963,12 +963,12 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
   SELF hasOnlyElementsOfTypes(Class<?>... types);
 
   /**
-   * Verifies that the actual group contains all the elements of given {@code Iterable}, in given order.
+   * Verifies that all elements of actual group are instances of given {@code Iterable}, in given order.
    * <p>
    * Example:
-   * <pre><code class='java'> Iterable&lt;String&gt; list = asList(1, "a", 1.00);
+   * <pre><code class='java'> Iterable&lt;Object&gt; list = asList(1, "a", 1.00);
    *
-   * // assertions will pass
+   * // assertion succeeds
    * assertThat(abc).hasExactlyElementsOfTypes(Integer.class, String.class, Double.class);
    *
    * // assertions will fail
@@ -976,7 +976,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * assertThat(abc).hasExactlyElementsOfTypes(String.class);</code></pre>
    * <p>
    *
-   * @param types the given {@code Iterable} we will get elements from.
+   * @param types the given {@code Iterable} we will get the types of elements from.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given argument is {@code null}.
    * @throws AssertionError if the actual group is {@code null}.

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -963,7 +963,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
   SELF hasOnlyElementsOfTypes(Class<?>... types);
 
   /**
-   * Verifies that all elements of actual group are instances of given types{@code Iterable}, in given order.
+   * Verifies that the elements are of the given types (in the given order).
    * <p>
    * Example:
    * <pre><code class='java'> Iterable&lt;Object&gt; list = asList(1, "a", 1.00);

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -962,6 +962,8 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    */
   SELF hasOnlyElementsOfTypes(Class<?>... types);
 
+  SELF hasExactlyElementsOfTypes(Class<?>... types);
+
   /**
    * Verifies that at least one element in the actual {@code Object} group has the specified type (matching
    * includes subclasses of the given type).

--- a/src/main/java/org/assertj/core/internal/ObjectArrays.java
+++ b/src/main/java/org/assertj/core/internal/ObjectArrays.java
@@ -677,7 +677,7 @@ public class ObjectArrays {
 
   public <E> void assertHasExactlyElementsOfTypes(AssertionInfo info, E[] actual, Class<?>... types) {
     Objects.instance().assertNotNull(info, actual);
-    List<Class<?>> actualTypeList = extractTypeList(asList(actual));
+    List<Class<?>> actualTypeList = Streams.stream(asList(actual)).map(Object::getClass).collect(Collectors.toList());
     /* We want to compare the types instead of elements. Using getComparisonStrategy() would return the comparison
      strategy comparing elements not the types.*/
     IterableDiff diff = diff(actualTypeList, asList(types), StandardComparisonStrategy.instance());
@@ -755,10 +755,6 @@ public class ObjectArrays {
 
   public void assertContainsAnyOf(AssertionInfo info, Object[] actual, Object[] values) {
     arrays.assertContainsAnyOf(info, failures, actual, values);
-  }
-
-  private static List<Class<?>> extractTypeList(List<Object> list) {
-    return Streams.stream(list).map(Object::getClass).collect(Collectors.toList());
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/ObjectArrays.java
+++ b/src/main/java/org/assertj/core/internal/ObjectArrays.java
@@ -682,14 +682,14 @@ public class ObjectArrays {
       int i = 0;
       for (Object elementFromActual : actualTypeList) {
         if (!getComparisonStrategy().areEqual(elementFromActual, types[i])) {
-          throw failures.failure(info, elementsDifferAtIndex(elementFromActual.getClass(), types[i], i, getComparisonStrategy()));
+          throw failures.failure(info, elementsDifferAtIndex(elementFromActual, types[i], i, getComparisonStrategy()));
         }
         i++;
       }
       return;
     }
     throw failures.failure(info,
-      shouldContainExactly(actual.getClass(), asList(types), diff.missing, diff.unexpected,
+      shouldContainExactly(actual, asList(types), diff.missing, diff.unexpected,
         getComparisonStrategy()));
 
   }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test.java
@@ -5,17 +5,22 @@ import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
 
 import static org.mockito.Mockito.verify;
 
-public class AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test extends AtomicReferenceArrayAssertBaseTest
+/**
+ * Tests for <code>{@link AtomicReferenceArrayAssert#hasExactlyElementsOfTypes(Class...)} </code>.
+ */
+class AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test extends AtomicReferenceArrayAssertBaseTest
 {
+  private final Class<?>[] types = { Short.class };
+
   @Override
   protected AtomicReferenceArrayAssert<Object> invoke_api_method()
   {
-    return assertions.hasExactlyElementsOfTypes(Short.class);
+    return assertions.hasExactlyElementsOfTypes(types);
   }
 
   @Override
   protected void verify_internal_effects()
   {
-    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), internalArray(), Short.class);
+    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), internalArray(), types);
   }
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test.java
@@ -1,0 +1,21 @@
+package org.assertj.core.api.atomic.referencearray;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class AtomicReferenceArrayAssert_hasExactlyElementsOfTypes_Test extends AtomicReferenceArrayAssertBaseTest
+{
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method()
+  {
+    return assertions.hasExactlyElementsOfTypes(Short.class);
+  }
+
+  @Override
+  protected void verify_internal_effects()
+  {
+    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), internalArray(), Short.class);
+  }
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasExactlyElementsOfTypes_Test.java
@@ -1,22 +1,23 @@
 package org.assertj.core.api.iterable;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.util.Lists.newArrayList;
+import org.assertj.core.api.*;
 
-import java.util.List;
-
-import org.assertj.core.internal.ObjectArrays;
-import org.junit.jupiter.api.Test;
+import static org.mockito.Mockito.verify;
 
 /**
- * Only make one test since assertion is delegated to {@link ObjectArrays} which has its own tests.
+ * Tests for <code>{@link AbstractIterableAssert#hasExactlyElementsOfTypes(Class...)}</code>.
  */
-class IterableAssert_hasExactlyElementsOfTypes_Test
+class IterableAssert_hasExactlyElementsOfTypes_Test extends ObjectArrayAssertBaseTest
 {
-  @Test
-  void should_pass_if_actual_has_elements_of_the_expected_types_in_order()
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method()
   {
-    List<Object> list = newArrayList(1, "a", 1.00);
-    assertThat(list).hasExactlyElementsOfTypes(Integer.class, String.class, Double.class);
+    return assertions.hasExactlyElementsOfTypes(Integer.class, Double.class);
+  }
+
+  @Override
+  protected void verify_internal_effects()
+  {
+    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), getActual(assertions), Integer.class, Double.class);
   }
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasExactlyElementsOfTypes_Test.java
@@ -1,0 +1,18 @@
+package org.assertj.core.api.iterable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.newArrayList;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+public class IterableAssert_hasExactlyElementsOfTypes_Test
+{
+  @Test
+  void should_pass_if_actual_has_elements_of_the_expected_types_in_order()
+  {
+    List<Object> list = newArrayList(1, "a", 1.00);
+    assertThat(list).hasExactlyElementsOfTypes(Integer.class, String.class, Double.class);
+  }
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasExactlyElementsOfTypes_Test.java
@@ -5,9 +5,13 @@ import static org.assertj.core.util.Lists.newArrayList;
 
 import java.util.List;
 
+import org.assertj.core.internal.ObjectArrays;
 import org.junit.jupiter.api.Test;
 
-public class IterableAssert_hasExactlyElementsOfTypes_Test
+/**
+ * Only make one test since assertion is delegated to {@link ObjectArrays} which has its own tests.
+ */
+class IterableAssert_hasExactlyElementsOfTypes_Test
 {
   @Test
   void should_pass_if_actual_has_elements_of_the_expected_types_in_order()

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_hasExactlyElementsOfTypes_Test.java
@@ -1,0 +1,21 @@
+package org.assertj.core.api.objectarray;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+public class ObjectArrayAssert_hasExactlyElementsOfTypes_Test extends ObjectArrayAssertBaseTest
+{
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method()
+  {
+    return assertions.hasExactlyElementsOfTypes(Integer.class);
+  }
+
+  @Override
+  protected void verify_internal_effects()
+  {
+    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), getActual(assertions), Integer.class);
+  }
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_hasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_hasExactlyElementsOfTypes_Test.java
@@ -5,17 +5,22 @@ import org.assertj.core.api.ObjectArrayAssertBaseTest;
 
 import static org.mockito.Mockito.verify;
 
-public class ObjectArrayAssert_hasExactlyElementsOfTypes_Test extends ObjectArrayAssertBaseTest
+/**
+ * Tests for <code>{@link ObjectArrayAssert#hasExactlyElementsOfTypes(Class...)} </code>.
+ */
+class ObjectArrayAssert_hasExactlyElementsOfTypes_Test extends ObjectArrayAssertBaseTest
 {
+  private final Class<?>[] types = { Integer.class };
+
   @Override
   protected ObjectArrayAssert<Object> invoke_api_method()
   {
-    return assertions.hasExactlyElementsOfTypes(Integer.class);
+    return assertions.hasExactlyElementsOfTypes(types);
   }
 
   @Override
   protected void verify_internal_effects()
   {
-    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), getActual(assertions), Integer.class);
+    verify(arrays).assertHasExactlyElementsOfTypes(getInfo(assertions), getActual(assertions), types);
   }
 }

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
@@ -14,11 +14,15 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ObjectArrays;
 import org.assertj.core.internal.ObjectArraysBaseTest;
 import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.jupiter.api.Test;
 
-public class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBaseTest
+/**
+ * Tests for <code>{@link ObjectArrays#assertHasExactlyElementsOfTypes(AssertionInfo, Object[], Class...)}</code>.
+ */
+class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBaseTest
 {
   private static final Object[] arrayOfObjects = {"a", 'b', new LinkedList<>(), 10L};
 

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
@@ -1,0 +1,92 @@
+package org.assertj.core.internal.objectarrays;
+
+import java.util.LinkedList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
+import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.Arrays.asList;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ObjectArraysBaseTest;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.junit.jupiter.api.Test;
+
+public class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBaseTest
+{
+  private static final Object[] arrayOfObjects = {"a", 'b', new LinkedList<>(), 10L};
+
+  @Test
+  void should_pass_if_actual_has_exactly_elements_of_the_expected_types_in_order()
+  {
+    arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, Character.class, LinkedList.class, Long.class);
+  }
+
+  @Test
+  void should_fail_if_actual_is_null()
+  {
+    // GIVEN
+    Object[] array = null;
+    // GIVEN
+    AssertionError error = expectAssertionError(() -> arrays.assertHasExactlyElementsOfTypes(someInfo(), array, String.class));
+    // THEN
+    assertThat(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_one_element_in_actual_does_not_belong_to_the_expected_type() {
+    // GIVEN
+    AssertionError error = expectAssertionError(() -> arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects,
+      String.class, Character.class, LinkedList.class, Double.class));
+    // THEN
+    Object[] expected = {String.class, Character.class, LinkedList.class, Double.class};
+    assertThat(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(Double.class),newArrayList(Long.class)).create());
+  }
+
+  @Test
+  void should_fail_if_types_of_elements_are_not_in_the_same_order_as_expected()
+  {
+    AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() -> arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects,
+      Character.class, String.class, LinkedList.class, Long.class));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+
+    verify(failures).failure(info, elementsDifferAtIndex(String.class, Character.class, 0));
+  }
+
+  @Test
+  void should_fail_if_actual_has_more_elements_than_expected()
+  {
+    AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() -> arrays.assertHasExactlyElementsOfTypes(info, arrayOfObjects,String.class, Character.class));
+    Object[] expected = {String.class, Character.class};
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info, shouldContainExactly(arrayOfObjects, asList(expected),
+      newArrayList(), newArrayList(LinkedList.class, Long.class),
+      StandardComparisonStrategy.instance()));
+  }
+
+  @Test
+  void should_fail_if_actual_contains_all_types_but_has_less_elements_than_expected()
+  {
+    AssertionInfo info = someInfo();
+
+    Throwable error = catchThrowable(() ->
+      arrays.assertHasExactlyElementsOfTypes(info, arrayOfObjects,String.class, Character.class,LinkedList.class, Long.class, Long.class));
+    Object[] expected = {String.class, Character.class,LinkedList.class, Long.class, Long.class};
+    assertThat(error).isInstanceOf(AssertionError.class);
+
+    verify(failures).failure(info, shouldContainExactly(arrayOfObjects, asList(expected),
+      newArrayList(Long.class), newArrayList(),
+      StandardComparisonStrategy.instance()));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
@@ -43,7 +43,7 @@ class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBase
   }
 
   @Test
-  void should_fail_if_one_element_in_actual_does_not_belong_to_the_expected_type() {
+  void should_fail_if_one_element_in_actual_does_not_have_the_expected_type() {
     // WHEN
     AssertionError error = expectAssertionError(() ->
       arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Double.class));
@@ -74,7 +74,7 @@ class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBase
   }
 
   @Test
-  void should_fail_if_actual_contains_all_types_but_has_less_elements_than_expected()
+  void should_fail_if_actual_elements_types_are_found_but_there_are_not_enough_expected_type_elements()
   {
     // WHEN
     AssertionError error = expectAssertionError(() ->
@@ -89,13 +89,13 @@ class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBase
   // ------------------------------------------------------------------------------------------------------------------
 
   @Test
-  void should_pass_if_actual_has_exactly_elements_of_the_expected_types_in_order_according_to_custom_comparison_strategy()
+  void should_pass_if_actual_has_exactly_elements_of_the_expected_types_whatever_the_custom_comparison_strategy_is()
   {
     arraysWithCustomComparisonStrategy.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Long.class);
   }
 
   @Test
-  void should_fail_if_one_element_in_actual_does_not_belong_to_the_expected_type_according_to_custom_comparison_strategy() {
+  void should_fail_if_one_element_in_actual_does_not_have_the_expected_type_whatever_the_custom_comparison_strategy_is() {
     // WHEN
     AssertionError error = expectAssertionError(() ->
       arraysWithCustomComparisonStrategy.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Double.class));
@@ -105,7 +105,7 @@ class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBase
   }
 
   @Test
-  void should_fail_if_types_of_elements_are_not_in_the_same_order_as_expected_according_to_custom_comparison_strategy()
+  void should_fail_if_types_of_elements_are_not_in_the_same_order_as_expected_whatever_the_custom_comparison_strategy_is()
   {
     // WHEN
     AssertionError error = expectAssertionError(() ->
@@ -115,7 +115,7 @@ class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBase
   }
 
   @Test
-  void should_fail_if_actual_contains_all_types_but_has_less_elements_than_expected_according_to_custom_comparison_strategy()
+  void should_fail_if_actual_elements_types_are_found_but_there_are_not_enough_expected_type_elements_whatever_the_custom_comparison_strategy_is()
   {
     // WHEN
     AssertionError error = expectAssertionError(() ->

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertHasExactlyElementsOfTypes_Test.java
@@ -1,9 +1,6 @@
 package org.assertj.core.internal.objectarrays;
 
-import java.util.LinkedList;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.test.TestData.someInfo;
@@ -11,7 +8,6 @@ import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.internal.ObjectArrays;
@@ -19,17 +15,19 @@ import org.assertj.core.internal.ObjectArraysBaseTest;
 import org.assertj.core.internal.StandardComparisonStrategy;
 import org.junit.jupiter.api.Test;
 
+import java.util.LinkedList;
+
 /**
  * Tests for <code>{@link ObjectArrays#assertHasExactlyElementsOfTypes(AssertionInfo, Object[], Class...)}</code>.
  */
 class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBaseTest
 {
-  private static final Object[] arrayOfObjects = {"a", 'b', new LinkedList<>(), 10L};
+  private static final Object[] arrayOfObjects = {"a", new LinkedList<>(),10L};
 
   @Test
   void should_pass_if_actual_has_exactly_elements_of_the_expected_types_in_order()
   {
-    arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, Character.class, LinkedList.class, Long.class);
+    arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Long.class);
   }
 
   @Test
@@ -37,60 +35,93 @@ class ObjectArrays_assertHasExactlyElementsOfTypes_Test extends ObjectArraysBase
   {
     // GIVEN
     Object[] array = null;
-    // GIVEN
-    AssertionError error = expectAssertionError(() -> arrays.assertHasExactlyElementsOfTypes(someInfo(), array, String.class));
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arrays.assertHasExactlyElementsOfTypes(someInfo(), array, String.class));
     // THEN
-    assertThat(error).hasMessage(actualIsNull());
+    then(error).hasMessage(actualIsNull());
   }
 
   @Test
   void should_fail_if_one_element_in_actual_does_not_belong_to_the_expected_type() {
-    // GIVEN
-    AssertionError error = expectAssertionError(() -> arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects,
-      String.class, Character.class, LinkedList.class, Double.class));
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Double.class));
     // THEN
-    Object[] expected = {String.class, Character.class, LinkedList.class, Double.class};
-    assertThat(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(Double.class),newArrayList(Long.class)).create());
+    Class<?>[] expected = {String.class, LinkedList.class, Double.class};
+    then(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(Double.class),newArrayList(Long.class)).create());
   }
 
   @Test
   void should_fail_if_types_of_elements_are_not_in_the_same_order_as_expected()
   {
-    AssertionInfo info = someInfo();
-
-    Throwable error = catchThrowable(() -> arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects,
-      Character.class, String.class, LinkedList.class, Long.class));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-
-    verify(failures).failure(info, elementsDifferAtIndex(String.class, Character.class, 0));
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, LinkedList.class, String.class, Long.class));
+    // THEN
+    then(error).hasMessage(elementsDifferAtIndex(String.class, LinkedList.class,0).create());
   }
 
   @Test
   void should_fail_if_actual_has_more_elements_than_expected()
   {
-    AssertionInfo info = someInfo();
-
-    Throwable error = catchThrowable(() -> arrays.assertHasExactlyElementsOfTypes(info, arrayOfObjects,String.class, Character.class));
-    Object[] expected = {String.class, Character.class};
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, shouldContainExactly(arrayOfObjects, asList(expected),
-      newArrayList(), newArrayList(LinkedList.class, Long.class),
-      StandardComparisonStrategy.instance()));
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class));
+    // THEN
+    Class<?>[] expected = {String.class};
+    then(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(), newArrayList(LinkedList.class, Long.class)).create());
   }
 
   @Test
   void should_fail_if_actual_contains_all_types_but_has_less_elements_than_expected()
   {
-    AssertionInfo info = someInfo();
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arrays.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Long.class, Long.class));
+    // THEN
+    Class<?>[] expected = {String.class, LinkedList.class, Long.class, Long.class};
+    then(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(Long.class), newArrayList()).create());
+  }
 
-    Throwable error = catchThrowable(() ->
-      arrays.assertHasExactlyElementsOfTypes(info, arrayOfObjects,String.class, Character.class,LinkedList.class, Long.class, Long.class));
-    Object[] expected = {String.class, Character.class,LinkedList.class, Long.class, Long.class};
-    assertThat(error).isInstanceOf(AssertionError.class);
+  // ------------------------------------------------------------------------------------------------------------------
+  // tests using a custom comparison strategy
+  // ------------------------------------------------------------------------------------------------------------------
 
-    verify(failures).failure(info, shouldContainExactly(arrayOfObjects, asList(expected),
-      newArrayList(Long.class), newArrayList(),
-      StandardComparisonStrategy.instance()));
+  @Test
+  void should_pass_if_actual_has_exactly_elements_of_the_expected_types_in_order_according_to_custom_comparison_strategy()
+  {
+    arraysWithCustomComparisonStrategy.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Long.class);
+  }
+
+  @Test
+  void should_fail_if_one_element_in_actual_does_not_belong_to_the_expected_type_according_to_custom_comparison_strategy() {
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arraysWithCustomComparisonStrategy.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Double.class));
+    // THEN
+    Class<?>[] expected = {String.class, LinkedList.class, Double.class};
+    then(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(Double.class), newArrayList(Long.class), StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_fail_if_types_of_elements_are_not_in_the_same_order_as_expected_according_to_custom_comparison_strategy()
+  {
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arraysWithCustomComparisonStrategy.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, LinkedList.class, String.class, Long.class));
+    // THEN
+    then(error).hasMessage(elementsDifferAtIndex(String.class, LinkedList.class,0, StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_all_types_but_has_less_elements_than_expected_according_to_custom_comparison_strategy()
+  {
+    // WHEN
+    AssertionError error = expectAssertionError(() ->
+      arraysWithCustomComparisonStrategy.assertHasExactlyElementsOfTypes(someInfo(), arrayOfObjects, String.class, LinkedList.class, Long.class, Long.class));
+    // THEN
+    Class<?>[] expected = {String.class, LinkedList.class, Long.class, Long.class};
+    then(error).hasMessage(shouldContainExactly(arrayOfObjects, asList(expected), newArrayList(Long.class), newArrayList(), StandardComparisonStrategy.instance()).create());
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #1907 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* Implemented the `hasExactlyElementsOfTypes` (in `AbstractIterableAssert`, `AbstractObjectArrayAssert`, and `AtomicReferenceArrayAssert`)which calls `assertHasExactlyElementsOfTypes`. The comparison is made by extracting a  List<Object> having the classes of each variable and check if the values have the same types. If so, check whether they are in the correct order.
* Test: added tests for invoking api method and verifying the internal effects. Also, tests of `assertHasExactlyElementsOfTypes` including multiple cases are added.


