### PR TITLE
Fix #2296 : 2D arrays - assert size of first dimension only

### DIFF
--- a/src/main/java/org/assertj/core/api/Array2DAssert.java
+++ b/src/main/java/org/assertj/core/api/Array2DAssert.java
@@ -105,6 +105,24 @@ public interface Array2DAssert<SELF extends Array2DAssert<SELF, ELEMENT>, ELEMEN
   SELF hasDimensions(int expectedFirstDimension, int expectedSecondDimension);
 
   /**
+   * Verifies that the first dimension of 2D array has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new int[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new int[][] { }).hasRowSize(1);
+   * assertThat(new int[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new int[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedRowSize the expected number of rows in first dimension of the actual array.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  SELF hasRowSize(int expectedRowSize);
+
+  /**
    * Verifies that the actual array has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object[] and primitive arrays (e.g. int[]).

--- a/src/main/java/org/assertj/core/api/Boolean2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Boolean2DArrayAssert.java
@@ -212,6 +212,28 @@ public class Boolean2DArrayAssert extends Abstract2DArrayAssert<Boolean2DArrayAs
   }
 
   /**
+   * Verifies that the first dimension of actual {@code boolean[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new boolean[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new boolean[][] { }).hasRowSize(1, 1);
+   * assertThat(new boolean[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new boolean[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual array.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Boolean2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    boolean2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code boolean[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/main/java/org/assertj/core/api/Byte2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Byte2DArrayAssert.java
@@ -213,6 +213,29 @@ public class Byte2DArrayAssert extends Abstract2DArrayAssert<Byte2DArrayAssert, 
   }
 
   /**
+   * Verifies that the first dimension of actual {@code byte[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new byte[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new byte[][] { }).hasRowSize(1);
+   * assertThat(new byte[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new byte[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code byte[][].
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Byte2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    byte2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+
+  /**
    * Verifies that the actual {@code byte[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/main/java/org/assertj/core/api/Char2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Char2DArrayAssert.java
@@ -213,6 +213,28 @@ public class Char2DArrayAssert extends Abstract2DArrayAssert<Char2DArrayAssert, 
   }
 
   /**
+   * Verifies that the first dimension of actual {@code char[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new char[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new char[][] { }).hasRowSize(1, 1);
+   * assertThat(new char[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new char[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code char[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Char2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    char2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code char[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object[] and primitive arrays (e.g. int[]).

--- a/src/main/java/org/assertj/core/api/Double2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Double2DArrayAssert.java
@@ -213,6 +213,28 @@ public class Double2DArrayAssert extends Abstract2DArrayAssert<Double2DArrayAsse
   }
 
   /**
+   * Verifies that the first dimension of actual {@code double[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new double[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new double[][] { }).hasRowSize(1, 1);
+   * assertThat(new double[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new double[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code double[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Double2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    double2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code double[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/main/java/org/assertj/core/api/Float2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Float2DArrayAssert.java
@@ -208,6 +208,28 @@ public class Float2DArrayAssert extends Abstract2DArrayAssert<Float2DArrayAssert
   }
 
   /**
+   * Verifies that the first dimension of actual {@code float[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new float[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new float[][] { }).hasRowSize(1, 1);
+   * assertThat(new float[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new float[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(2); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code float[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Float2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    float2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code float[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/main/java/org/assertj/core/api/Int2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Int2DArrayAssert.java
@@ -125,6 +125,29 @@ public class Int2DArrayAssert extends Abstract2DArrayAssert<Int2DArrayAssert, in
     return myself;
   }
 
+
+  /**
+   * Verifies that the first dimension of actual {@code int[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new int[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new int[][] { }).hasRowSize(1, 1);
+   * assertThat(new int[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new int[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code int[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Int2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    int2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
   /**
    * Verifies that the actual {@code int[][]} has the same dimensions as the given array.
    * <p>

--- a/src/main/java/org/assertj/core/api/Long2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Long2DArrayAssert.java
@@ -212,6 +212,28 @@ public class Long2DArrayAssert extends Abstract2DArrayAssert<Long2DArrayAssert, 
   }
 
   /**
+   * Verifies that the first dimension of actual {@code long[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new long[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new long[][] { }).hasRowSize(1, 1);
+   * assertThat(new long[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new long[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code long[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Long2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    long2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code long[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/main/java/org/assertj/core/api/Object2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Object2DArrayAssert.java
@@ -215,6 +215,28 @@ public class Object2DArrayAssert<ELEMENT> extends
   }
 
   /**
+   * Verifies that the first dimension of actual {@code ELEMENT[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new String[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new String[][] { }).hasRowSize(1, 1);
+   * assertThat(new String[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new String[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code ELEMENT[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Object2DArrayAssert<ELEMENT> hasRowSize(int expectedFirstDimension) {
+    object2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code ELEMENT[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/main/java/org/assertj/core/api/Short2DArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/Short2DArrayAssert.java
@@ -211,6 +211,28 @@ public class Short2DArrayAssert extends Abstract2DArrayAssert<Short2DArrayAssert
   }
 
   /**
+   * Verifies that the first dimension of actual {@code short[][]} has the given row size.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(new short[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(2);
+   *
+   * // assertions will fail
+   * assertThat(new short[][] { }).hasRowSize(1, 1);
+   * assertThat(new short[][] {{1, 2, 3}, {4, 5, 6}}).hasRowSize(3);
+   * assertThat(new short[][] {{1, 2, 3}, {4, 5, 6, 7}}).hasRowSize(1); </code></pre>
+   *
+   * @param expectedFirstDimension the expected number of values in first dimension of the actual {@code short[][]}.
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual number of rows are not equal to the given one.
+   */
+  @Override
+  public Short2DArrayAssert hasRowSize(int expectedFirstDimension) {
+    short2dArrays.assertHasDimensions(info, actual, expectedFirstDimension, 0);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code short[][]} has the same dimensions as the given array.
    * <p>
    * Parameter is declared as Object to accept both Object and primitive arrays.

--- a/src/test/java/org/assertj/core/api/boolean2darray/Boolean2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/boolean2darray/Boolean2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.boolean2darray;
+
+import org.assertj.core.api.Boolean2DArrayAssert;
+import org.assertj.core.api.Boolean2DArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Boolean2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+@DisplayName("Boolean2DArrayAssert hasRowSize")
+class Boolean2DArrayAssert_hasRowSize_Test extends Boolean2DArrayAssertBaseTest {
+
+  @Override
+  protected Boolean2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(1);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 1, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/byte2darray/Byte2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/byte2darray/Byte2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.byte2darray;
+
+import org.assertj.core.api.Byte2DArrayAssert;
+import org.assertj.core.api.Byte2DArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Byte2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+@DisplayName("Byte2DArrayAssert hasRowSize")
+class Byte2DArrayAssert_hasRowSize_Test extends Byte2DArrayAssertBaseTest {
+
+  @Override
+  protected Byte2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(3);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 3, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/char2darray/Char2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/char2darray/Char2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.char2darray;
+
+import org.assertj.core.api.Char2DArrayAssert;
+import org.assertj.core.api.Char2DArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Char2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+class Char2DArrayAssert_hasRowSize_Test extends Char2DArrayAssertBaseTest {
+
+  @Override
+  protected Char2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(1);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 1, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/double2darray/Double2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/double2darray/Double2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.double2darray;
+
+import org.assertj.core.api.Double2DArrayAssert;
+import org.assertj.core.api.Double2DArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Double2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+class Double2DArrayAssert_hasRowSize_Test extends Double2DArrayAssertBaseTest {
+
+  @Override
+  protected Double2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(2);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 2, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/float2darray/Float2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/float2darray/Float2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.float2darray;
+
+import org.assertj.core.api.Float2DArrayAssert;
+import org.assertj.core.api.Float2DArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Float2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+class Float2DArrayAssert_hasRowSize_Test extends Float2DArrayAssertBaseTest {
+
+  @Override
+  protected Float2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(1);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 1, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/int2darray/Int2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/int2darray/Int2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.int2darray;
+
+import org.assertj.core.api.Int2DArrayAssert;
+import org.assertj.core.api.Int2DArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Int2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+class Int2DArrayAssert_hasRowSize_Test extends Int2DArrayAssertBaseTest {
+
+  @Override
+  protected Int2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(3);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 3, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/long2darray/Long2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/long2darray/Long2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.long2darray;
+
+import org.assertj.core.api.Long2DArrayAssert;
+import org.assertj.core.api.Long2DArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Long2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+class Long2DArrayAssert_hasRowSize_Test extends Long2DArrayAssertBaseTest {
+
+  @Override
+  protected Long2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(1);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 1, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/object2darray/Object2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/object2darray/Object2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.object2darray;
+
+import org.assertj.core.api.Object2DArrayAssert;
+import org.assertj.core.api.Object2DArrayAssertBaseTest;
+import org.junit.jupiter.api.DisplayName;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Object2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+@DisplayName("Object2DArrayAssert hasRowSize")
+class Object2DArrayAssert_hasRowSize_Test extends Object2DArrayAssertBaseTest {
+
+  @Override
+  protected Object2DArrayAssert<Object> invoke_api_method() {
+    return assertions.hasRowSize(1);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 1, 0);
+  }
+}

--- a/src/test/java/org/assertj/core/api/short2darray/Short2DArrayAssert_hasRowSize_Test.java
+++ b/src/test/java/org/assertj/core/api/short2darray/Short2DArrayAssert_hasRowSize_Test.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.short2darray;
+
+import org.assertj.core.api.Short2DArrayAssert;
+import org.assertj.core.api.Short2DArrayAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for <code>{@link Short2DArrayAssert#hasRowSize(int)}</code>.
+ * 
+ * @author Sekar Mylsamy
+ */
+class Short2DArrayAssert_hasRowSize_Test extends Short2DArrayAssertBaseTest {
+
+  @Override
+  protected Short2DArrayAssert invoke_api_method() {
+    return assertions.hasRowSize(1);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(arrays).assertHasDimensions(getInfo(assertions), getActual(assertions), 1, 0);
+  }
+}


### PR DESCRIPTION
- Fixes #2296
- Unit tests : YES
- Javadoc with a code example (on API only) : Y