### PR TITLE
Improve assertion error for hasSameElementsAs(emptyList())

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -380,7 +380,9 @@ public class Iterables {
    */
   public void assertContainsOnly(AssertionInfo info, Iterable<?> actual, Object[] expectedValues) {
     final List<?> actualAsList = newArrayList(actual);
-    if (commonCheckThatIterableAssertionSucceeds(info, actualAsList, expectedValues)) return;
+    checkNotNullIterables(info, actualAsList, expectedValues);
+    // if both actual and values are empty, then assertion passes.
+    if (actualAsList.isEmpty() && expectedValues.length == 0) return;
 
     // after the for loop, unexpected = expectedValues - actual
     List<Object> unexpectedValues = newArrayList(actualAsList);

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasSameElementsAs_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasSameElementsAs_Test.java
@@ -19,7 +19,7 @@ import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
 /**
- * Tests for <code>{@link org.assertj.core.api.AbstractIterableAssert#containsOnlyElementsOf(Iterable)} </code>.
+ * Tests for <code>{@link org.assertj.core.api.AbstractIterableAssert#hasSameElementsAs(Iterable)} </code>.
  * 
  * @author Christopher Arnott
  */

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasSameElementsAs_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_hasSameElementsAs_Test.java
@@ -12,9 +12,16 @@
  */
 package org.assertj.core.api.iterable;
 
+import java.util.Collections;
 import java.util.List;
+
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ConcreteIterableAssert;
 import org.assertj.core.api.IterableAssertBaseTest;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.util.Lists.emptyList;
 import static org.assertj.core.util.Lists.newArrayList;
 import static org.mockito.Mockito.verify;
 
@@ -35,5 +42,12 @@ class IterableAssert_hasSameElementsAs_Test extends IterableAssertBaseTest {
   @Override
   protected void verify_internal_effects() {
     verify(iterables).assertContainsOnly(getInfo(assertions), getActual(assertions), values.toArray());
+  }
+
+  @Test
+  void should_have_an_helpful_error_message_when_expected_is_empty() {
+    assertThatExceptionOfType(AssertionError.class)
+      .isThrownBy(() -> assertThat(Collections.singleton("element")).hasSameElementsAs(emptyList()))
+      .withMessageContaining("[\"element\"]");
   }
 }


### PR DESCRIPTION
Inlined commonCheckThatIterableAssertionSucceeds in assertContainsOnly and removed failIfEmptySinceActualIsNotEmpty call because expectedValues is not a subsequence.

#### Check List:
* Fixes #2294
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
