### PR TITLE
File size assert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -1372,6 +1372,33 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
     return internalContent(charset);
   }
 
+  /**
+   * Returns an {@code Assert} object that allows performing assertions on the size of the {@link File} under test.
+   * <p>
+   * Once this method is called, the object under test is no longer the {@link File} but its size,
+   * to perform assertions on the {@link File}, call {@link AbstractFileSizeAssert#returnToFile()}.
+   * <p>
+   * Example:
+   * <pre><code class='java'> File file = File.createTempFile(&quot;tmp&quot;, &quot;bin&quot;);
+   * Files.write(file.toPath(), new byte[] {1, 1});
+   *
+   * // assertion will pass
+   * assertThat(file).size().isGreaterThan(1L).isLessThan(5L);
+   *
+   * // assertions will fail
+   * assertThat(file).size().isBetween(5L, 10L);</code></pre>
+   *
+   * @return AbstractFileSizeAssert built with the {@code File}'s size.
+   * @throws NullPointerException if the given {@code File} is {@code null}.
+   * @since 3.21.0
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  @CheckReturnValue
+  public AbstractFileSizeAssert<SELF> size() {
+    requireNonNull(actual, "Can not perform assertions on the size of a null file.");
+    return new FileSizeAssert(this, actual.length());
+  }
+
   // this method was introduced to avoid to avoid double proxying in soft assertions for content()
   private AbstractStringAssert<?> internalContent(Charset charset) {
     files.assertCanRead(info, actual);

--- a/src/main/java/org/assertj/core/api/AbstractFileSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileSizeAssert.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api;
+
+//@format:off
+public abstract class AbstractFileSizeAssert<SELF extends AbstractFileAssert<SELF>>
+    extends AbstractLongAssert<AbstractFileSizeAssert<SELF>> {
+//@format:on
+
+  protected AbstractFileSizeAssert(Long actual, Class<?> selfType) {
+    super(actual, selfType);
+  }
+
+  public abstract AbstractFileAssert<SELF> returnToFile();
+}

--- a/src/main/java/org/assertj/core/api/Assumptions.java
+++ b/src/main/java/org/assertj/core/api/Assumptions.java
@@ -1341,6 +1341,7 @@ public class Assumptions {
     if (assertion instanceof MapAssert) return asAssumption(MapAssert.class, Map.class, actual);
     if (assertion instanceof AbstractObjectArrayAssert) return asAssumption(ObjectArrayAssert.class, Object[].class, actual);
     if (assertion instanceof IterableSizeAssert) return asIterableSizeAssumption(assertion);
+    if (assertion instanceof FileSizeAssert) return asFileSizeAssumption(assertion);
     if (assertion instanceof MapSizeAssert) return asMapSizeAssumption(assertion);
     if (assertion instanceof ObjectAssert) return asAssumption(ObjectAssert.class, Object.class, actual);
     if (assertion instanceof RecursiveComparisonAssert) return asRecursiveComparisonAssumption(assertion);
@@ -1366,5 +1367,11 @@ public class Assumptions {
     IterableSizeAssert<?> iterableSizeAssert = (IterableSizeAssert<?>) assertion;
     Class<?>[] constructorTypes = array(AbstractIterableAssert.class, Integer.class);
     return asAssumption(IterableSizeAssert.class, constructorTypes, iterableSizeAssert.returnToIterable(), assertion.actual);
+  }
+
+  private static AbstractAssert<?, ?> asFileSizeAssumption(AbstractAssert<?, ?> assertion) {
+    FileSizeAssert<?> fileSizeAssert = (FileSizeAssert<?>) assertion;
+    Class<?>[] constructorTypes = array(AbstractIterableAssert.class, Long.class);
+    return asAssumption(FileSizeAssert.class, constructorTypes, fileSizeAssert.returnToFile(), assertion.actual);
   }
 }

--- a/src/main/java/org/assertj/core/api/FileSizeAssert.java
+++ b/src/main/java/org/assertj/core/api/FileSizeAssert.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import org.assertj.core.util.CheckReturnValue;
+
+public class FileSizeAssert<T> extends AbstractFileSizeAssert<FileAssert> {
+
+  private AbstractFileAssert<FileAssert> source;
+
+  public FileSizeAssert(AbstractFileAssert<FileAssert> source, Long i) {
+    super(i, FileSizeAssert.class);
+    this.source = source;
+  }
+
+  @Override
+  @CheckReturnValue
+  public AbstractFileAssert<FileAssert> returnToFile() {
+    return source;
+  }
+}

--- a/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
+++ b/src/main/java/org/assertj/core/api/ProxifyMethodChangingTheObjectUnderTest.java
@@ -82,6 +82,7 @@ public class ProxifyMethodChangingTheObjectUnderTest {
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private AbstractAssert<?, ?> createAssertProxy(AbstractAssert<?, ?> currentAssert) {
     if (currentAssert instanceof IterableSizeAssert) return createIterableSizeAssertProxy(currentAssert);
+    if (currentAssert instanceof FileSizeAssert) return createFileSizeAssertProxy(currentAssert);
     if (currentAssert instanceof MapSizeAssert) return createMapSizeAssertProxy(currentAssert);
     if (currentAssert instanceof RecursiveComparisonAssert)
       return createRecursiveComparisonAssertProxy((RecursiveComparisonAssert) currentAssert);
@@ -103,6 +104,12 @@ public class ProxifyMethodChangingTheObjectUnderTest {
     IterableSizeAssert<?> iterableSizeAssert = (IterableSizeAssert<?>) currentAssert;
     // can't use the usual way of building soft proxy since IterableSizeAssert takes 2 parameters
     return proxies.createIterableSizeAssertProxy(iterableSizeAssert);
+  }
+
+  private FileSizeAssert<?> createFileSizeAssertProxy(Object currentAssert) {
+    FileSizeAssert<?> fileSizeAssert = (FileSizeAssert<?>) currentAssert;
+    // can't use the usual way of building soft proxy since FileSizeAssert takes 2 parameters
+    return proxies.createFileSizeAssertProxy(fileSizeAssert);
   }
 
   @SuppressWarnings("rawtypes")

--- a/src/main/java/org/assertj/core/api/SoftProxies.java
+++ b/src/main/java/org/assertj/core/api/SoftProxies.java
@@ -130,6 +130,19 @@ class SoftProxies {
                                               () -> generateProxyClass(assertClass));
   }
 
+  FileSizeAssert<?> createFileSizeAssertProxy(FileSizeAssert<?> fileSizeAssert) {
+    Class<?> proxyClass = createSoftAssertionProxyClass(FileSizeAssert.class);
+    try {
+      Constructor<?> constructor = proxyClass.getConstructor(AbstractFileAssert.class, Long.class);
+      FileSizeAssert<?> proxiedAssert = (FileSizeAssert<?>) constructor.newInstance(fileSizeAssert.returnToFile(),
+        fileSizeAssert.actual);
+      ((AssertJProxySetup) proxiedAssert).assertj$setup(new ProxifyMethodChangingTheObjectUnderTest(this), collector);
+      return proxiedAssert;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   IterableSizeAssert<?> createIterableSizeAssertProxy(IterableSizeAssert<?> iterableSizeAssert) {
     Class<?> proxyClass = createSoftAssertionProxyClass(IterableSizeAssert.class);
     try {

--- a/src/test/java/org/assertj/core/api/file/FileAssert_size_Test.java
+++ b/src/test/java/org/assertj/core/api/file/FileAssert_size_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.file;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class FileAssert_size_Test {
+
+  @Test
+  void should_be_able_to_use_file_assertions_on_file_size() {
+
+    File file = new File("src/test/resources/actual_file.txt");
+
+    assertThat(file).size()
+      .isGreaterThan(4L)
+      .isLessThan(8L)
+      .isEqualTo(7L)
+      .isBetween(1L, 7L)
+      .returnToFile().hasContent("actual");
+  }
+
+  @Test
+  void should_have_a_helpful_error_message_when_size_is_used_on_a_null_file() {
+    File nullFile = null;
+    assertThatNullPointerException().isThrownBy(() -> assertThat(nullFile).size().isGreaterThan(1))
+      .withMessage("Can not perform assertions on the size of a null file.");
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #2322 
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES 
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

This adds the `size` method on file assertions.
