### PR TITLE
Configure pitest

### DIFF
--- a/cdg-pitest-licence.txt
+++ b/cdg-pitest-licence.txt
@@ -1,0 +1,7 @@
+#Licence file for pitest git plugin
+#Tue May 04 09:26:47 BST 2021
+expires=04/05/2023
+keyVersion=1
+signature=D1RXTdu1ITmJhlRqssvVts6xi5xeyobnq4QCOeLHRuggH1sk4FECLCMPXPtAe0mkUPFI3kuioxmQcnGpm4Xol/Q3YnhI3bKZWjNNgl1XdW3SiGzKqYg/mzwXZeWPPSBQ5pl3Bf0SvcvcZaQaLzAWtgRtjRWqyuBGegASqDOqwGc\=
+packages=org.assertj.*
+type=OSSS

--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.pitest</groupId>
+        <artifactId>pitest-maven</artifactId>
+        <version>1.6.6</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-junit5-plugin</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+          </dependency>
+        </dependencies>
+        <configuration>
+          <threads>3</threads>
+          <timestampedReports>false</timestampedReports>
+          <failWhenNoMutations>false</failWhenNoMutations>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -671,6 +688,26 @@
       <properties>
         <argLine>-Dnet.bytebuddy.experimental=true --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED</argLine>
       </properties>
+    </profile>
+    <profile>
+      <id>pitest</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.pitest</groupId>
+            <artifactId>pitest-maven</artifactId>
+            <executions>
+              <execution>
+                <id>pitest</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>mutationCoverage</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <mockito.version>3.9.0</mockito.version>
     <!-- Plugin versions overriding -->
     <jacoco-maven-plugin.version>0.8.6</jacoco-maven-plugin.version>
+    <cdg.pitest.version>0.0.7</cdg.pitest.version>
   </properties>
 
   <dependencyManagement>
@@ -587,7 +588,12 @@
           <dependency>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-junit5-plugin</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>0.14</version>
+          </dependency>
+          <dependency>
+            <groupId>com.groupcdg</groupId>
+            <artifactId>pitest-git-plugin</artifactId>
+            <version>${cdg.pitest.version}</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -705,7 +705,7 @@
             <executions>
               <execution>
                 <id>pitest</id>
-                <phase>test</phase>
+                <phase>test-compile</phase>
                 <goals>
                   <goal>mutationCoverage</goal>
                 </goals>

--- a/src/main/java/org/assertj/core/api/DefaultAssertionErrorCollector.java
+++ b/src/main/java/org/assertj/core/api/DefaultAssertionErrorCollector.java
@@ -201,6 +201,7 @@ public class DefaultAssertionErrorCollector implements AssertionErrorCollector {
           || className.startsWith("com.intellij.rt.execution.junit.")
           || className.startsWith("com.intellij.rt.junit.") // since IntelliJ IDEA build 193.2956.37
           || className.startsWith("org.apache.maven.surefire")
+          || className.startsWith("org.pitest.")
           || className.startsWith("org.assertj")) {
         continue;
       }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_equal_hashCode_Test.java
@@ -39,7 +39,11 @@ class AbstractAssert_equal_hashCode_Test {
   @SuppressWarnings("deprecation")
   void should_not_fail_when_equals_exceptions_is_deactivated() {
     AbstractAssert.throwUnsupportedExceptionOnEquals = false;
-    assertions.equals("anotherString");
+    try {
+      assertions.equals("anotherString");
+    } finally {
+      AbstractAssert.throwUnsupportedExceptionOnEquals = true;
+    }
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_areEqual_Test.java
+++ b/src/test/java/org/assertj/core/internal/StandardComparisonStrategy_areEqual_Test.java
@@ -279,6 +279,18 @@ class StandardComparisonStrategy_areEqual_Test {
     then(result).isEqualTo(expected);
   }
 
+  @Test
+  void should_work_with_inconsistent_equals_methods() {
+    NonConsistent nonConsistentX = new NonConsistent();
+
+    boolean firstInvocation = underTest.areEqual(nonConsistentX, nonConsistentX);
+    then(firstInvocation).isEqualTo(true);
+    boolean secondInvocation = underTest.areEqual(nonConsistentX, nonConsistentX);
+    then(secondInvocation).isEqualTo(false);
+    boolean thirdInvocation = underTest.areEqual(nonConsistentX, nonConsistentX);
+    then(thirdInvocation).isEqualTo(true);
+  }
+
   private static Stream<Arguments> correctEquals() {
     Object object = new Object();
 
@@ -303,7 +315,6 @@ class StandardComparisonStrategy_areEqual_Test {
     NonTransitive nonTransitiveY = new NonTransitive(nonTransitiveZ, null);
     NonTransitive nonTransitiveX = new NonTransitive(nonTransitiveY, nonTransitiveZ);
 
-    NonConsistent nonConsistentX = new NonConsistent();
 
     return Stream.of(arguments(alwaysTrue, null, true),
                      arguments(alwaysFalse, alwaysFalse, false),
@@ -312,10 +323,7 @@ class StandardComparisonStrategy_areEqual_Test {
                      arguments(nonSymmetricY, nonSymmetricX, false),
                      arguments(nonTransitiveX, nonTransitiveY, true),
                      arguments(nonTransitiveY, nonTransitiveZ, true),
-                     arguments(nonTransitiveX, nonTransitiveZ, false),
-                     arguments(nonConsistentX, nonConsistentX, true),
-                     arguments(nonConsistentX, nonConsistentX, false),
-                     arguments(nonConsistentX, nonConsistentX, true));
+                     arguments(nonTransitiveX, nonTransitiveZ, false));
   }
 
   private static class AlwaysTrue {


### PR DESCRIPTION
This PR adds a profile so pitest can be easily run against assertj core

```bash
mvn -Ppitest test-compile
```

The plugin has been bound to the test-compile (rather than test) as an easy way of preventing surefire from also running. As pitest runs the tests itself, additional running surefire just slows feedback.

A full analysis of the project takes around 45 minutes.

The PR also adds git integration, this allows just local changes to be analysed with

```bash
mvn -Ppitest -Dfeatures="+GIT" test-compile
```

Or for changes to be brought into scope from git history

```bash
mvn -Ppitest -Dfeatures="+GIT(from[HEAD~10])" test-compile
```

Once merged, this can be built on in a future PR to provide mutation testing feedback on all incoming PRs as described here -> https://blog.pitest.org/dont-let-your-code-dry/

The PR also modifies several tests to remove test order dependencies, and to exclude the pitest test runners from stack traces.
