### PR TITLE
Update ShouldBeEqual assertion message

### DIFF
--- a/src/main/java/org/assertj/core/api/Descriptable.java
+++ b/src/main/java/org/assertj/core/api/Descriptable.java
@@ -46,7 +46,7 @@ public interface Descriptable<SELF> {
    * } catch (AssertionError e) {
    *   assertThat(e).hasMessage(&quot;[check Frodo's age]\n
    *                             expected: 33\n
-   *                             but was : 50&quot;);
+   *                              but was: 50&quot;);
    * }</code></pre>
    *
    * @param description the new description to set.
@@ -82,7 +82,7 @@ public interface Descriptable<SELF> {
    * {
    *   assertThat(e).hasMessage(&quot;[check Frodo's age]\n
    *                             expected: 33\n
-   *                             but was : 50&quot;);
+   *                              but was: 50&quot;);
    * }</code></pre>
    *
    * @param descriptionSupplier the description {@link Supplier}.

--- a/src/main/java/org/assertj/core/error/ShouldBeEqual.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqual.java
@@ -41,7 +41,7 @@ import org.assertj.core.util.VisibleForTesting;
  */
 public class ShouldBeEqual implements AssertionErrorFactory {
 
-  private static final String EXPECTED_BUT_WAS_MESSAGE = "%nexpected: %s%nbut was : %s";
+  private static final String EXPECTED_BUT_WAS_MESSAGE = "%nexpected: %s%n but was: %s";
   private static final String EXPECTED_BUT_WAS_MESSAGE_USING_COMPARATOR = EXPECTED_BUT_WAS_MESSAGE + "%n%s";
   private static final Class<?>[] MSG_ARG_TYPES = array(String.class, String.class, String.class);
   private static final Class<?>[] MSG_ARG_TYPES_FOR_ASSERTION_FAILED_ERROR = array(String.class, Object.class,

--- a/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringCase.java
+++ b/src/main/java/org/assertj/core/error/ShouldBeEqualIgnoringCase.java
@@ -31,6 +31,6 @@ public class ShouldBeEqualIgnoringCase extends BasicErrorMessageFactory {
   }
 
   private ShouldBeEqualIgnoringCase(CharSequence actual, CharSequence expected) {
-    super("%nexpected: %s%nbut was : %s%nignoring case considerations", expected, actual);
+    super("%nexpected: %s%n but was: %s%nignoring case considerations", expected, actual);
   }
 }

--- a/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_isInstanceOfSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/abstract_/AbstractAssert_isInstanceOfSatisfying_Test.java
@@ -78,7 +78,7 @@ class AbstractAssert_isInstanceOfSatisfying_Test extends AbstractAssertBaseTest 
     // THEN
     then(assertionError).hasMessage(format("[check light saber] %n" +
                                            "expected: \"Green\"%n" +
-                                           "but was : \"Red\""));
+                                           " but was: \"Red\""));
   }
 
   @Test

--- a/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasValueSatisfying_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/reference/AtomicReferenceAssert_hasValueSatisfying_Test.java
@@ -44,7 +44,7 @@ class AtomicReferenceAssert_hasValueSatisfying_Test {
     AssertionError error = expectAssertionError(() -> assertThat(actual).hasValueSatisfying(value -> assertThat(value).isEqualToIgnoringCase(expectedValue)));
     // THEN
     then(error).hasMessageContainingAll("expected: \"bar\"",
-                                        "but was : \"foo\"");
+                                        " but was: \"foo\"");
   }
 
   @Test

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_Test.java
@@ -39,7 +39,7 @@ class ShouldBeEqual_Test {
     then(error.getExpected().getValue()).isEqualTo(STANDARD_REPRESENTATION.toStringOf(expected));
     then(error).hasMessage(format("[Jedi] %n" +
                                   "expected: \"Yoda\"%n" +
-                                  "but was : \"Luke\"%n" +
+                                  " but was: \"Luke\"%n" +
                                   "when comparing values using CaseInsensitiveStringComparator"));
   }
 
@@ -56,7 +56,7 @@ class ShouldBeEqual_Test {
     then(error.getExpected().getValue()).isEqualTo("[1, 2, 4]");
     then(error).hasMessage(format("[numbers] %n" +
                                   "expected: [1, 2, 4]%n" +
-                                  "but was : [1, 2, 3]"));
+                                  " but was: [1, 2, 3]"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_Test.java
@@ -59,7 +59,7 @@ class ShouldBeEqual_newAssertionError_Test {
     then(error).isInstanceOf(AssertionFailedError.class)
                .hasMessage(format("[Jedi] %n" +
                                   "expected: \"Yoda\"%n" +
-                                  "but was : \"Luke\""));
+                                  " but was: \"Luke\""));
   }
 
   public static Stream<String> parameters() {

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test.java
@@ -61,7 +61,7 @@ class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test {
     then(error).isInstanceOf(AssertionFailedError.class)
                .hasMessage(format("[my test] %n" +
                                   "expected: 42.0%n" +
-                                  "but was : 42.0f"));
+                                  " but was: 42.0f"));
   }
 
   @Test
@@ -78,7 +78,7 @@ class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test {
     then(error).isInstanceOf(AssertionFailedError.class)
                .hasMessage("[my test] %n" +
                            "expected: \"Person[name=Jake] (Person@%s)\"%n" +
-                           "but was : \"Person[name=Jake] (Person@%s)\"",
+                           " but was: \"Person[name=Jake] (Person@%s)\"",
                            toHexString(expected.hashCode()), toHexString(actual.hashCode()));
   }
 
@@ -97,7 +97,7 @@ class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test {
     then(error).isInstanceOf(AssertionFailedError.class)
                .hasMessage("[my test] %n" +
                            "expected: \"Person[name=Jake] (Person@%s)\"%n" +
-                           "but was : \"Person[name=Jake] (Person@%s)\"%n" +
+                           " but was: \"Person[name=Jake] (Person@%s)\"%n" +
                            "when comparing values using PersonComparator",
                            toHexString(expected.hashCode()), toHexString(actual.hashCode()));
   }
@@ -116,7 +116,7 @@ class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test {
     then(error).isInstanceOf(AssertionFailedError.class)
                .hasMessage("[my test] %n" +
                            "expected: \"null (ToStringIsNull@%s)\"%n" +
-                           "but was : null",
+                           " but was: null",
                            toHexString(expected.hashCode()));
   }
 
@@ -134,7 +134,7 @@ class ShouldBeEqual_newAssertionError_differentiating_expected_and_actual_Test {
     then(error).isInstanceOf(AssertionFailedError.class)
                .hasMessage("[my test] %n" +
                            "expected: null%n" +
-                           "but was : \"null (ToStringIsNull@%s)\"",
+                           " but was: \"null (ToStringIsNull@%s)\"",
                            toHexString(actual.hashCode()));
   }
 

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_Test.java
@@ -75,7 +75,7 @@ class ShouldBeEqual_newAssertionError_without_JUnit_Test {
                                            new Class<?>[] { String.class, Object.class, Object.class },
                                            format("[Jedi] %n" +
                                                   "expected: \"Yoda\"%n" +
-                                                  "but was : \"Luke\""),
+                                                  " but was: \"Luke\""),
                                            STANDARD_REPRESENTATION.toStringOf("Yoda"),
                                            STANDARD_REPRESENTATION.toStringOf("Luke"));
     assertThat(error).isNotInstanceOf(ComparisonFailure.class)
@@ -85,7 +85,7 @@ class ShouldBeEqual_newAssertionError_without_JUnit_Test {
     assertThat(assertionFailedError.getExpected().getValue()).isEqualTo(STANDARD_REPRESENTATION.toStringOf("Yoda"));
     assertThat(error).hasMessage(format("[Jedi] %n" +
                                         "expected: \"Yoda\"%n" +
-                                        "but was : \"Luke\""));
+                                        " but was: \"Luke\""));
   }
 
   private static Object createComparisonFailure(ConstructorInvoker invoker) throws Exception {

--- a/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test.java
@@ -79,7 +79,7 @@ class ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test {
                                                      array(String.class, Object.class, Object.class),
                                                      format("[Jedi] %n" +
                                                             "expected: \"Yoda\"%n" +
-                                                            "but was : \"Luke\""),
+                                                            " but was: \"Luke\""),
                                                      STANDARD_REPRESENTATION.toStringOf("Yoda"),
                                                      STANDARD_REPRESENTATION.toStringOf("Luke"));
     verify(constructorInvoker).newInstance(ComparisonFailure.class.getName(),
@@ -90,6 +90,6 @@ class ShouldBeEqual_newAssertionError_without_JUnit_and_OTA4J_Test {
     assertThat(error).isNotInstanceOfAny(ComparisonFailure.class, AssertionFailedError.class)
                      .hasMessage(format("[Jedi] %n" +
                                         "expected: \"Yoda\"%n" +
-                                        "but was : \"Luke\""));
+                                        " but was: \"Luke\""));
   }
 }

--- a/src/test/java/org/assertj/core/matcher/AssertionMatcher_matches_Test.java
+++ b/src/test/java/org/assertj/core/matcher/AssertionMatcher_matches_Test.java
@@ -94,7 +94,7 @@ class AssertionMatcher_matches_Test {
     verify(description).appendText(argThat(new ArgumentMatcher<String>() {
       @Override
       public boolean matches(String s) {
-        return s.contains(format("%nexpected: 0%nbut was : 1"))
+        return s.contains(format("%nexpected: 0%n but was: 1"))
             && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test$1.assertion(AssertionMatcher_matches_Test.java:")
             && s.contains("at org.assertj.core.matcher.AssertionMatcher.matches(AssertionMatcher.java:")
             && s.contains("at org.assertj.core.matcher.AssertionMatcher_matches_Test.matcher_should_fill_description_when_assertion_fails(AssertionMatcher_matches_Test.java:");

--- a/src/test/java/org/assertj/core/test/ErrorMessagesForTest.java
+++ b/src/test/java/org/assertj/core/test/ErrorMessagesForTest.java
@@ -17,11 +17,11 @@ import static java.lang.String.format;
 public class ErrorMessagesForTest {
 
   public static String shouldBeEqualMessage(String actual, String expected) {
-    return format("%nexpected: " + expected + "%nbut was : " + actual);
+    return format("%nexpected: " + expected + "%n but was: " + actual);
   }
 
   public static String shouldBeEqualMessage(String description, String actual, String expected) {
-    return format("[" + description + "] %nexpected: " + expected + "%nbut was : " + actual);
+    return format("[" + description + "] %nexpected: " + expected + "%n but was: " + actual);
   }
 
 }


### PR DESCRIPTION
Move the trailing space after "was" to a leading space before "but" so that IntellIJ's diff regexes can pick it up

#### Check List:
* Fixes #2199 (ignore if not applicable)
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)
