### PR TITLE
 fix issue 971:to have ability to ignore all assert when expected value is null

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -169,6 +169,8 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
+
   /**
    * Create assertion for {@link IntPredicate}.
    *
@@ -182,6 +184,33 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
+   * Create conditional assertion for {@link IntPredicate}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(IntPredicateAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link IntPredicate}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(IntPredicateAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
+
+  /**
    * Create assertion for {@link LongPredicate}.
    *
    * @param actual the actual value.
@@ -192,7 +221,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static LongPredicateAssert assertThat(LongPredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link LongPredicate}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(LongPredicateAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LongPredicate}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(LongPredicateAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link DoublePredicate}.
    *
@@ -204,7 +257,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static DoublePredicateAssert assertThat(DoublePredicate actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link DoublePredicate}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(DoublePredicateAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link DoublePredicate}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(DoublePredicateAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link java.util.concurrent.CompletableFuture}.
    *
@@ -253,6 +330,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static OptionalDoubleAssert assertThat(OptionalDouble actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link java.util.OptionalDouble}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(OptionalDoubleAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link java.util.OptionalDouble}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(OptionalDoubleAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Create assertion for {@link java.util.OptionalInt}.
@@ -264,7 +366,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static OptionalIntAssert assertThat(OptionalInt actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link java.util.OptionalInt}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(OptionalIntAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link java.util.OptionalInt}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(OptionalIntAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link java.util.OptionalInt}.
    *
@@ -275,6 +401,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static OptionalLongAssert assertThat(OptionalLong actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link java.util.OptionalInt}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(OptionalLongAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link java.util.OptionalInt}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(OptionalLongAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link BigDecimalAssert}</code>.
@@ -282,8 +433,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static BigDecimalAssert assertThat(BigDecimal actual) {
+  public static AbstractBigDecimalAssert<?> assertThat(BigDecimal actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link BigDecimalAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractBigDecimalAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link BigDecimalAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractBigDecimalAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -293,28 +469,135 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 2.7.0 / 3.7.0
    */
-  public static BigIntegerAssert assertThat(BigInteger actual) {
+  public static AbstractBigIntegerAssert<?> assertThat(BigInteger actual) {
     return new BigIntegerAssert(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link BigIntegerAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractBigIntegerAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link BigIntegerAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractBigIntegerAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link UriAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static UriAssert assertThat(URI actual) {
+  public static AbstractUriAssert<?> assertThat(URI actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link UriAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractUriAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link UriAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractUriAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link UrlAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static UrlAssert assertThat(URL actual) {
+  public static AbstractUrlAssert<?> assertThat(URL actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link UrlAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractUrlAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link UrlAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractUrlAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+  /**
+   * Creates a new instance of <code>{@link BooleanAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractBooleanAssert<?> assertThat(boolean actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link BooleanAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractBooleanAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link BooleanAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractBooleanAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -323,19 +606,10 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static BooleanAssert assertThat(boolean actual) {
+  public static AbstractBooleanAssert<?> assertThat(Boolean actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
-  /**
-   * Creates a new instance of <code>{@link BooleanAssert}</code>.
-   *
-   * @param actual the actual value.
-   * @return the created assertion object.
-   */
-  public static BooleanAssert assertThat(Boolean actual) {
-    return AssertionsForClassTypes.assertThat(actual);
-  }
 
   /**
    * Creates a new instance of <code>{@link BooleanArrayAssert}</code>.
@@ -343,9 +617,35 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static BooleanArrayAssert assertThat(boolean[] actual) {
+  public static AbstractBooleanArrayAssert<?> assertThat(boolean[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link BooleanArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractBooleanArrayAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link BooleanArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractBooleanArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Creates a new instance of <code>{@link Boolean2DArrayAssert}</code>.
@@ -357,15 +657,30 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Boolean2DArrayAssert assertThat(boolean[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
   /**
-   * Creates a new instance of <code>{@link ByteAssert}</code>.
-   *
-   * @param actual the actual value.
-   * @return the created assertion object.
+   * Create conditional assertion for {@link Boolean2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
    */
-  public static ByteAssert assertThat(byte actual) {
-    return AssertionsForClassTypes.assertThat(actual);
+  public static void conditionalAssertThat(Boolean2DArrayAssert  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Boolean2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Boolean2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -374,9 +689,45 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ByteAssert assertThat(Byte actual) {
+  public static AbstractByteAssert<?> assertThat(byte actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link ByteAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractByteAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ByteAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractByteAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
+  /**
+   * Creates a new instance of <code>{@link ByteAssert}</code>.
+   *
+   * @param actual the actual value.
+   * @return the created assertion object.
+   */
+  public static AbstractByteAssert<?> assertThat(Byte actual) {
+    return AssertionsForClassTypes.assertThat(actual);
+  }
+
 
   /**
    * Creates a new instance of <code>{@link ByteArrayAssert}</code>.
@@ -384,8 +735,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ByteArrayAssert assertThat(byte[] actual) {
+  public static AbstractByteArrayAssert<?> assertThat(byte[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link ByteArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractByteArrayAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ByteArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractByteArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -398,6 +774,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Byte2DArrayAssert assertThat(byte[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link Byte2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Byte2DArrayAssert  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Byte2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Byte2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link CharacterAssert}</code>.
@@ -405,18 +806,67 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static CharacterAssert assertThat(char actual) {
+  public static AbstractCharacterAssert<?> assertThat(char actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link CharacterAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractCharacterAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link CharacterAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractCharacterAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link CharArrayAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static CharArrayAssert assertThat(char[] actual) {
+  public static AbstractCharArrayAssert<?> assertThat(char[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link CharArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractCharArrayAssert<?>  argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link CharArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractCharArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -429,6 +879,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Char2DArrayAssert assertThat(char[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link Char2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Char2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Char2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Char2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link CharacterAssert}</code>.
@@ -436,7 +911,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static CharacterAssert assertThat(Character actual) {
+  public static AbstractCharacterAssert<?> assertThat(Character actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -449,15 +924,64 @@ public class Assertions implements InstanceOfAssertFactories {
   public static ClassAssert assertThat(Class<?> actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link ClassAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(ClassAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ClassAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(ClassAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link DoubleAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static DoubleAssert assertThat(double actual) {
+  public static AbstractDoubleAssert<?> assertThat(double actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link DoubleAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractDoubleAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link DoubleAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractDoubleAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -466,7 +990,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static DoubleAssert assertThat(Double actual) {
+  public static AbstractDoubleAssert<?> assertThat(Double actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -476,10 +1000,34 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static DoubleArrayAssert assertThat(double[] actual) {
+  public static AbstractDoubleArrayAssert<?> assertThat(double[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link DoubleArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractDoubleArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link DoubleArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractDoubleArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link Double2DArrayAssert}</code>.
    *
@@ -490,6 +1038,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Double2DArrayAssert assertThat(double[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link Double2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Double2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Double2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Double2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link FileAssert}</code>.
@@ -497,8 +1070,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static FileAssert assertThat(File actual) {
+  public static AbstractFileAssert<?> assertThat(File actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link FileAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractFileAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link FileAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractFileAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -520,8 +1118,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static InputStreamAssert assertThat(InputStream actual) {
+  public static AbstractInputStreamAssert<?, ? extends InputStream> assertThat(InputStream actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link InputStreamAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractInputStreamAssert<?, ? extends InputStream> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link InputStreamAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractInputStreamAssert<?, ? extends InputStream> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -530,19 +1153,44 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static FloatAssert assertThat(float actual) {
+  public static AbstractFloatAssert<?> assertThat(float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link FloatAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractFloatAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link FloatAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractFloatAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link FloatAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static FloatAssert assertThat(Float actual) {
+  public static AbstractFloatAssert<?> assertThat(Float actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+
 
   /**
    * Creates a new instance of <code>{@link FloatArrayAssert}</code>.
@@ -550,8 +1198,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static FloatArrayAssert assertThat(float[] actual) {
+  public static AbstractFloatArrayAssert<?> assertThat(float[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link FloatArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractFloatArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link FloatArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractFloatArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -560,8 +1233,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static IntegerAssert assertThat(int actual) {
+  public static AbstractIntegerAssert<?> assertThat(int actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link IntegerAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractIntegerAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link IntegerAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractIntegerAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -570,8 +1268,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static IntArrayAssert assertThat(int[] actual) {
+  public static AbstractIntArrayAssert<?> assertThat(int[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link IntArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractIntArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link IntArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractIntArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -584,6 +1307,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Int2DArrayAssert assertThat(int[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link Int2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Int2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Int2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Int2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link Float2DArrayAssert}</code>.
@@ -595,6 +1343,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Float2DArrayAssert assertThat(float[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link Float2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Float2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Float2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Float2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link IntegerAssert}</code>.
@@ -602,18 +1375,19 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static IntegerAssert assertThat(Integer actual) {
+  public static AbstractIntegerAssert<?> assertThat(Integer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+
 
   /**
    * Creates a new instance of <code>{@link FactoryBasedNavigableIterableAssert}</code> allowing to navigate to any {@code Iterable} element
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link IterableAssert#first() first()}</li>
-   * <li>{@link IterableAssert#last() last()}</li>
-   * <li>{@link IterableAssert#element(int) element(index)}</li>
+   * <li>{@link AbstractIterableAssert#first() first()}</li>
+   * <li>{@link AbstractIterableAssert#last() last()}</li>
+   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -650,14 +1424,15 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual, assertFactory);
   }
 
+
   /**
    * Creates a new instance of <code>{@link ClassBasedNavigableIterableAssert}</code> allowing to navigate to any {@code Iterable} element
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link IterableAssert#first() first()}</li>
-   * <li>{@link IterableAssert#last() last()}</li>
-   * <li>{@link IterableAssert#element(int) element(index)}</li>
+   * <li>{@link AbstractIterableAssert#first() first()}</li>
+   * <li>{@link AbstractIterableAssert#last() last()}</li>
+   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -690,9 +1465,9 @@ public class Assertions implements InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link IterableAssert#first() first()}</li>
-   * <li>{@link IterableAssert#last() last()}</li>
-   * <li>{@link IterableAssert#element(int) element(index)}</li>
+   * <li>{@link AbstractIterableAssert#first() first()}</li>
+   * <li>{@link AbstractIterableAssert#last() last()}</li>
+   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the {@code ELEMENT_ASSERT} parameter of the given
@@ -733,9 +1508,9 @@ public class Assertions implements InstanceOfAssertFactories {
    * in order to perform assertions on it.
    * <p>
    * Navigational methods provided:<ul>
-   * <li>{@link IterableAssert#first() first()}</li>
-   * <li>{@link IterableAssert#last() last()}</li>
-   * <li>{@link IterableAssert#element(int) element(index)}</li>
+   * <li>{@link AbstractIterableAssert#first() first()}</li>
+   * <li>{@link AbstractIterableAssert#last() last()}</li>
+   * <li>{@link AbstractIterableAssert#element(int) element(index)}</li>
    * </ul>
    * <p>
    * The available assertions after navigating to an element depend on the given {@code assertClass}
@@ -771,8 +1546,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static LongAssert assertThat(long actual) {
+  public static AbstractLongAssert<?> assertThat(long actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link LongAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractLongAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LongAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractLongAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -781,7 +1581,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static LongAssert assertThat(Long actual) {
+  public static AbstractLongAssert<?> assertThat(Long actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -791,8 +1591,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static LongArrayAssert assertThat(long[] actual) {
+  public static AbstractLongArrayAssert<?> assertThat(long[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link LongArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractLongArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LongArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractLongArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -804,6 +1629,31 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static Long2DArrayAssert assertThat(long[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link Long2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Long2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Long2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Long2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -846,8 +1696,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ShortAssert assertThat(short actual) {
+  public static AbstractShortAssert<?> assertThat(short actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link ShortAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractShortAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ShortAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractShortAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -856,7 +1731,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ShortAssert assertThat(Short actual) {
+  public static AbstractShortAssert<?> assertThat(Short actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -866,8 +1741,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ShortArrayAssert assertThat(short[] actual) {
+  public static AbstractShortArrayAssert<?> assertThat(short[] actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link ShortArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractShortArrayAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ShortArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractShortArrayAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -880,6 +1780,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static Short2DArrayAssert assertThat(short[][] actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link Short2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(Short2DArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link Short2DArrayAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(Short2DArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link DateAssert}</code>.
@@ -887,18 +1812,67 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static DateAssert assertThat(Date actual) {
+  public static AbstractDateAssert<?> assertThat(Date actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link DateAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractDateAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link DateAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractDateAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Creates a new instance of <code>{@link ZonedDateTimeAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static ZonedDateTimeAssert assertThat(ZonedDateTime actual) {
+  public static AbstractZonedDateTimeAssert<?> assertThat(ZonedDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link ZonedDateTimeAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractZonedDateTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ZonedDateTimeAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractZonedDateTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -907,8 +1881,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static LocalDateTimeAssert assertThat(LocalDateTime actual) {
+  public static AbstractLocalDateTimeAssert<?> assertThat(LocalDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link LocalDateTimeAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractLocalDateTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LocalDateTimeAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractLocalDateTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -917,18 +1916,67 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static OffsetDateTimeAssert assertThat(OffsetDateTime actual) {
+  public static AbstractOffsetDateTimeAssert<?> assertThat(OffsetDateTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link java.time.OffsetDateTime}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractOffsetDateTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link java.time.OffsetDateTime}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractOffsetDateTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link java.time.OffsetTime}.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static OffsetTimeAssert assertThat(OffsetTime actual) {
+  public static AbstractOffsetTimeAssert<?> assertThat(OffsetTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link java.time.OffsetTime}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractOffsetTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link java.time.OffsetDateTime}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractOffsetTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -937,8 +1985,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static LocalTimeAssert assertThat(LocalTime actual) {
+  public static AbstractLocalTimeAssert<?> assertThat(LocalTime actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link LocalTimeAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractLocalTimeAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LocalTimeAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractLocalTimeAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -947,8 +2020,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static LocalDateAssert assertThat(LocalDate actual) {
+  public static AbstractLocalDateAssert<?> assertThat(LocalDate actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link LocalDateAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractLocalDateAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LocalDateAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractLocalDateAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -958,8 +2056,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.7.0
    */
-  public static InstantAssert assertThat(Instant actual) {
+  public static AbstractInstantAssert<?> assertThat(Instant actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link InstantAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractInstantAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link InstantAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractInstantAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -969,9 +2092,35 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.15.0
    */
-  public static DurationAssert assertThat(Duration actual) {
+  public static AbstractDurationAssert<?> assertThat(Duration actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link DurationAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractDurationAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link DurationAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractDurationAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Creates a new instance of <code>{@link PeriodAssert}</code>.
@@ -980,10 +2129,34 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.17.0
    */
-  public static PeriodAssert assertThat(Period actual) {
+  public static AbstractPeriodAssert<?> assertThat(Period actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link PeriodAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractPeriodAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link PeriodAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractPeriodAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link AtomicBoolean}.
    *
@@ -993,6 +2166,31 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicBooleanAssert assertThat(AtomicBoolean actual) {
     return new AtomicBooleanAssert(actual);
+  }
+  /**
+   * Create conditional assertion for {@link AtomicBoolean}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AtomicBooleanAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link AtomicBoolean}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AtomicBooleanAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1005,7 +2203,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static AtomicIntegerAssert assertThat(AtomicInteger actual) {
     return new AtomicIntegerAssert(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link AtomicInteger}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AtomicIntegerAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link AtomicInteger}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AtomicIntegerAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create int[] assertion for {@link AtomicIntegerArray}.
    *
@@ -1015,6 +2237,31 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicIntegerArrayAssert assertThat(AtomicIntegerArray actual) {
     return new AtomicIntegerArrayAssert(actual);
+  }
+  /**
+   * Create conditional assertion for {@link AtomicIntegerArray}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AtomicIntegerArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link AtomicIntegerArray}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AtomicIntegerArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1039,7 +2286,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static LongAdderAssert assertThat(LongAdder actual) {
     return new LongAdderAssert(actual);
   }
-
+  /**
+   * Create conditional assertion for {@link LongAdder}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(LongAdderAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link LongAdder}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(LongAdderAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
   /**
    * Create assertion for {@link AtomicLong}.
    *
@@ -1049,6 +2320,31 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicLongAssert assertThat(AtomicLong actual) {
     return new AtomicLongAssert(actual);
+  }
+  /**
+   * Create conditional assertion for {@link AtomicLong}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AtomicLongAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link AtomicLong}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AtomicLongAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1060,6 +2356,31 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static AtomicLongArrayAssert assertThat(AtomicLongArray actual) {
     return new AtomicLongArrayAssert(actual);
+  }
+  /**
+   * Create conditional assertion for {@link AtomicLongArray}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AtomicLongArrayAssert argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link AtomicLongArray}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AtomicLongArrayAssert argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1141,8 +2462,33 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created {@link ThrowableAssert}.
    */
-  public static ThrowableAssert assertThat(Throwable actual) {
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThat(Throwable actual) {
     return AssertionsForClassTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link ThrowableAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractThrowableAssert<?, ? extends Throwable> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link ThrowableAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractThrowableAssert<?, ? extends Throwable> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -1174,7 +2520,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    */
   @CanIgnoreReturnValue
-  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).hasBeenThrown();
   }
 
@@ -1211,7 +2557,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @since 3.9.0
    */
   @CanIgnoreReturnValue
-  public static ThrowableAssert assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownBy(ThrowingCallable shouldRaiseThrowable,
                                                                                    String description, Object... args) {
     return assertThat(catchThrowable(shouldRaiseThrowable)).as(description, args).hasBeenThrown();
   }
@@ -1251,7 +2597,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created {@link ThrowableAssert}.
    * @since 3.7.0
    */
-  public static ThrowableAssert assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
+  public static AbstractThrowableAssert<?, ? extends Throwable> assertThatCode(ThrowingCallable shouldRaiseOrNotThrowable) {
     return AssertionsForClassTypes.assertThatCode(shouldRaiseOrNotThrowable);
   }
 
@@ -1519,6 +2865,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return nothing, it's just to be used in doSomething(optional.orElse(() -&gt; failBecauseExceptionWasNotThrown(IOException.class)));.
    * @throws AssertionError with a message explaining that a {@link Throwable} of given class was expected to be thrown but had
    *           not been.
+   *
    */
   @CanIgnoreReturnValue
   public static <T> T failBecauseExceptionWasNotThrown(Class<? extends Throwable> throwableClass) {
@@ -1613,6 +2960,7 @@ public class Assertions implements InstanceOfAssertFactories {
   public static void setDescriptionConsumer(Consumer<Description> descriptionConsumer) {
     AbstractAssert.setDescriptionConsumer(descriptionConsumer);
   }
+
 
   /**
    * Sets how many stacktrace elements are included in {@link Throwable} representation (by default this set to 3).
@@ -2822,7 +4170,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static CharSequenceAssert assertThat(CharSequence actual) {
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(CharSequence actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
@@ -2833,7 +4181,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static CharSequenceAssert assertThat(StringBuilder actual) {
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuilder actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -2844,7 +4192,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the created assertion object.
    * @since 3.11.0
    */
-  public static CharSequenceAssert assertThat(StringBuffer actual) {
+  public static AbstractCharSequenceAssert<?, ? extends CharSequence> assertThat(StringBuffer actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
 
@@ -2854,9 +4202,35 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static StringAssert assertThat(String actual) {
+  public static AbstractStringAssert<?> assertThat(String actual) {
     return AssertionsForClassTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link StringAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractStringAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link StringAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractStringAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
+
 
   /**
    * Creates a new instance of <code>{@link IterableAssert}</code>.
@@ -2910,6 +4284,7 @@ public class Assertions implements InstanceOfAssertFactories {
   public static <ELEMENT> ListAssert<ELEMENT> assertThat(List<? extends ELEMENT> actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
+
 
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link Stream}.
@@ -2972,6 +4347,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link LongStream}.
    * <p>
@@ -3002,6 +4378,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of <code>{@link ListAssert}</code> from the given {@link IntStream}.
    * <p>
@@ -3031,6 +4408,31 @@ public class Assertions implements InstanceOfAssertFactories {
   public static ListAssert<Integer> assertThat(IntStream actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
+  /**
+   * Create conditional assertion for {@link IntStream}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(ListAssert<Integer> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link IntStream}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(ListAssert<Integer> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
+  }
 
   /**
    * Creates a new instance of <code>{@link SpliteratorAssert}</code> from the given {@link Spliterator}.
@@ -3048,14 +4450,40 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
+
   /**
    * Creates a new instance of {@link PathAssert}
    *
    * @param actual the path to test
    * @return the created assertion object
    */
-  public static PathAssert assertThat(Path actual) {
+  public static AbstractPathAssert<?> assertThat(Path actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
+  }
+  /**
+   * Create conditional assertion for {@link PathAssert}
+   * @param argument the return value of assertThat
+   * @param condition the condition
+   * @param expected  the expected value
+   */
+  public static void conditionalAssertThat(AbstractPathAssert<?> argument,boolean condition,Object expected) {
+    if (condition) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("condition is false");
+  }
+  /**
+   * Create not null assertion for {@link PathAssert}
+   * @param argument the return value of assertThat
+   * @param expected  the expected value
+   */
+  public static void notNullAssertThat(AbstractPathAssert<?> argument,Object expected) {
+    if (expected!=null) {
+      argument.isEqualTo(expected);
+      return;
+    }
+    System.out.println("expected is null");
   }
 
   /**
@@ -3081,7 +4509,7 @@ public class Assertions implements InstanceOfAssertFactories {
    * @param actual the actual value.
    * @return the created assertion object.
    */
-  public static <T extends Comparable<? super T>> GenericComparableAssert<T> assertThat(T actual) {
+  public static <T extends Comparable<? super T>> AbstractComparableAssert<?, T> assertThat(T actual) {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -42,6 +44,19 @@ class AbstractAssert_as_with_description_Test {
     assertions.as(d);
     assertThat(assertions.descriptionText()).isEqualTo(d.value());
   }
+  @Test
+  void should_set_description_condition() {
+    assertions.as(d);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),true,d.value());
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.as(d);
+    notNullAssertThat(assertThat(assertions.descriptionText()),d.value());
+  }
+
+
+
 
   @Test
   void should_return_this() {

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_text_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_as_with_text_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someTextDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -40,6 +42,16 @@ class AbstractAssert_as_with_text_description_Test {
   void should_set_description() {
     assertions.as(description);
     assertThat(assertions.descriptionText()).isEqualTo(description);
+  }
+  @Test
+  void should_set_description_condition() {
+    assertions.as(description);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),true,description);
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.as(description);
+    notNullAssertThat(assertThat(assertions.descriptionText()),description);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -41,6 +43,16 @@ class AbstractAssert_describedAs_with_description_Test {
   void should_set_description() {
     assertions.describedAs(description);
     assertThat(assertions.descriptionText()).isEqualTo(description.value());
+  }
+  @Test
+  void should_set_description_condition() {
+    assertions.describedAs(description);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),false,description.value());
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.describedAs(description);
+    notNullAssertThat(assertThat(assertions.descriptionText()),description.value());
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_text_description_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_describedAs_with_text_description_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.api.abstract_;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.conditionalAssertThat;
+import static org.assertj.core.api.Assertions.notNullAssertThat;
 import static org.assertj.core.test.TestData.someTextDescription;
 
 import org.assertj.core.api.AbstractAssert;
@@ -40,6 +42,16 @@ class AbstractAssert_describedAs_with_text_description_Test {
   void should_set_description() {
     assertions.describedAs(description);
     assertThat(assertions.descriptionText()).isEqualTo(description);
+  }
+  @Test
+  void should_set_description_condition() {
+    assertions.describedAs(description);
+    conditionalAssertThat(assertThat(assertions.descriptionText()),false,description);
+  }
+  @Test
+  void should_set_description_not_null() {
+    assertions.describedAs(description);
+    notNullAssertThat(assertThat(assertions.descriptionText()),description);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
@@ -12,12 +12,11 @@
  */
 package org.assertj.core.api.abstract_;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.ConcreteAssert;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests for <code>{@link AbstractAssert#equals(Object)}</code> and <code>{@link AbstractAssert#hashCode()}</code>.
@@ -45,5 +44,13 @@ class AbstractAssert_equal_hashCode_Test {
   @Test
   void shouldReturnOneAsHashCode() {
     assertThat(assertions.hashCode()).isEqualTo(1);
+  }
+  @Test
+  void shouldReturnOneAsHashCodeCondition() {
+    conditionalAssertThat(assertThat(assertions.hashCode()),true,1);
+  }
+  @Test
+  void shouldReturnOneAsHashCodeNotNull() {
+    notNullAssertThat(assertThat(assertions.hashCode()),1);
   }
 }


### PR DESCRIPTION
#### Check List:
* Fixes #971
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES 
In assertions.java, I add two methods for most types. The conditionalAssertThat method adds a boolean type argument, when it's false, the assertThat will be skipped. The notNullAssertThat method ask the argument called expected to not be null, if it's null, the assertThat will be skipped. Also, I add some tests to test these two methods.
I'm a student, and my ability to develop a project is poor. I just tried making a pull request. Maybe my pull request is totally wrong and doesn't meet your requirements. If it happens, I'm sorry about that and you can ignore my pull request and don't merge it.



