### PR TITLE
Map entry values handle deep equality comparison again

### DIFF
--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -485,22 +485,23 @@ public class Maps {
   private static <K, V> Map<K, V> mapWithoutExpectedEntries(Map<K, V> actual, Entry<? extends K, ? extends V>[] expectedEntries) {
     // Stream API avoided for performance reasons
     try {
-      return removeExpectedEntries(clone(actual), expectedEntries);
+      Map<K, V> clonedMap = clone(actual);
+      removeEntries(clonedMap, expectedEntries);
+      return clonedMap;
     } catch (NoSuchMethodException | UnsupportedOperationException e) {
       // actual cannot be cloned or is unmodifiable, falling back to LinkedHashMap
-      return removeExpectedEntries(new LinkedHashMap<K, V>(actual), expectedEntries);
+      Map<K, V> copiedMap = new LinkedHashMap<>(actual);
+      removeEntries(copiedMap, expectedEntries);
+      return copiedMap;
     }
   }
 
-  private static <K, V> Map<K, V> removeExpectedEntries(Map<K, V> map, Entry<? extends K, ? extends V>[] expectedEntries) {
-    for (Entry<? extends K, ? extends V> expectedEntry : expectedEntries) {
+  private static <K, V> void removeEntries(Map<K, V> map, Entry<? extends K, ? extends V>[] entries) {
+    for (Entry<? extends K, ? extends V> entry : entries) {
       // must perform deep equals comparison on values as Map.remove(Object, Object) relies on
       // Objects.equals which does not handle deep equality (e.g. arrays in map entry values)
-      if (containsEntry(map, expectedEntry)) {
-        map.remove(expectedEntry.getKey());
-      }
+      if (containsEntry(map, entry)) map.remove(entry.getKey());
     }
-    return map;
   }
 
   public <K, V> void assertContainsExactly(AssertionInfo info, Map<K, V> actual, Entry<? extends K, ? extends V>[] entries) {

--- a/src/main/java/org/assertj/core/internal/Maps.java
+++ b/src/main/java/org/assertj/core/internal/Maps.java
@@ -494,11 +494,10 @@ public class Maps {
 
   private static <K, V> Map<K, V> removeExpectedEntries(Map<K, V> map, Entry<? extends K, ? extends V>[] expectedEntries) {
     for (Entry<? extends K, ? extends V> expectedEntry : expectedEntries) {
-      K key = expectedEntry.getKey();
       // must perform deep equals comparison on values as Map.remove(Object, Object) relies on
       // Objects.equals which does not handle deep equality (e.g. arrays in map entry values)
-      if (map.containsKey(key) && deepEquals(map.get(key), expectedEntry.getValue())) {
-        map.remove(key);
+      if (containsEntry(map, expectedEntry)) {
+        map.remove(expectedEntry.getKey());
       }
     }
     return map;

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsExactlyInAnyOrderEntriesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsExactlyInAnyOrderEntriesOf_Test.java
@@ -52,15 +52,4 @@ class MapAssert_containsExactlyInAnyOrderEntriesOf_Test extends MapAssertBaseTes
     assertThat(actualMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
   }
 
-  @Test
-  void invoke_api_like_user_with_value_array() {
-
-    // GIVEN
-    Map<String, byte[]> actualMap = mapOf(entry("key1", new byte[]{1, 2}),
-      entry("key2", new byte[]{3, 4, 5}));
-    Map<String, byte[]> expectedMap = mapOf(entry("key2", new byte[]{3, 4, 5}),
-      entry("key1", new byte[]{1, 2}));
-    // THEN
-    assertThat(actualMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
-  }
 }

--- a/src/test/java/org/assertj/core/api/map/MapAssert_containsExactlyInAnyOrderEntriesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/map/MapAssert_containsExactlyInAnyOrderEntriesOf_Test.java
@@ -52,4 +52,15 @@ class MapAssert_containsExactlyInAnyOrderEntriesOf_Test extends MapAssertBaseTes
     assertThat(actualMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
   }
 
+  @Test
+  void invoke_api_like_user_with_value_array() {
+
+    // GIVEN
+    Map<String, byte[]> actualMap = mapOf(entry("key1", new byte[]{1, 2}),
+      entry("key2", new byte[]{3, 4, 5}));
+    Map<String, byte[]> expectedMap = mapOf(entry("key2", new byte[]{3, 4, 5}),
+      entry("key1", new byte[]{1, 2}));
+    // THEN
+    assertThat(actualMap).containsExactlyInAnyOrderEntriesOf(expectedMap);
+  }
 }

--- a/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
+++ b/src/test/java/org/assertj/core/internal/maps/Maps_assertContainsOnly_Test.java
@@ -243,4 +243,14 @@ class Maps_assertContainsOnly_Test extends MapsBaseTest {
                                set(entry("name", "Yoda"), entry("job", "Jedi"))));
   }
 
+  @SuppressWarnings("unchecked")
+  @Test
+  void should_pass_if_value_type_is_array() {
+    // GIVEN
+    Map<String, byte[]> actual = mapOf(entry("key1", new byte[] { 1, 2 }), entry("key2", new byte[] { 3, 4, 5 }));
+    Entry<String, byte[]>[] expected = new Entry[] { entry("key2", new byte[] { 3, 4, 5 }), entry("key1", new byte[] { 1, 2 }) };
+    // WHEN/THEN
+    assertThatNoException().isThrownBy(() -> maps.assertContainsOnly(info, actual, expected));
+  }
+
 }


### PR DESCRIPTION
This appears to have broken in PR #2167 specifically with the use of
`Map.remove(Object, Object)` that does not perform deep equality
checking on the map entry value (e.g. arrays).

#### Check List:
* Fixes https://github.com/assertj/assertj-core/issues/2264
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
