### PR TITLE
Add isWritable as an alias of canWrite for File assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -554,10 +554,39 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code File} is {@code null}.
    * @throws AssertionError if the actual {@code File} can not be modified by the application.
+   * @see #isWritable()
    */
   public SELF canWrite() {
     files.assertCanWrite(info, actual);
     return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code File} can be modified by the application (alias of {@link #canWrite()}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File tmpFile = File.createTempFile(&quot;tmp&quot;, &quot;txt&quot;);
+   * File tmpDir = Files.createTempDirectory(&quot;tmp&quot;).toFile();
+   *
+   * // assertions will pass
+   * assertThat(tmpFile).isWritable();
+   * assertThat(tmpDir).isWritable();
+   *
+   * tmpFile.setReadOnly();
+   * tmpDir.setReadOnly();
+   *
+   * // assertions will fail
+   * assertThat(tmpFile).isWritable();
+   * assertThat(tmpDir).isWritable();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code File} is {@code null}.
+   * @throws AssertionError if the actual {@code File} can not be modified by the application.
+   * @see #canWrite()
+   * @since 3.21.0
+   */
+  public SELF isWritable() {
+	  return canWrite();
   }
 
   /**

--- a/src/test/java/org/assertj/core/api/file/FileAssert_isWritable_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_isWritable_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.api.FileAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for <code>{@link FileAssert#isWritable()}</code>.
+ * 
+ * @author Ivan Aguilar
+ * 
+ */
+class FileAssert_isWritable_Test extends FileAssertBaseTest {
+
+	@Override
+	protected FileAssert invoke_api_method() {
+		return assertions.isWritable();
+	}
+
+	@Override
+	protected void verify_internal_effects() {
+		verify(files).assertCanWrite(getInfo(assertions), getActual(assertions));
+	}
+
+}


### PR DESCRIPTION
* Fixes #2235 
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Hello! I already finished the issue, I ran the tests and seems fine, it is everything okay? :) 

![test](https://user-images.githubusercontent.com/42753018/123361358-83bab880-d534-11eb-91fc-65185dbe8f51.jpeg)

