### PR TITLE
Add isReadable as an alias of canRead for File assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -230,7 +230,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @throws AssertionError if the actual {@code File} can not be read by the application.
    *
    * @see #canRead()
-   * @since 3.20.0
+   * @since 3.21.0
    */
   public SELF isReadable() {
     return canRead();

--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -207,6 +207,36 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   }
 
   /**
+   * Verifies that the actual {@code File} can be read by the application (alias of {@link #canRead()})
+   *
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * File tmpDir = Files.createTempDirectory(&quot;tmp&quot;).toFile();
+   *
+   * // assertions will pass
+   * assertThat(tmpFile).isReadable();
+   * assertThat(tmpDir).isReadable();
+   *
+   * tmpFile.setReadable(false);
+   * tmpDir.setReadable(false);
+   *
+   * // assertions will fail
+   * assertThat(tmpFile).isReadable();
+   * assertThat(tmpDir).isReadable();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} can not be read by the application.
+   *
+   * @see #canRead()
+   * @since 3.20.0
+   */
+  public SELF isReadable() {
+    return canRead();
+  }
+
+  /**
    * Verifies that the content of the actual {@code File} is equal to the content of the given one.
    * The charset to use when reading the actual file can be provided with {@link #usingCharset(Charset)} or
    * {@link #usingCharset(String)} prior to calling this method; if not, the platform's default charset (as returned by

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isReadable_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isReadable_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+
+/**
+ * Tests for <code>{@link FileAssert#isReadable()}</code>.
+ */
+class FileAssert_isReadable_Test extends FileAssertBaseTest {
+  @Override
+  protected FileAssert invoke_api_method() {
+    return assertions.isReadable();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(files).assertCanRead(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isReadable_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isReadable_Test.java
@@ -17,11 +17,8 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.FileAssert;
 import org.assertj.core.api.FileAssertBaseTest;
 
-
-/**
- * Tests for <code>{@link FileAssert#isReadable()}</code>.
- */
 class FileAssert_isReadable_Test extends FileAssertBaseTest {
+
   @Override
   protected FileAssert invoke_api_method() {
     return assertions.isReadable();
@@ -31,4 +28,5 @@ class FileAssert_isReadable_Test extends FileAssertBaseTest {
   protected void verify_internal_effects() {
     verify(files).assertCanRead(getInfo(assertions), getActual(assertions));
   }
+
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2234
* Unit tests : YES
* Javadoc with a code example (on API only) : YES 
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)