### PR TITLE
Add workflow to check binary compatibility of `main` against the latest release

### DIFF
--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -1,0 +1,35 @@
+name: Binary Compatibility
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  japicmp:
+    name: Compare with the latest release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+      - name: Cache Maven Repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-maven
+      - name: Compare
+        run: >
+          ./mvnw -V --no-transfer-progress -e package japicmp:cmp
+          -Djapicmp.breakBuildOnBinaryIncompatibleModifications=true
+      - name: Print Result
+        run: cat target/japicmp/default-cli.diff
+      - name: Upload Reports
+        uses: actions/upload-artifact@v2
+        with:
+          name: japicmp
+          path: target/japicmp
+          if-no-files-found: error

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,23 @@ BAD! (not in the same line)
 
 To be sure of what the javadoc actually looks, simply generate it and read it in your browser.
 
+## Binary compatibility
+
+Try to keep binary compatibility whenever possible. It means that you can safely:
+* Rewrite the body of methods, constructors, and initializers (like static blocks).
+* Rewrite code in the above that previously threw exceptions to no longer do so.
+* Add fields, methods, and constructors.
+* Delete elements declared private.
+* Reorder fields, methods, and constructors.
+* Move a method higher in a class hierarchy.
+* Reorder the list of direct super-interfaces in a class or interface.
+* Insert new class or interface types in a type hierarchy.
+* Add generics (since the compiler erases them).
+* Update package-private elements.
+
+Other changes could compromise binary compatibility.
+These are not automatically rejected, but we will carefully evaluate each of them to weigh all the pros and cons.
+
 ## Legal stuff:
 
 Project license(s): Apache License Version 2.0

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Github CI status](https://github.com/assertj/assertj-core/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/assertj/assertj-core/actions/workflows/main.yml?query=branch%3Amain)
 [![Github Cross-Version status](https://github.com/assertj/assertj-core/actions/workflows/cross-version.yml/badge.svg?branch=main)](https://github.com/assertj/assertj-core/actions/workflows/cross-version.yml?query=branch%3Amain)
+[![Binary Compatibility](https://github.com/assertj/assertj-core/actions/workflows/binary-compatibility.yml/badge.svg?branch=main)](https://github.com/assertj/assertj-core/actions/workflows/binary-compatibility.yml?query=branch%3Amain)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.assertj/assertj-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.assertj/assertj-core)
 [![Javadocs](http://www.javadoc.io/badge/org.assertj/assertj-core.svg)](http://www.javadoc.io/doc/org.assertj/assertj-core)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=joel-costigliola_assertj-core&metric=alert_status)](https://sonarcloud.io/dashboard?id=joel-costigliola_assertj-core)

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
   <properties>
     <javadocAdditionalOptions>-html5 --allow-script-in-comments --no-module-directories</javadocAdditionalOptions>
     <byte-buddy.version>1.11.5</byte-buddy.version>
+    <hamcrest.version>2.2</hamcrest.version>
     <opentest4j.version>1.2.0</opentest4j.version>
     <bnd.version>5.3.0</bnd.version>
     <cdg.pitest.version>0.0.10</cdg.pitest.version>
@@ -52,7 +53,7 @@
       <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
-        <version>2.2</version>
+        <version>${hamcrest.version}</version>
       </dependency>
       <dependency>
         <groupId>org.opentest4j</groupId>
@@ -668,6 +669,44 @@
                 </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>com.github.siom79.japicmp</groupId>
+          <artifactId>japicmp-maven-plugin</artifactId>
+          <version>0.15.3</version>
+          <configuration>
+            <dependencies>
+              <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${junit.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit-jupiter.version}</version>
+              </dependency>
+              <dependency>
+                <groupId>org.opentest4j</groupId>
+                <artifactId>opentest4j</artifactId>
+                <version>${opentest4j.version}</version>
+              </dependency>
+            </dependencies>
+            <parameter>
+              <excludes>
+                <exclude>org.assertj.core.internal</exclude>
+              </excludes>
+              <onlyBinaryIncompatible>true</onlyBinaryIncompatible>
+              <onlyModified>true</onlyModified>
+              <reportOnlyFilename>true</reportOnlyFilename>
+            </parameter>
+            <skipXmlReport>true</skipXmlReport>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
This adds the configuration to execute [`japicmp`](https://github.com/siom79/japicmp) for checking the binary compatibility of `main` against the latest released version. The result is printed as part of the workflow and also published as an artifact.

The new workflow runs only for push events on `main`, but an example of the run can be found here: https://github.com/assertj/assertj-core/actions/runs/962080274