### PR TITLE
Improve performance in StandardComparisonStrategy#areEqual

### DIFF
--- a/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
+++ b/src/main/java/org/assertj/core/internal/StandardComparisonStrategy.java
@@ -83,24 +83,33 @@ public class StandardComparisonStrategy extends AbstractComparisonStrategy {
   @Override
   public boolean areEqual(Object actual, Object other) {
     if (actual == null) return other == null;
-    if (actual instanceof Object[] && other instanceof Object[])
-      return java.util.Arrays.deepEquals((Object[]) actual, (Object[]) other);
-    if (actual instanceof byte[] && other instanceof byte[])
-      return java.util.Arrays.equals((byte[]) actual, (byte[]) other);
-    if (actual instanceof short[] && other instanceof short[])
-      return java.util.Arrays.equals((short[]) actual, (short[]) other);
-    if (actual instanceof int[] && other instanceof int[])
-      return java.util.Arrays.equals((int[]) actual, (int[]) other);
-    if (actual instanceof long[] && other instanceof long[])
-      return java.util.Arrays.equals((long[]) actual, (long[]) other);
-    if (actual instanceof char[] && other instanceof char[])
-      return java.util.Arrays.equals((char[]) actual, (char[]) other);
-    if (actual instanceof float[] && other instanceof float[])
-      return java.util.Arrays.equals((float[]) actual, (float[]) other);
-    if (actual instanceof double[] && other instanceof double[])
-      return java.util.Arrays.equals((double[]) actual, (double[]) other);
-    if (actual instanceof boolean[] && other instanceof boolean[])
-      return java.util.Arrays.equals((boolean[]) actual, (boolean[]) other);
+    Class<?> actualClass = actual.getClass();
+    if (actualClass.isArray()) {
+      Class<?> otherClass = other.getClass();
+      if (otherClass.isArray()) {
+        if (actualClass.getComponentType().isPrimitive() && otherClass.getComponentType().isPrimitive()) {
+          if (actual instanceof byte[] && other instanceof byte[])
+            return java.util.Arrays.equals((byte[]) actual, (byte[]) other);
+          if (actual instanceof short[] && other instanceof short[])
+            return java.util.Arrays.equals((short[]) actual, (short[]) other);
+          if (actual instanceof int[] && other instanceof int[])
+            return java.util.Arrays.equals((int[]) actual, (int[]) other);
+          if (actual instanceof long[] && other instanceof long[])
+            return java.util.Arrays.equals((long[]) actual, (long[]) other);
+          if (actual instanceof char[] && other instanceof char[])
+            return java.util.Arrays.equals((char[]) actual, (char[]) other);
+          if (actual instanceof float[] && other instanceof float[])
+            return java.util.Arrays.equals((float[]) actual, (float[]) other);
+          if (actual instanceof double[] && other instanceof double[])
+            return java.util.Arrays.equals((double[]) actual, (double[]) other);
+          if (actual instanceof boolean[] && other instanceof boolean[])
+            return java.util.Arrays.equals((boolean[]) actual, (boolean[]) other);
+        }
+
+        if (actual instanceof Object[] && other instanceof Object[])
+          return java.util.Arrays.deepEquals((Object[]) actual, (Object[]) other);
+      }
+    }
     return actual.equals(other);
   }
 


### PR DESCRIPTION
While working on PR #2171 I noticed that the performance degradation with the changes in that PR + this change are way lower than the changes in that PR without this change here.

Did some JFR profiling and most of the time is spend in this method here. With this PR the idea is to avoid doing `instanceof` checks if the actual is not an array. I know that `Objects#deepEquals` is similar, but I cannot explain why the performance degrades so much in the AssertJ code (perhaps because I am using `Long` for the testing and the reference is the same.

I can add a different object type in the benchmark if you want