### PR TITLE
Issue #2237 Implement hasSize to Path assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1108,6 +1108,40 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
   }
 
   /**
+   * Assert that the tested {@link Path} has the given size in bytes.
+   * <p>
+   * Note that the actual {@link Path} must exist and must be readable.
+   * <p>
+   * Examples:
+   * <pre><code class="java"> // Given the following empty paths
+   * /root/sub-dir-1/foo.ext
+   * /root/sub-dir-1/bar.ext
+   *
+   * Path emptyPath = Paths.get("/root/sub-dir-1/foo.ext")
+   * Path nonEmptyPath = Files.write(Paths.get("/root/sub-dir-1/bar.ext"),
+   *                                 "The Quick Brown Fox.".getBytes());
+   * // the following assertions pass
+   * assertThat(emptyPath).hasSize(0);
+   * assertThat(nonEmptyPath).hasSize(20);
+   *
+   * // the following assertions fail
+   * assertThat(emptyPath).hasSize(5);
+   * assertThat(nonEmptyPath).hasSize(0);</code></code></pre>
+   *
+   * @param expectedSize the expected {@code Path} file size in bytes
+   * @return {@code this} assertion object
+   * @throws AssertionError is the actual {@code Path} is {@code null}.
+   * @throws AssertionError if the actual {@code Path} does not exist.
+   * @throws AssertionError if the actual {@code Path} is not readable.
+   * @throws AssertionError if the actual {@code Path} file size is not equal to the expected size.
+   * @throws UncheckedIOException if any I/O error occurs.
+   */
+  public SELF hasSize(long expectedSize) {
+    paths.assertHasSize(info, actual, expectedSize);
+    return myself;
+  }
+
+  /**
    * Assert that the tested {@link Path} starts with the given path.
    *
    * <p>

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1111,7 +1111,8 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * Assert that the tested {@link Path} has the given size in bytes.
    * <p>
    * Note that the actual {@link Path} must exist and must be readable.
-   * <p>
+   * </p>
+   *
    * Examples:
    * <pre><code class="java"> // Given the following empty paths
    * /root/sub-dir-1/foo.ext
@@ -1126,7 +1127,7 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    *
    * // the following assertions fail
    * assertThat(emptyPath).hasSize(5);
-   * assertThat(nonEmptyPath).hasSize(0);</code></code></pre>
+   * assertThat(nonEmptyPath).hasSize(0);</code></pre>
    *
    * @param expectedSize the expected {@code Path} file size in bytes
    * @return {@code this} assertion object

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1113,7 +1113,7 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
   /**
    * Assert that the tested {@link Path} has the given size in bytes.
    * <p>
-   * Note that the actual {@link Path} must exist and must be readable.
+   * Note that the actual {@link Path} must exist and be a regular file.
    * </p>
    *
    * Examples:
@@ -1136,9 +1136,10 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * @return {@code this} assertion object
    * @throws AssertionError is the actual {@code Path} is {@code null}.
    * @throws AssertionError if the actual {@code Path} does not exist.
-   * @throws AssertionError if the actual {@code Path} is not readable.
+   * @throws AssertionError if the actual {@code Path} is not a regular file.
    * @throws AssertionError if the actual {@code Path} file size is not equal to the expected size.
    * @throws UncheckedIOException if any I/O error occurs.
+   * @since 3.21.0
    */
   public SELF hasSize(long expectedSize) {
     paths.assertHasSize(info, actual, expectedSize);

--- a/src/main/java/org/assertj/core/error/ShouldHaveSize.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSize.java
@@ -31,6 +31,13 @@ public class ShouldHaveSize extends BasicErrorMessageFactory {
                                                       + "but had:%n"
                                                       + "  %s bytes";
 
+  private static final String SHOULD_HAVE_PATH_SIZE = "%nExpecting path%n"
+                                                      + "  %s%n"
+                                                      + "to have a size of:%n"
+                                                      + "  %s bytes%n"
+                                                      + "but had:%n"
+                                                      + "  %s bytes";
+
   /**
    * Creates a new <code>{@link ShouldHaveSize}</code>.
    * @param actual the actual value in the failed assertion.
@@ -95,7 +102,7 @@ public class ShouldHaveSize extends BasicErrorMessageFactory {
   }
 
   private ShouldHaveSize(Path actual, long expectedSize, long actualSize) {
-    super(SHOULD_HAVE_FILE_SIZE, actual, expectedSize, actualSize);
+    super(SHOULD_HAVE_PATH_SIZE, actual, expectedSize, actualSize);
   }
 
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSize.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSize.java
@@ -15,6 +15,7 @@ package org.assertj.core.error;
 import static java.lang.String.format;
 
 import java.io.File;
+import java.nio.file.Path;
 
 /**
  * Creates an error message indicating that an assertion that verifies that a value have certain size failed.
@@ -80,6 +81,21 @@ public class ShouldHaveSize extends BasicErrorMessageFactory {
 
   private ShouldHaveSize(File actual, long expectedSize) {
     super(SHOULD_HAVE_FILE_SIZE, actual, expectedSize, actual.length());
+  }
+
+  /**
+   * Creates a new <code>{@link ShouldHaveSize}</code> for Path file size
+   * @param actual The actual path file in the failed assertion
+   * @param expectedSize The expected size of the path file
+   * @param actualSize The actual size of the path file
+   * @return the created {@code ErrorMessageFactory}
+   */
+  public static ErrorMessageFactory shouldHaveSize(Path actual, long expectedSize, long actualSize) {
+    return new ShouldHaveSize(actual, expectedSize, actualSize);
+  }
+
+  private ShouldHaveSize(Path actual, long expectedSize, long actualSize) {
+    super(SHOULD_HAVE_FILE_SIZE, actual, expectedSize, actualSize);
   }
 
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveSize.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveSize.java
@@ -15,6 +15,8 @@ package org.assertj.core.error;
 import static java.lang.String.format;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
@@ -94,15 +96,14 @@ public class ShouldHaveSize extends BasicErrorMessageFactory {
    * Creates a new <code>{@link ShouldHaveSize}</code> for Path file size
    * @param actual The actual path file in the failed assertion
    * @param expectedSize The expected size of the path file
-   * @param actualSize The actual size of the path file
    * @return the created {@code ErrorMessageFactory}
    */
-  public static ErrorMessageFactory shouldHaveSize(Path actual, long expectedSize, long actualSize) {
-    return new ShouldHaveSize(actual, expectedSize, actualSize);
+  public static ErrorMessageFactory shouldHaveSize(Path actual, long expectedSize) throws IOException {
+    return new ShouldHaveSize(actual, expectedSize);
   }
 
-  private ShouldHaveSize(Path actual, long expectedSize, long actualSize) {
-    super(SHOULD_HAVE_PATH_SIZE, actual, expectedSize, actualSize);
+  private ShouldHaveSize(Path actual, long expectedSize) throws IOException {
+    super(SHOULD_HAVE_PATH_SIZE, actual, expectedSize, Files.size(actual));
   }
 
 }

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -42,6 +42,7 @@ import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
+import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.error.ShouldNotBeEmpty.shouldNotBeEmpty;
 import static org.assertj.core.error.ShouldNotContain.directoryShouldNotContain;
 import static org.assertj.core.error.ShouldNotExist.shouldNotExist;
@@ -226,6 +227,20 @@ public class Paths {
   public void assertHasNoParentRaw(final AssertionInfo info, final Path actual) {
     assertNotNull(info, actual);
     if (actual.getParent() != null) throw failures.failure(info, shouldHaveNoParent(actual));
+  }
+
+  public void assertHasSize(final AssertionInfo info, final Path actual, long expectedSize) {
+    assertIsReadable(info, actual);
+
+    long actualSize;
+    try {
+      actualSize = nioFilesWrapper.size(actual);
+    } catch(IOException e) {
+      throw new UncheckedIOException(format("unable to verify size of file in path: <$s>", actual), e);
+    }
+
+    if (actualSize == expectedSize) return;
+    throw failures.failure(info, shouldHaveSize(actual, expectedSize, actualSize));
   }
 
   public void assertStartsWith(final AssertionInfo info, final Path actual, final Path start) {

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -230,12 +230,12 @@ public class Paths {
   }
 
   public void assertHasSize(final AssertionInfo info, final Path actual, long expectedSize) {
-    assertExists(info, actual);
+    assertIsRegularFile(info, actual);
     try {
       long actualSize = nioFilesWrapper.size(actual);
-      if (actualSize != expectedSize) throw failures.failure(info, shouldHaveSize(actual, expectedSize, actualSize));
+      if (actualSize != expectedSize) throw failures.failure(info, shouldHaveSize(actual, expectedSize));
     } catch(IOException e) {
-      throw new UncheckedIOException(format("unable to verify the size of the path: <$s>", actual), e);
+      throw new UncheckedIOException(format("unable to verify the size of the path: <%s>", actual), e);
     }
   }
 

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -230,17 +230,13 @@ public class Paths {
   }
 
   public void assertHasSize(final AssertionInfo info, final Path actual, long expectedSize) {
-    assertIsReadable(info, actual);
-
-    long actualSize;
+    assertExists(info, actual);
     try {
-      actualSize = nioFilesWrapper.size(actual);
+      long actualSize = nioFilesWrapper.size(actual);
+      if (actualSize != expectedSize) throw failures.failure(info, shouldHaveSize(actual, expectedSize, actualSize));
     } catch(IOException e) {
-      throw new UncheckedIOException(format("unable to verify size of file in path: <$s>", actual), e);
+      throw new UncheckedIOException(format("unable to verify the size of the path: <$s>", actual), e);
     }
-
-    if (actualSize == expectedSize) return;
-    throw failures.failure(info, shouldHaveSize(actual, expectedSize, actualSize));
   }
 
   public void assertStartsWith(final AssertionInfo info, final Path actual, final Path start) {

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasSize_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasSize_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link PathAssert#hasSize(long)}</code>
+ */
+@DisplayName("PathAssert hasSize")
+class PathAssert_hasSize_Test extends PathAssertBaseTest {
+
+  private long expected = 22L;
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.hasSize(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertHasSize(getInfo(assertions), getActual(assertions), expected);
+  }
+}

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasSize_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasSize_Test.java
@@ -12,27 +12,21 @@
  */
 package org.assertj.core.api.path;
 
-import org.assertj.core.api.PathAssert;
-import org.assertj.core.api.PathAssertBaseTest;
-import org.junit.jupiter.api.DisplayName;
-
 import static org.mockito.Mockito.verify;
 
-/**
- * Tests for <code>{@link PathAssert#hasSize(long)}</code>
- */
-@DisplayName("PathAssert hasSize")
-class PathAssert_hasSize_Test extends PathAssertBaseTest {
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
 
-  private long expected = 22L;
+class PathAssert_hasSize_Test extends PathAssertBaseTest {
 
   @Override
   protected PathAssert invoke_api_method() {
-    return assertions.hasSize(expected);
+    return assertions.hasSize(0L);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(paths).assertHasSize(getInfo(assertions), getActual(assertions), expected);
+    verify(paths).assertHasSize(getInfo(assertions), getActual(assertions), 0L);
   }
+
 }

--- a/src/test/java/org/assertj/core/error/ShouldHaveSize_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveSize_create_Test.java
@@ -18,42 +18,47 @@ import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
 import static org.assertj.core.util.Lists.list;
 
-import org.assertj.core.description.TextDescription;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.assertj.core.description.Description;
+import org.assertj.core.internal.TestDescription;
 import org.assertj.core.presentation.HexadecimalRepresentation;
+import org.assertj.core.presentation.Representation;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Tests for <code>{@link ShouldHaveSize#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
+ * Tests for <code>{@link ShouldHaveSize#create(Description, Representation)}</code>.
  *
  * @author Alex Ruiz
  * @author Yvonne Wang
  */
-@DisplayName("ShouldHaveSize create:")
 class ShouldHaveSize_create_Test {
 
   private ErrorMessageFactory factory;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     factory = shouldHaveSize(list('a', 'b'), 4, 2);
   }
 
   @Test
   void should_create_error_message() {
     // WHEN
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
     // THEN
-    then(message).isEqualTo(String.format("[Test] %nExpected size: 2 but was: 4 in:%n['a', 'b']"));
+    then(message).isEqualTo(String.format("[TEST] %nExpected size: 2 but was: 4 in:%n['a', 'b']"));
   }
 
   @Test
   void should_create_error_message_with_hexadecimal_representation() {
     // WHEN
-    String message = factory.create(new TextDescription("Test"), new HexadecimalRepresentation());
+    String message = factory.create(new TestDescription("TEST"), new HexadecimalRepresentation());
     // THEN
-    then(message).isEqualTo(String.format("[Test] %nExpected size: 2 but was: 4 in:%n['0x0061', '0x0062']"));
+    then(message).isEqualTo(String.format("[TEST] %nExpected size: 2 but was: 4 in:%n['0x0061', '0x0062']"));
   }
 
   @Test
@@ -61,9 +66,9 @@ class ShouldHaveSize_create_Test {
     // GIVEN
     ErrorMessageFactory factory = shouldHaveSize(new FakeFile("ab%sc"), 3L);
     // WHEN
-    String actualErrorMessage = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String actualErrorMessage = factory.create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
     // THEN
-    then(actualErrorMessage).isEqualTo(format("[Test] %n"
+    then(actualErrorMessage).isEqualTo(format("[TEST] %n"
                                               + "Expecting file%n"
                                               + "  ab%%sc%n"
                                               + "to have a size of:%n"
@@ -71,4 +76,22 @@ class ShouldHaveSize_create_Test {
                                               + "but had:%n"
                                               + "  0L bytes"));
   }
+
+  @Test
+  void should_create_error_message_for_incorrect_path_size(@TempDir Path tempDir) throws IOException {
+    // GIVEN
+    Path actual = Files.write(tempDir.resolve("actual"), "content".getBytes());
+    // WHEN
+    String actualErrorMessage = shouldHaveSize(actual, 0L).create(new TestDescription("TEST"), STANDARD_REPRESENTATION);
+    // THEN
+    then(actualErrorMessage).isEqualTo("[TEST] %n"
+                                       + "Expecting path%n"
+                                       + "  %s%n"
+                                       + "to have a size of:%n"
+                                       + "  0L bytes%n"
+                                       + "but had:%n"
+                                       + "  7L bytes",
+                                       actual);
+  }
+
 }

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSize_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSize_Test.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
+import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
+
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.mockito.BDDMockito.given;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Paths;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Path;
+
+/**
+ * Tests for <code>{@link Paths#assertHasSize(AssertionInfo, Path, long)} </code>
+ */
+@DisplayName("Paths assertHasSize")
+class Paths_assertHasSize_Test extends MockPathsBaseTest {
+
+  private long expectedSize;
+
+  @BeforeEach
+  public void setUpPath() {
+    given(nioFilesWrapper.exists(actual)).willReturn(true);
+    given(nioFilesWrapper.isReadable(actual)).willReturn(true);
+    expectedSize = 1L;
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, null, expectedSize));
+    // THEN
+    then(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_exist() {
+    // GIVEN
+    given(nioFilesWrapper.exists(actual)).willReturn(false);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, expectedSize));
+    // THEN
+    then(error).hasMessage(shouldExist(actual).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_readable() {
+    // GIVEN
+    given(nioFilesWrapper.isReadable(actual)).willReturn(false);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, expectedSize));
+    // THEN
+    then(error).hasMessage(shouldBeReadable(actual).create());
+  }
+
+  @Test
+  void should_throw_IOException_if_IO_error_occurs_when_finding_path_size() throws IOException {
+    // GIVEN
+    IOException exception = new IOException();
+    given(nioFilesWrapper.size(actual)).willThrow(exception);
+    // THEN
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> paths.assertHasSize(info, actual, expectedSize))
+      .withMessage(format("unable to verify size of file in path: <$s>", actual));
+  }
+
+  @Test
+  void should_pass_if_actual_size_equals_expected_size() throws IOException{
+    // GIVEN
+    long actualSize = expectedSize;
+    given(nioFilesWrapper.size(actual)).willReturn(actualSize);
+    // THEN
+    paths.assertHasSize(info, actual, expectedSize);
+  }
+
+  @Test
+  void should_fail_if_actual_size_does_not_equal_expected_size() throws IOException{
+    // GIVEN
+    long actualSize = 2L;
+    given(nioFilesWrapper.size(actual)).willReturn(actualSize);
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, expectedSize));
+    // THEN
+    then(error).hasMessage(shouldHaveSize(actual, expectedSize, actualSize).create());
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSize_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasSize_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldExist.shouldExist;
 import static org.assertj.core.error.ShouldHaveSize.shouldHaveSize;
-import static org.assertj.core.error.ShouldBeReadable.shouldBeReadable;
 
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -67,23 +66,13 @@ class Paths_assertHasSize_Test extends MockPathsBaseTest {
   }
 
   @Test
-  void should_fail_if_actual_is_not_readable() {
-    // GIVEN
-    given(nioFilesWrapper.isReadable(actual)).willReturn(false);
-    // WHEN
-    AssertionError error = expectAssertionError(() -> paths.assertHasSize(info, actual, expectedSize));
-    // THEN
-    then(error).hasMessage(shouldBeReadable(actual).create());
-  }
-
-  @Test
   void should_throw_IOException_if_IO_error_occurs_when_finding_path_size() throws IOException {
     // GIVEN
     IOException exception = new IOException();
     given(nioFilesWrapper.size(actual)).willThrow(exception);
     // THEN
     assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> paths.assertHasSize(info, actual, expectedSize))
-      .withMessage(format("unable to verify size of file in path: <$s>", actual));
+      .withMessage(format("unable to verify the size of the path: <$s>", actual));
   }
 
   @Test


### PR DESCRIPTION
#### Check List:
* Fixes #2237  
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES 
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Implemented the feature `assertThat(Path).hasSize(expectedSize)`. Verifies the size in bytes of the path file.