### PR TITLE
Fix 'toString' method of subclasses of AtomicReference isn't used for…

### DIFF
--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -252,7 +252,8 @@ public class StandardRepresentation implements Representation {
     try {
       Method method = object.getClass().getMethod("toString");
       Class<?> declaringClass = method.getDeclaringClass();
-      return object.getClass()==declaringClass;
+//      return object.getClass()==declaringClass;
+      return !Object.class.equals(declaringClass);
     } catch (NoSuchMethodException | SecurityException e) {
       // NoSuchMethodException should not occur as toString is always defined.
       // if SecurityException occurs, returning false will lead to format iterable

--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -111,7 +111,7 @@ public class StandardRepresentation implements Representation {
 
   private static final Map<Class<?>, Function<?, String>> customFormatterByType = new HashMap<>();
   private static final Class<?>[] TYPE_WITH_UNAMBIGUOUS_REPRESENTATION = { Date.class, LocalDateTime.class, ZonedDateTime.class,
-    OffsetDateTime.class, Calendar.class };
+      OffsetDateTime.class, Calendar.class };
 
   protected enum GroupType {
     ITERABLE("iterable"), ARRAY("array");
@@ -213,9 +213,14 @@ public class StandardRepresentation implements Representation {
     if (object instanceof OffsetDateTime) return toStringOf((OffsetDateTime) object);
     if (object instanceof ZonedDateTime) return toStringOf((ZonedDateTime) object);
     if (object instanceof LongAdder) return toStringOf((LongAdder) object);
-    if (object instanceof AtomicReference && !hasOverriddenToString(object)) return toStringOf((AtomicReference<?>) object);
-    if (object instanceof AtomicMarkableReference && !hasOverriddenToString(object)) return toStringOf((AtomicMarkableReference<?>) object);
-    if (object instanceof AtomicStampedReference && !hasOverriddenToString(object)) return toStringOf((AtomicStampedReference<?>) object);
+    if (object instanceof AtomicReference && !hasOverriddenToString(object) || object.getClass().equals(AtomicReference.class))
+      return toStringOf((AtomicReference<?>) object);
+    if (object instanceof AtomicMarkableReference && !hasOverriddenToString(object)
+        || object.getClass().equals(AtomicMarkableReference.class))
+      return toStringOf((AtomicMarkableReference<?>) object);
+    if (object instanceof AtomicStampedReference && !hasOverriddenToString(object)
+        || object.getClass().equals(AtomicStampedReference.class))
+      return toStringOf((AtomicStampedReference<?>) object);
     if (object instanceof AtomicIntegerFieldUpdater) return AtomicIntegerFieldUpdater.class.getSimpleName();
     if (object instanceof AtomicLongFieldUpdater) return AtomicLongFieldUpdater.class.getSimpleName();
     if (object instanceof AtomicReferenceFieldUpdater) return AtomicReferenceFieldUpdater.class.getSimpleName();
@@ -342,7 +347,7 @@ public class StandardRepresentation implements Representation {
   protected String toStringOf(ComparatorBasedComparisonStrategy comparatorBasedComparisonStrategy) {
     String comparatorDescription = comparatorBasedComparisonStrategy.getComparatorDescription();
     return comparatorDescription == null ? toStringOf(comparatorBasedComparisonStrategy.getComparator())
-      : quote(comparatorDescription);
+        : quote(comparatorDescription);
   }
 
   protected String toStringOf(Calendar calendar) {
@@ -472,7 +477,7 @@ public class StandardRepresentation implements Representation {
         pw.println("\tat " + elements[i]);
       }
       pw.print("\t...(" + (elements.length - maxStackTraceElementsDisplayed)
-        + " remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)");
+               + " remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)");
       return sw.toString();
     } finally {
       Closeables.closeQuietly(sw, pw);
@@ -484,13 +489,15 @@ public class StandardRepresentation implements Representation {
   }
 
   protected String toStringOf(AtomicMarkableReference<?> atomicMarkableReference) {
-    return String.format("%s[marked=%s, reference=%s]", atomicMarkableReference.getClass().getSimpleName(), atomicMarkableReference.isMarked(),
-      toStringOf(atomicMarkableReference.getReference()));
+    return String.format("%s[marked=%s, reference=%s]", atomicMarkableReference.getClass().getSimpleName(),
+                         atomicMarkableReference.isMarked(),
+                         toStringOf(atomicMarkableReference.getReference()));
   }
 
   protected String toStringOf(AtomicStampedReference<?> atomicStampedReference) {
-    return String.format("%s[stamp=%s, reference=%s]", atomicStampedReference.getClass().getSimpleName(), atomicStampedReference.getStamp(),
-      toStringOf(atomicStampedReference.getReference()));
+    return String.format("%s[stamp=%s, reference=%s]", atomicStampedReference.getClass().getSimpleName(),
+                         atomicStampedReference.getStamp(),
+                         toStringOf(atomicStampedReference.getReference()));
   }
 
   protected String multiLineFormat(Iterable<?> iterable) {
@@ -582,7 +589,7 @@ public class StandardRepresentation implements Representation {
   private List<String> representElements(Stream<?> elements, String start, String end, String elementSeparator,
                                          String indentation, Object root) {
     return elements.map(element -> safeStringOf(element, start, end, elementSeparator, indentation, root))
-      .collect(toList());
+                   .collect(toList());
   }
 
   // this method only deals with max number of elements to display, the elements representation is already computed
@@ -637,12 +644,12 @@ public class StandardRepresentation implements Representation {
 
   private String toStringOf(DeleteDelta<?> deleteDelta) {
     return String.format("Missing content at line %s:%n  %s%n", deleteDelta.lineNumber(),
-      formatLines(deleteDelta.getOriginal().getLines()));
+                         formatLines(deleteDelta.getOriginal().getLines()));
   }
 
   private String toStringOf(InsertDelta<?> insertDelta) {
     return String.format("Extra content at line %s:%n  %s%n", insertDelta.lineNumber(),
-      formatLines(insertDelta.getRevised().getLines()));
+                         formatLines(insertDelta.getRevised().getLines()));
   }
 
   private String toStringOf(Duration duration) {

--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -252,7 +252,6 @@ public class StandardRepresentation implements Representation {
     try {
       Method method = object.getClass().getMethod("toString");
       Class<?> declaringClass = method.getDeclaringClass();
-//      return object.getClass()==declaringClass;
       return !Object.class.equals(declaringClass);
     } catch (NoSuchMethodException | SecurityException e) {
       // NoSuchMethodException should not occur as toString is always defined.
@@ -631,9 +630,9 @@ public class StandardRepresentation implements Representation {
 
   private String toStringOf(ChangeDelta<?> changeDelta) {
     return String.format("Changed content at line %s:%nexpecting:%n  %s%nbut was:%n  %s%n",
-      changeDelta.lineNumber(),
-      formatLines(changeDelta.getOriginal().getLines()),
-      formatLines(changeDelta.getRevised().getLines()));
+                         changeDelta.lineNumber(),
+                         formatLines(changeDelta.getOriginal().getLines()),
+                         formatLines(changeDelta.getRevised().getLines()));
   }
 
   private String toStringOf(DeleteDelta<?> deleteDelta) {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomicReferences_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomicReferences_Test.java
@@ -38,7 +38,7 @@ public class StandardRepresentation_toStringOf_AtomicReferences_Test {
       }
     }
     // GIVEN
-    MyData myData = new MyData("Description");
+    Object myData = new MyData("Description");
     // WHEN
     String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
     // THEN
@@ -57,7 +57,7 @@ public class StandardRepresentation_toStringOf_AtomicReferences_Test {
       // has no overridden toString, use the predefined one
     }
     // GIVEN
-    MyData myData = new MyData("Description");
+    Object myData = new MyData("Description");
     // WHEN
     String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
     // THEN
@@ -80,7 +80,7 @@ public class StandardRepresentation_toStringOf_AtomicReferences_Test {
       }
     }
     // GIVEN
-    MyData myData = new MyData("Description");
+    Object myData = new MyData("Description");
     // WHEN
     String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
     // THEN
@@ -100,7 +100,7 @@ public class StandardRepresentation_toStringOf_AtomicReferences_Test {
       // has no overridden toString, use the predefined one which gives "%s[marked=%s, reference=%s]"
     }
     // GIVEN
-    MyData myData = new MyData("Description");
+    Object myData = new MyData("Description");
     // WHEN
     String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
     // THEN
@@ -123,7 +123,7 @@ public class StandardRepresentation_toStringOf_AtomicReferences_Test {
       }
     }
     // GIVEN
-    MyData myData = new MyData("Description");
+    Object myData = new MyData("Description");
     // WHEN
     String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
     // THEN
@@ -143,7 +143,7 @@ public class StandardRepresentation_toStringOf_AtomicReferences_Test {
       // has no overridden toString, use the predefined one which gives "%s[stamp=%s, reference=%s]"
     }
     // GIVEN
-    MyData myData = new MyData("Description");
+    Object myData = new MyData("Description");
     // WHEN
     String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
     // THEN

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomicReferences_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomicReferences_Test.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicMarkableReference;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicStampedReference;
 
-public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
+public class StandardRepresentation_toStringOf_AtomicReferences_Test {
 
   @Test
   public void should_use_overridden_toString_AtomicReference() {

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomiceReferences_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomiceReferences_Test.java
@@ -1,0 +1,153 @@
+package org.assertj.core.presentation;
+
+import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicMarkableReference;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicStampedReference;
+
+public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
+  static Representation standardRepresentation = new StandardRepresentation();
+
+  @Test
+  public void should_use_overridden_toString_AtomicReference(){
+    class MyData extends AtomicReference<String> {
+      private String description;
+
+      MyData(String description) {
+        this.description = description;
+      }
+
+      @Override
+      public String toString() {
+        return "MyData[" + description + "]";
+      }
+    }
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[Description]");
+  }
+
+  @Test
+  public void should_use_predefined_toString_AtomicReference(){
+    class MyData extends AtomicReference<String> {
+      private String description;
+
+      MyData(String description) {
+        this.description = description;
+      }
+
+      // has no overridden toString
+    }
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[null]");
+  }
+
+  @Test
+  public void should_use_overridden_toString_AtomicMarkableReference(){
+    class MyData extends AtomicMarkableReference<String> {
+      private String description;
+
+      MyData(String description) {
+        super(description, true);
+        this.description = description;
+      }
+
+      @Override
+      public String toString() {
+        return "MyData[" + description + "]";
+      }
+    }
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[Description]");
+  }
+
+  @Test
+  public void should_use_predefined_toString_AtomicMarkableReference(){
+    class MyData extends AtomicMarkableReference<String> {
+      private String description;
+
+      MyData(String description) {
+        super(description, true);
+        this.description = description;
+      }
+
+      // has no overridden toString
+    }
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[marked=true, reference=\"Description\"]");
+  }
+
+  @Test
+  public void should_use_overridden_toString_AtomicStampedReference(){
+    class MyData extends AtomicStampedReference<String> {
+      private String description;
+
+      MyData(String description) {
+        super(description, 0);
+        this.description = description;
+      }
+
+      @Override
+      public String toString() {
+        return "MyData[" + description + "]";
+      }
+    }
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[Description]");
+  }
+
+  @Test
+  public void should_use_predefined_toString_AtomicStampedReference(){
+    class MyData extends AtomicStampedReference<String> {
+      private String description;
+
+      MyData(String description) {
+        super(description, 0);
+        this.description = description;
+      }
+
+      // has no overridden toString
+    }
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[stamp=0, reference=\"Description\"]");
+  }
+
+  @Test
+  public void should_use_smartFormat(){
+    class MyIterable implements Iterable<String> {
+      ArrayList<String> arrayList;
+      public MyIterable(String[] strings) {
+        arrayList = new ArrayList<>(Arrays.asList(strings));
+      }
+
+      @Override
+      public Iterator<String> iterator() {
+        return arrayList.iterator();
+      }
+
+      // has no overridden toString
+    }
+    String[] strings = {"A", "B", "C"};
+    assertThat(standardRepresentation.toStringOf(new MyIterable(strings)))
+      .isEqualTo("[\"A\", \"B\", \"C\"]");
+  }
+
+  @Test
+  public void should_use_overridden_toString(){
+    class MyIterable implements Iterable<String> {
+      ArrayList<String> arrayList;
+      public MyIterable(String[] strings) {
+        arrayList = new ArrayList<>(Arrays.asList(strings));
+      }
+
+      @Override
+      public Iterator<String> iterator() {
+        return arrayList.iterator();
+      }
+
+      @Override
+      public String toString(){
+        return "MyIterable: " + arrayList;
+      }
+    }
+    String[] strings = {"A", "B", "C"};
+    assertThat(standardRepresentation.toStringOf(new MyIterable(strings)))
+      .isEqualTo("MyIterable: [A, B, C]");
+  }
+}

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomiceReferences_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomiceReferences_Test.java
@@ -14,17 +14,17 @@ package org.assertj.core.presentation;
 
 import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
-
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicMarkableReference;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicStampedReference;
 
 public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
-  static Representation standardRepresentation = new StandardRepresentation();
 
   @Test
-  public void should_use_overridden_toString_AtomicReference(){
+  public void should_use_overridden_toString_AtomicReference() {
     class MyData extends AtomicReference<String> {
       private String description;
 
@@ -37,11 +37,16 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
         return "MyData[" + description + "]";
       }
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[Description]");
+    // GIVEN
+    MyData myData = new MyData("Description");
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
+    // THEN
+    then(stringOf).isEqualTo("MyData[Description]");
   }
 
   @Test
-  public void should_use_predefined_toString_AtomicReference(){
+  public void should_use_predefined_toString_AtomicReference() {
     class MyData extends AtomicReference<String> {
       private String description;
 
@@ -49,13 +54,18 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
         this.description = description;
       }
 
-      // has no overridden toString
+      // has no overridden toString, use the predefined one
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("null");
+    // GIVEN
+    MyData myData = new MyData("Description");
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
+    // THEN
+    then(stringOf).isEqualTo("null");
   }
 
   @Test
-  public void should_use_overridden_toString_AtomicMarkableReference(){
+  public void should_use_overridden_toString_AtomicMarkableReference() {
     class MyData extends AtomicMarkableReference<String> {
       private String description;
 
@@ -69,11 +79,16 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
         return "MyData[" + description + "]";
       }
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[Description]");
+    // GIVEN
+    MyData myData = new MyData("Description");
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
+    // THEN
+    then(stringOf).isEqualTo("MyData[Description]");
   }
 
   @Test
-  public void should_use_predefined_toString_AtomicMarkableReference(){
+  public void should_use_predefined_toString_AtomicMarkableReference() {
     class MyData extends AtomicMarkableReference<String> {
       private String description;
 
@@ -82,13 +97,18 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
         this.description = description;
       }
 
-      // has no overridden toString
+      // has no overridden toString, use the predefined one which gives "%s[marked=%s, reference=%s]"
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[marked=true, reference=\"Description\"]");
+    // GIVEN
+    MyData myData = new MyData("Description");
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
+    // THEN
+    then(stringOf).isEqualTo("MyData[marked=true, reference=\"Description\"]");
   }
 
   @Test
-  public void should_use_overridden_toString_AtomicStampedReference(){
+  public void should_use_overridden_toString_AtomicStampedReference() {
     class MyData extends AtomicStampedReference<String> {
       private String description;
 
@@ -102,11 +122,16 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
         return "MyData[" + description + "]";
       }
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[Description]");
+    // GIVEN
+    MyData myData = new MyData("Description");
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
+    // THEN
+    then(stringOf).isEqualTo("MyData[Description]");
   }
 
   @Test
-  public void should_use_predefined_toString_AtomicStampedReference(){
+  public void should_use_predefined_toString_AtomicStampedReference() {
     class MyData extends AtomicStampedReference<String> {
       private String description;
 
@@ -115,15 +140,21 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
         this.description = description;
       }
 
-      // has no overridden toString
+      // has no overridden toString, use the predefined one which gives "%s[stamp=%s, reference=%s]"
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[stamp=0, reference=\"Description\"]");
+    // GIVEN
+    MyData myData = new MyData("Description");
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myData);
+    // THEN
+    then(stringOf).isEqualTo("MyData[stamp=0, reference=\"Description\"]");
   }
 
   @Test
-  public void should_use_smartFormat(){
+  public void should_use_smartFormat() {
     class MyIterable implements Iterable<String> {
       ArrayList<String> arrayList;
+
       public MyIterable(String[] strings) {
         arrayList = new ArrayList<>(Arrays.asList(strings));
       }
@@ -135,15 +166,20 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
 
       // has no overridden toString
     }
-    String[] strings = {"A", "B", "C"};
-    assertThat(standardRepresentation.toStringOf(new MyIterable(strings)))
-      .isEqualTo("[\"A\", \"B\", \"C\"]");
+    // GIVEN
+    String[] strings = { "A", "B", "C" };
+    MyIterable myIterable = new MyIterable(strings);
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myIterable);
+    // THEN
+    then(stringOf).isEqualTo("[\"A\", \"B\", \"C\"]");
   }
 
   @Test
-  public void should_use_overridden_toString(){
+  public void should_use_overridden_toString() {
     class MyIterable implements Iterable<String> {
       ArrayList<String> arrayList;
+
       public MyIterable(String[] strings) {
         arrayList = new ArrayList<>(Arrays.asList(strings));
       }
@@ -154,12 +190,16 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
       }
 
       @Override
-      public String toString(){
+      public String toString() {
         return "MyIterable: " + arrayList;
       }
     }
-    String[] strings = {"A", "B", "C"};
-    assertThat(standardRepresentation.toStringOf(new MyIterable(strings)))
-      .isEqualTo("MyIterable: [A, B, C]");
+    // GIVEN
+    String[] strings = { "A", "B", "C" };
+    MyIterable myIterable = new MyIterable(strings);
+    // WHEN
+    String stringOf = STANDARD_REPRESENTATION.toStringOf(myIterable);
+    // THEN
+    then(stringOf).isEqualTo("MyIterable: [A, B, C]");
   }
 }

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomiceReferences_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_toStringOf_AtomiceReferences_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
 package org.assertj.core.presentation;
 
 import org.junit.Test;
@@ -39,7 +51,7 @@ public class StandardRepresentation_toStringOf_AtomiceReferences_Test {
 
       // has no overridden toString
     }
-    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("MyData[null]");
+    assertThat(standardRepresentation.toStringOf(new MyData("Description"))).isEqualTo("null");
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes #2192 
* Unit tests : YES
* Javadoc with a code example (on API only) : NO

Thanks to the great help of all comments and my teammate @sustc11810424 

We modified `hasOverriddenToString` to check whether the declaring class of `toString` is the object's own class. Changes are applied to the three types of AtomicReferences mentioned,  with two tests for each. And two more tests are to make sure things still work for non-collection `Iterable`s.