### PR TITLE
[#2236] Add hasFileName as an alias of hasName for File assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -686,6 +686,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @throws AssertionError if the actual {@code File} does not have the expected name.
    *
    * @see java.io.File#getName() name definition.
+   * @see #hasFileName(String)
    */
   public SELF hasName(String expected) {
     files.assertHasName(info, actual, expected);
@@ -693,7 +694,20 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   }
 
   /**
-   * Alias for {@link #hasName(String)}.
+   * Verifies that the actual {@code File} has given name (alias of {@link #hasName(String)}).
+   *
+   * <p>
+   * Example:
+   * <pre><code class='java'> File xFile = new File(&quot;somewhere/xFile.java&quot;);
+   * File xDirectory = new File(&quot;somewhere/xDirectory&quot;);
+   *
+   * // assertion will pass
+   * assertThat(xFile).hasFileName(&quot;xFile.java&quot;);
+   * assertThat(xDirectory).hasFileName(&quot;xDirectory&quot;);
+   *
+   * // assertion will fail
+   * assertThat(xFile).hasFileName(&quot;xFile&quot;);
+   * assertThat(xDirectory).hasFileName(&quot;somewhere&quot;);</code></pre>
    *
    * @param expected the expected {@code File} name.
    * @return {@code this} assertion object.
@@ -702,6 +716,8 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @throws AssertionError if the actual {@code File} does not have the expected name.
    *
    * @see java.io.File#getName() name definition.
+   * @see #hasName(String)
+   * @since 3.20.0
    */
   public SELF hasFileName(String expected) {
     return hasName(expected);

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.function.Predicate;
 
@@ -689,6 +690,15 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   public SELF hasName(String expected) {
     files.assertHasName(info, actual, expected);
     return myself;
+  }
+
+  /**
+   * Alias for {@link #hasName(String)}.
+   *
+   * This method can be used to easily switch between {@link File} and {@link Path} assertions.
+   */
+  public SELF hasFileName(String expected) {
+    return hasName(expected);
   }
 
   /**

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -695,7 +695,13 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   /**
    * Alias for {@link #hasName(String)}.
    *
-   * This method can be used to easily switch between {@link File} and {@link Path} assertions.
+   * @param expected the expected {@code File} name.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the expected name is {@code null}.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} does not have the expected name.
+   *
+   * @see java.io.File#getName() name definition.
    */
   public SELF hasFileName(String expected) {
     return hasName(expected);

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -717,7 +717,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    *
    * @see java.io.File#getName() name definition.
    * @see #hasName(String)
-   * @since 3.20.0
+   * @since 3.21.0
    */
   public SELF hasFileName(String expected) {
     return hasName(expected);

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasFileName_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasFileName_Test.java
@@ -16,9 +16,7 @@ import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
-import org.junit.jupiter.api.DisplayName;
 
-@DisplayName("FileAssert hasFileName")
 class FileAssert_hasFileName_Test extends FileAssertBaseTest {
 
   private final String expected = "expected.name";

--- a/src/test/java/org/assertj/core/api/file/FileAssert_hasFileName_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_hasFileName_Test.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+@DisplayName("FileAssert hasFileName")
+class FileAssert_hasFileName_Test extends FileAssertBaseTest {
+
+  private final String expected = "expected.name";
+
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.hasFileName(expected);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertHasName(getInfo(assertions), getActual(assertions), expected);
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #2236
* Unit tests : YES 
* Javadoc with a code example (on API only) : Yes
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

