### PR TITLE
Apply pattern to file name only with `isDirectoryContaining` / `isDirectoryNotContaining`

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractFileAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractFileAssert.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.file.FileSystem;
+import java.nio.file.PathMatcher;
 import java.security.MessageDigest;
 import java.util.function.Predicate;
 
@@ -619,7 +620,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * @since 3.21.0
    */
   public SELF isWritable() {
-	  return canWrite();
+    return canWrite();
   }
 
   /**
@@ -989,16 +990,16 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   }
 
   /**
-   * Verify that the actual {@code File} is a directory containing at least one file matching the given {@code String}
-   * interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
+   * Verify that the actual {@code File} is a directory containing at least one entry with name matching
+   * the given {@code String}, interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
    * <p>
    * Note that the actual {@link File} must exist and be a directory.
    * <p>
    * Given the following directory structure:
    * <pre><code class="text"> /root/
    * /root/sub-dir-1/
-   * /root/sub-dir-1/file-1.ext
-   * /root/sub-dir-1/file-2.ext
+   * /root/sub-dir-1/file-1.txt
+   * /root/sub-dir-1/file-2.txt
    * /root/sub-file-1.ext
    * /root/sub-file-2.ext</code></pre>
    *
@@ -1006,24 +1007,28 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * <pre><code class="java"> File root = new File("root");
    *
    * // The following assertions succeed:
-   * assertThat(root).isDirectoryContaining("glob:**sub-dir*")
+   * assertThat(root).isDirectoryContaining("glob:sub-dir*")
+   *                 .isDirectoryContaining("glob:**sub-dir*")
+   *                 .isDirectoryContaining("glob:sub-file*")
    *                 .isDirectoryContaining("glob:**sub-file*")
+   *                 .isDirectoryContaining("glob:*.ext")
    *                 .isDirectoryContaining("glob:**.ext")
    *                 .isDirectoryContaining("regex:.*ext")
-   *                 .isDirectoryContaining("glob:**.{ext,bin");
+   *                 .isDirectoryContaining("glob:*.{ext,bin}");
    *
    * // The following assertions fail:
-   * assertThat(root).isDirectoryContaining("glob:**dir");
-   * assertThat(root).isDirectoryContaining("glob:**.bin");
-   * assertThat(root).isDirectoryContaining("glob:**.{java,class}"); </code></pre>
+   * assertThat(root).isDirectoryContaining("glob:sub-dir-1/file*");
+   * assertThat(root).isDirectoryContaining("glob:*.txt");
+   * assertThat(root).isDirectoryContaining("glob:**.txt");
+   * assertThat(root).isDirectoryContaining("glob:*.{java,class}"); </code></pre>
    *
-   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @param syntaxAndPattern the syntax and pattern for {@link PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
    * @throws AssertionError       if actual is {@code null}.
    * @throws AssertionError       if actual does not exist.
    * @throws AssertionError       if actual is not a directory.
-   * @throws AssertionError       if actual does not contain any files matching the given path matcher.
+   * @throws AssertionError       if actual does not contain any entries with name matching the given path matcher.
    * @see FileSystem#getPathMatcher(String)
    * @since 3.13.0
    */
@@ -1062,7 +1067,7 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * assertThat(root).isDirectoryRecursivelyContaining("glob:**.bin");
    * assertThat(root).isDirectoryRecursivelyContaining("glob:**.{java,class}"); </code></pre>
    *
-   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @param syntaxAndPattern the syntax and pattern for {@link PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
    * @throws AssertionError       if actual is {@code null}.
@@ -1161,16 +1166,16 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
   }
 
   /**
-   * Verify that the actual {@code File} is a directory that does not contain any files matching the given {@code String}
-   * interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
+   * Verify that the actual {@code File} is a directory that does not contain any entries with name matching
+   * the given {@code String}, interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
    * <p>
    * Note that the actual {@link File} must exist and be a directory.
    * <p>
    * Given the following directory structure:
    * <pre><code class="text"> /root/
    * /root/sub-dir-1/
-   * /root/sub-dir-1/file-1.ext
-   * /root/sub-dir-1/file-2.ext
+   * /root/sub-dir-1/file-1.txt
+   * /root/sub-dir-1/file-2.txt
    * /root/sub-file-1.ext
    * /root/sub-file-2.ext</code></pre>
    *
@@ -1178,25 +1183,29 @@ public abstract class AbstractFileAssert<SELF extends AbstractFileAssert<SELF>> 
    * <pre><code class="java"> File root = new File("root");
    *
    * // The following assertions succeed:
-   * assertThat(root).isDirectoryNotContaining("glob:**dir")
-   *                 .isDirectoryNotContaining("glob:**.bin")
-   *                 .isDirectoryNotContaining("regex:.*bin")
-   *                 .isDirectoryNotContaining("glob:**.{java,class}");
+   * assertThat(root).isDirectoryNotContaining("glob:sub-dir-1/file*")
+   *                 .isDirectoryNotContaining("glob:*.txt")
+   *                 .isDirectoryNotContaining("glob:**.txt")
+   *                 .isDirectoryNotContaining("regex:.*txt")
+   *                 .isDirectoryNotContaining("glob:*.{java,class}");
    *
    * // The following assertions fail:
+   * assertThat(root).isDirectoryNotContaining("glob:sub-dir*");
    * assertThat(root).isDirectoryNotContaining("glob:**sub-dir*");
+   * assertThat(root).isDirectoryNotContaining("glob:sub-file*");
    * assertThat(root).isDirectoryNotContaining("glob:**sub-file*");
+   * assertThat(root).isDirectoryNotContaining("glob:*.ext");
    * assertThat(root).isDirectoryNotContaining("glob:**.ext");
    * assertThat(root).isDirectoryNotContaining("regex:.*ext");
-   * assertThat(root).isDirectoryNotContaining("glob:**.{ext,bin"); </code></pre>
+   * assertThat(root).isDirectoryNotContaining("glob:*.{ext,bin}"); </code></pre>
    *
-   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @param syntaxAndPattern the syntax and pattern for {@link PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
    * @throws AssertionError       if actual is {@code null}.
    * @throws AssertionError       if actual does not exist.
    * @throws AssertionError       if actual is not a directory.
-   * @throws AssertionError       if actual contains a file matching the given path matcher.
+   * @throws AssertionError       if actual contains an entry with name matching the given path matcher.
    * @see FileSystem#getPathMatcher(String)
    * @since 3.13.0
    */

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -25,6 +25,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.ProviderMismatchException;
 import java.nio.file.spi.FileSystemProvider;
 import java.security.MessageDigest;
@@ -1501,16 +1502,16 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
   }
 
   /**
-   * Verify that the actual {@code Path} is a directory containing at least one file matching the given {@code String}
-   * interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
+   * Verify that the actual {@code Path} is a directory containing at least one entry with name matching
+   * the given {@code String}, interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
    * <p>
    * Note that the actual {@link Path} must exist and be a directory.
    * <p>
    * Given the following directory structure:
    * <pre><code class="text"> /root/
    * /root/sub-dir-1/
-   * /root/sub-dir-1/file-1.ext
-   * /root/sub-dir-1/file-2.ext
+   * /root/sub-dir-1/file-1.txt
+   * /root/sub-dir-1/file-2.txt
    * /root/sub-file-1.ext
    * /root/sub-file-2.ext</code></pre>
    *
@@ -1518,24 +1519,28 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * <pre><code class="java"> Path root = Paths.get("root");
    *
    * // The following assertions succeed:
-   * assertThat(root).isDirectoryContaining("glob:**sub-dir*")
+   * assertThat(root).isDirectoryContaining("glob:sub-dir*")
+   *                 .isDirectoryContaining("glob:**sub-dir*")
+   *                 .isDirectoryContaining("glob:sub-file*")
    *                 .isDirectoryContaining("glob:**sub-file*")
+   *                 .isDirectoryContaining("glob:*.ext")
    *                 .isDirectoryContaining("glob:**.ext")
    *                 .isDirectoryContaining("regex:.*ext")
-   *                 .isDirectoryContaining("glob:**.{ext,bin");
+   *                 .isDirectoryContaining("glob:*.{ext,bin}");
    *
    * // The following assertions fail:
-   * assertThat(root).isDirectoryContaining("glob:**dir");
-   * assertThat(root).isDirectoryContaining("glob:**.bin");
-   * assertThat(root).isDirectoryContaining("glob:**.{java,class}"); </code></pre>
+   * assertThat(root).isDirectoryContaining("glob:sub-dir-1/file*");
+   * assertThat(root).isDirectoryContaining("glob:*.txt");
+   * assertThat(root).isDirectoryContaining("glob:**.txt");
+   * assertThat(root).isDirectoryContaining("glob:*.{java,class}"); </code></pre>
    *
-   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @param syntaxAndPattern the syntax and pattern for {@link PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
    * @throws AssertionError       if actual is {@code null}.
    * @throws AssertionError       if actual does not exist.
    * @throws AssertionError       if actual is not a directory.
-   * @throws AssertionError       if actual does not contain any files matching the given path matcher.
+   * @throws AssertionError       if actual does not contain any entries with name matching the given path matcher.
    * @see FileSystem#getPathMatcher(String)
    * @since 3.13.0
    */
@@ -1574,7 +1579,7 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * assertThat(root).isDirectoryRecursivelyContaining("glob:**.bin");
    * assertThat(root).isDirectoryRecursivelyContaining("glob:**.{java,class}"); </code></pre>
    *
-   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @param syntaxAndPattern the syntax and pattern for {@link PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
    * @throws AssertionError       if actual is {@code null}.
@@ -1673,16 +1678,16 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
   }
 
   /**
-   * Verify that the actual {@code Path} is a directory that does not contain any files matching the given {@code String}
-   * interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
+   * Verify that the actual {@code Path} is a directory that does not contain any entries with name matching
+   * the given {@code String}, interpreted as a path matcher (as per {@link FileSystem#getPathMatcher(String)}).
    * <p>
    * Note that the actual {@link Path} must exist and be a directory.
    * <p>
    * Given the following directory structure:
    * <pre><code class="text"> /root/
    * /root/sub-dir-1/
-   * /root/sub-dir-1/file-1.ext
-   * /root/sub-dir-1/file-2.ext
+   * /root/sub-dir-1/file-1.txt
+   * /root/sub-dir-1/file-2.txt
    * /root/sub-file-1.ext
    * /root/sub-file-2.ext</code></pre>
    *
@@ -1690,25 +1695,29 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * <pre><code class="java"> Path root = Paths.get("root");
    *
    * // The following assertions succeed:
-   * assertThat(root).isDirectoryNotContaining("glob:**dir")
-   *                 .isDirectoryNotContaining("glob:**.bin")
-   *                 .isDirectoryNotContaining("regex:.*bin")
-   *                 .isDirectoryNotContaining("glob:**.{java,class}");
+   * assertThat(root).isDirectoryNotContaining("glob:sub-dir-1/file*")
+   *                 .isDirectoryNotContaining("glob:*.txt")
+   *                 .isDirectoryNotContaining("glob:**.txt")
+   *                 .isDirectoryNotContaining("regex:.*txt")
+   *                 .isDirectoryNotContaining("glob:*.{java,class}");
    *
    * // The following assertions fail:
+   * assertThat(root).isDirectoryNotContaining("glob:sub-dir*");
    * assertThat(root).isDirectoryNotContaining("glob:**sub-dir*");
+   * assertThat(root).isDirectoryNotContaining("glob:sub-file*");
    * assertThat(root).isDirectoryNotContaining("glob:**sub-file*");
+   * assertThat(root).isDirectoryNotContaining("glob:*.ext");
    * assertThat(root).isDirectoryNotContaining("glob:**.ext");
    * assertThat(root).isDirectoryNotContaining("regex:.*ext");
-   * assertThat(root).isDirectoryNotContaining("glob:**.{ext,bin"); </code></pre>
+   * assertThat(root).isDirectoryNotContaining("glob:*.{ext,bin}"); </code></pre>
    *
-   * @param syntaxAndPattern the syntax and pattern for {@link java.nio.file.PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
+   * @param syntaxAndPattern the syntax and pattern for {@link PathMatcher} as described in {@link FileSystem#getPathMatcher(String)}.
    * @return {@code this} assertion object.
    * @throws NullPointerException if the given syntaxAndPattern is {@code null}.
    * @throws AssertionError       if actual is {@code null}.
    * @throws AssertionError       if actual does not exist.
    * @throws AssertionError       if actual is not a directory.
-   * @throws AssertionError       if actual contains a file matching the given path matcher.
+   * @throws AssertionError       if actual contains an entry with name matching the given path matcher.
    * @see FileSystem#getPathMatcher(String)
    * @since 3.13.0
    */

--- a/src/main/java/org/assertj/core/error/ShouldContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldContain.java
@@ -83,11 +83,12 @@ public class ShouldContain extends BasicErrorMessageFactory {
   }
 
   public static ErrorMessageFactory directoryShouldContain(Path actual, List<Path> directoryContent, String filterDescription) {
-    return new ShouldContain(actual, toPathNames(directoryContent), filterDescription);
+    return new ShouldContain(actual, toPathFileNames(directoryContent), filterDescription);
   }
 
-  private static List<String> toPathNames(List<Path> files) {
+  private static List<String> toPathFileNames(List<Path> files) {
     return files.stream()
+                .map(Path::getFileName)
                 .map(Path::toString)
                 .collect(toList());
   }

--- a/src/main/java/org/assertj/core/error/ShouldNotContain.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotContain.java
@@ -69,11 +69,12 @@ public class ShouldNotContain extends BasicErrorMessageFactory {
   }
 
   public static ErrorMessageFactory directoryShouldNotContain(Path actual, List<Path> matchingContent, String filterDescription) {
-    return new ShouldNotContain(actual, toPathNames(matchingContent), filterDescription);
+    return new ShouldNotContain(actual, toPathFileNames(matchingContent), filterDescription);
   }
 
-  private static List<String> toPathNames(List<Path> files) {
+  private static List<String> toPathFileNames(List<Path> files) {
     return files.stream()
+                .map(Path::getFileName)
                 .map(Path::toString)
                 .collect(toList());
   }

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -481,14 +481,16 @@ public class Files {
 
   public void assertIsDirectoryContaining(AssertionInfo info, File actual, String syntaxAndPattern) {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
-    FileFilter filter = fileFilter(info, actual, syntaxAndPattern);
-    assertIsDirectoryContaining(info, actual, filter, format("the '%s' pattern", syntaxAndPattern));
+    FileFilter fileNameFilter = fileNameFilter(info, actual, syntaxAndPattern);
+    assertIsDirectoryContaining(info, actual, fileNameFilter, format("the '%s' pattern", syntaxAndPattern));
   }
 
   public void assertIsDirectoryRecursivelyContaining(AssertionInfo info, File actual, String syntaxAndPattern) {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
-    FileFilter filter = fileFilter(info, actual, syntaxAndPattern);
-    assertIsDirectoryRecursivelyContaining(info, actual, filter::accept, format("the '%s' pattern", syntaxAndPattern));
+    assertNotNull(info, actual);
+    PathMatcher pathMatcher = actual.toPath().getFileSystem().getPathMatcher(syntaxAndPattern);
+    assertIsDirectoryRecursivelyContaining(info, actual, file -> pathMatcher.matches(file.toPath()),
+                                           format("the '%s' pattern", syntaxAndPattern));
   }
 
   public void assertIsDirectoryRecursivelyContaining(AssertionInfo info, File actual, Predicate<File> filter) {
@@ -503,8 +505,8 @@ public class Files {
 
   public void assertIsDirectoryNotContaining(AssertionInfo info, File actual, String syntaxAndPattern) {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
-    FileFilter filter = fileFilter(info, actual, syntaxAndPattern);
-    assertIsDirectoryNotContaining(info, actual, filter, format("the '%s' pattern", syntaxAndPattern));
+    FileFilter fileNameFilter = fileNameFilter(info, actual, syntaxAndPattern);
+    assertIsDirectoryNotContaining(info, actual, fileNameFilter, format("the '%s' pattern", syntaxAndPattern));
   }
 
   // non-public section
@@ -566,10 +568,10 @@ public class Files {
     }
   }
 
-  private static FileFilter fileFilter(AssertionInfo info, File actual, String syntaxAndPattern) {
+  private FileFilter fileNameFilter(AssertionInfo info, File actual, String syntaxAndPattern) {
     assertNotNull(info, actual);
     PathMatcher matcher = actual.toPath().getFileSystem().getPathMatcher(syntaxAndPattern);
-    return file -> matcher.matches(file.toPath());
+    return file -> matcher.matches(file.toPath().getFileName());
   }
 
   private static void assertNotNull(AssertionInfo info, File actual) {

--- a/src/main/java/org/assertj/core/internal/Files.java
+++ b/src/main/java/org/assertj/core/internal/Files.java
@@ -568,7 +568,7 @@ public class Files {
     }
   }
 
-  private FileFilter fileNameFilter(AssertionInfo info, File actual, String syntaxAndPattern) {
+  private static FileFilter fileNameFilter(AssertionInfo info, File actual, String syntaxAndPattern) {
     assertNotNull(info, actual);
     PathMatcher matcher = actual.toPath().getFileSystem().getPathMatcher(syntaxAndPattern);
     return file -> matcher.matches(file.toPath().getFileName());

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -320,13 +320,14 @@ public class Paths {
 
   public void assertIsDirectoryContaining(AssertionInfo info, Path actual, String syntaxAndPattern) {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
-    PathMatcher pathMatcher = pathMatcher(info, actual, syntaxAndPattern);
-    assertIsDirectoryContaining(info, actual, pathMatcher::matches, format("the '%s' pattern", syntaxAndPattern));
+    Filter<Path> filter = fileNameFilter(info, actual, syntaxAndPattern);
+    assertIsDirectoryContaining(info, actual, filter, format("the '%s' pattern", syntaxAndPattern));
   }
 
   public void assertIsDirectoryRecursivelyContaining(AssertionInfo info, Path actual, String syntaxAndPattern) {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
-    PathMatcher pathMatcher = pathMatcher(info, actual, syntaxAndPattern);
+    assertNotNull(info, actual);
+    PathMatcher pathMatcher = actual.getFileSystem().getPathMatcher(syntaxAndPattern);
     assertIsDirectoryRecursivelyContaining(info, actual, pathMatcher::matches,
                                            format("the '%s' pattern", syntaxAndPattern));
   }
@@ -343,8 +344,8 @@ public class Paths {
 
   public void assertIsDirectoryNotContaining(AssertionInfo info, Path actual, String syntaxAndPattern) {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
-    PathMatcher pathMatcher = pathMatcher(info, actual, syntaxAndPattern);
-    assertIsDirectoryNotContaining(info, actual, pathMatcher::matches, format("the '%s' pattern", syntaxAndPattern));
+    Filter<Path> filter = fileNameFilter(info, actual, syntaxAndPattern);
+    assertIsDirectoryNotContaining(info, actual, filter, format("the '%s' pattern", syntaxAndPattern));
   }
 
   public void assertIsEmptyDirectory(AssertionInfo info, Path actual) {
@@ -432,9 +433,10 @@ public class Paths {
     }
   }
 
-  private PathMatcher pathMatcher(AssertionInfo info, Path actual, String syntaxAndPattern) {
+  private Filter<Path> fileNameFilter(AssertionInfo info, Path actual, String syntaxAndPattern) {
     assertNotNull(info, actual);
-    return actual.getFileSystem().getPathMatcher(syntaxAndPattern);
+    PathMatcher matcher = actual.getFileSystem().getPathMatcher(syntaxAndPattern);
+    return entry -> matcher.matches(entry.getFileName());
   }
 
   private static void assertNotNull(final AssertionInfo info, final Path actual) {

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -328,8 +328,7 @@ public class Paths {
     requireNonNull(syntaxAndPattern, "The syntax and pattern should not be null");
     assertNotNull(info, actual);
     PathMatcher pathMatcher = actual.getFileSystem().getPathMatcher(syntaxAndPattern);
-    assertIsDirectoryRecursivelyContaining(info, actual, pathMatcher::matches,
-                                           format("the '%s' pattern", syntaxAndPattern));
+    assertIsDirectoryRecursivelyContaining(info, actual, pathMatcher::matches, format("the '%s' pattern", syntaxAndPattern));
   }
 
   public void assertIsDirectoryRecursivelyContaining(AssertionInfo info, Path actual, Predicate<Path> filter) {

--- a/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContain_create_Test.java
@@ -338,8 +338,7 @@ class ShouldContain_create_Test {
                                    "  root%n" +
                                    "to contain at least one file matching glob:**.java but there was none.%n" +
                                    "The directory content was:%n" +
-                                   "  [%s, %s]",
-                                   directory.resolve("foo.txt"), directory.resolve("bar.txt")));
+                                   "  [foo.txt, bar.txt]"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotContain_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotContain_create_Test.java
@@ -109,8 +109,7 @@ class ShouldNotContain_create_Test {
                                    "Expecting directory:%n" +
                                    "  root%n" +
                                    "not to contain any files matching glob:**.java but found some:%n" +
-                                   "  [%s, %s]",
-                                   directory.resolve("foo.txt"), directory.resolve("bar.txt")));
+                                   "  [foo.txt, bar.txt]"));
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/FilesBaseTest.java
+++ b/src/test/java/org/assertj/core/internal/FilesBaseTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.assertj.core.api.AssertionInfo;
 import org.assertj.core.util.diff.Delta;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Base class for testing <code>{@link Files}</code>, set up diff and failures attributes (which is why it is in
@@ -45,6 +46,9 @@ import org.junit.jupiter.api.BeforeEach;
 public class FilesBaseTest {
 
   protected static final AssertionInfo INFO = someInfo();
+
+  @TempDir
+  protected Path tempDir;
 
   protected File actual;
   protected Failures failures;
@@ -125,8 +129,8 @@ public class FilesBaseTest {
     given(file.listFiles(any(FileFilter.class))).will(invocation -> {
       FileFilter filter = invocation.getArgument(0);
       return filesByName.keySet().stream()
-                        .map(name -> filesByName.get(name))
-                        .filter(fileWithName -> filter.accept(fileWithName))
+                        .map(filesByName::get)
+                        .filter(filter::accept)
                         .toArray(File[]::new);
     });
     return file;

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_with_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_with_Predicate_Test.java
@@ -30,17 +30,13 @@ import java.io.FileFilter;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link Files#assertIsDirectoryContaining(AssertionInfo, File, Predicate)}</code>
- *
  * @author Valeriy Vyrva
  */
-class Files_assertIsDirectoryContaining_Predicate_Test extends FilesBaseTest {
+class Files_assertIsDirectoryContaining_with_Predicate_Test extends FilesBaseTest {
 
   private static final Predicate<File> JAVA_SOURCE = file -> file.getName().endsWith(".java");
 

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_with_String_Test.java
@@ -13,6 +13,8 @@
 package org.assertj.core.internal.files;
 
 import static java.lang.String.format;
+import static java.nio.file.Files.createDirectory;
+import static java.nio.file.Files.createFile;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -30,6 +32,7 @@ import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.FileFilter;
+import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -37,17 +40,15 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for <code>{@link Files#assertIsDirectoryContaining(AssertionInfo, File, String)}</code>
- *
  * @author Valeriy Vyrva
  */
-class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseTest {
+class Files_assertIsDirectoryContaining_with_String_Test extends FilesBaseTest {
 
   private static final String JAVA_SOURCE_PATTERN = "regex:.+\\.java";
   private static final String JAVA_SOURCE_PATTERN_DESCRIPTION = format("the '%s' pattern", JAVA_SOURCE_PATTERN);
@@ -192,4 +193,21 @@ class Files_assertIsDirectoryContaining_SyntaxAndPattern_Test extends FilesBaseT
     }
     given(path.getFileSystem()).willReturn(fileSystem);
   }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "glob:**file",
+      "glob:file",
+      "regex:.*file",
+      "regex:file",
+  })
+  void should_pass_if_actual_contains_at_least_one_path_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
+    // GIVEN
+    File actual = createDirectory(tempDir.resolve("actual")).toFile();
+    createFile(actual.toPath().resolve("file"));
+    createDirectory(actual.toPath().resolve("directory"));
+    // WHEN/THEN
+    files.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern);
+  }
+
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryContaining_with_String_Test.java
@@ -16,7 +16,6 @@ import static java.lang.String.format;
 import static java.nio.file.Files.createDirectory;
 import static java.nio.file.Files.createFile;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -226,7 +225,7 @@ class Files_assertIsDirectoryContaining_with_String_Test extends FilesBaseTest {
     // WHEN
     AssertionError error = expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
-    then(error).hasMessage(directoryShouldContain(actual, toFileNames(singletonList(directory)),
+    then(error).hasMessage(directoryShouldContain(actual, list(directory),
                                                   format("the '%s' pattern", syntaxAndPattern)).create());
   }
 
@@ -245,7 +244,7 @@ class Files_assertIsDirectoryContaining_with_String_Test extends FilesBaseTest {
     // WHEN
     AssertionError error = expectAssertionError(() -> files.assertIsDirectoryContaining(INFO, actual, syntaxAndPattern));
     // THEN
-    then(error).hasMessage(directoryShouldContain(actual, toFileNames(singletonList(directory)),
+    then(error).hasMessage(directoryShouldContain(actual, list(directory),
                                                   format("the '%s' pattern", syntaxAndPattern)).create());
   }
 

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_with_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_with_Predicate_Test.java
@@ -30,17 +30,13 @@ import java.io.FileFilter;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Files;
 import org.assertj.core.internal.FilesBaseTest;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for <code>{@link Files#assertIsDirectoryNotContaining(AssertionInfo, File, Predicate)}</code>
- *
  * @author Valeriy Vyrva
  */
-class Files_assertIsDirectoryNotContaining_Predicate_Test extends FilesBaseTest {
+class Files_assertIsDirectoryNotContaining_with_Predicate_Test extends FilesBaseTest {
 
   private static final Predicate<File> JAVA_SOURCE = file -> file.getName().endsWith(".java");
 

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_with_String_Test.java
@@ -16,7 +16,6 @@ import static java.lang.String.format;
 import static java.nio.file.Files.createDirectory;
 import static java.nio.file.Files.createFile;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -53,7 +52,7 @@ class Files_assertIsDirectoryNotContaining_with_String_Test extends FilesBaseTes
   void should_pass_if_actual_does_not_contain_files_matching_the_given_pathMatcherPattern() {
     // GIVEN
     File file = mockRegularFile("root", "Test.class");
-    List<File> items = singletonList(file);
+    List<File> items = list(file);
     File actual = mockDirectory(items, "root");
     mockPathMatcher(actual);
     // THEN
@@ -186,9 +185,7 @@ class Files_assertIsDirectoryNotContaining_with_String_Test extends FilesBaseTes
     AssertionError error = expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual,
                                                                                            syntaxAndPattern));
     // THEN
-    then(error).hasMessage(directoryShouldNotContain(actual,
-                                                     toFileNames(singletonList(file)),
-                                                     "the '" + syntaxAndPattern + "' pattern").create());
+    then(error).hasMessage(directoryShouldNotContain(actual, list(file), "the '" + syntaxAndPattern + "' pattern").create());
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/files/Files_assertIsDirectoryNotContaining_with_String_Test.java
@@ -177,15 +177,45 @@ class Files_assertIsDirectoryNotContaining_with_String_Test extends FilesBaseTes
       "regex:.*file",
       "regex:file",
   })
-  void should_fail_if_actual_contains_at_least_one_path_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
+  void should_fail_if_actual_directly_contains_any_entries_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
     // GIVEN
     File actual = createDirectory(tempDir.resolve("actual")).toFile();
     File file = createFile(actual.toPath().resolve("file")).toFile();
     // WHEN
-    AssertionError error = expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual,
-                                                                                           syntaxAndPattern));
+    AssertionError error = expectAssertionError(() -> files.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern));
     // THEN
     then(error).hasMessage(directoryShouldNotContain(actual, list(file), "the '" + syntaxAndPattern + "' pattern").create());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "glob:**file",
+      "glob:file",
+      "regex:.*file",
+      "regex:file",
+  })
+  void should_pass_if_actual_does_not_contain_any_entries_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
+    // GIVEN
+    File actual = createDirectory(tempDir.resolve("actual")).toFile();
+    createDirectory(actual.toPath().resolve("directory"));
+    // WHEN/THEN
+    files.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "glob:**file",
+      "glob:file",
+      "regex:.*file",
+      "regex:file",
+  })
+  void should_pass_if_actual_recursively_contains_any_entries_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
+    // GIVEN
+    File actual = createDirectory(tempDir.resolve("actual")).toFile();
+    File directory = createDirectory(actual.toPath().resolve("directory")).toFile();
+    createFile(directory.toPath().resolve("file"));
+    // WHEN/THEN
+    files.assertIsDirectoryNotContaining(INFO, actual, syntaxAndPattern);
   }
 
 }

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryContaining_with_String_Test.java
@@ -113,9 +113,9 @@ class Paths_assertIsDirectoryContaining_with_String_Test extends PathsBaseTest {
   @ParameterizedTest
   @ValueSource(strings = {
       "glob:**file",
-//    "glob:file",    // fails due to gh-2329
+      "glob:file",
       "regex:.*file",
-//    "regex:file",   // fails due to gh-2329
+      "regex:file",
   })
   void should_pass_if_actual_directly_contains_any_entries_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
     // GIVEN

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
@@ -114,7 +114,7 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
       "regex:.*file",
       "regex:file",
   })
-  void should_fail_if_actual_contains_at_least_one_path_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
+  void should_fail_if_actual_directly_contains_any_entries_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("actual"));
     Path file = createFile(actual.resolve("file"));

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryNotContaining_with_String_Test.java
@@ -110,11 +110,11 @@ class Paths_assertIsDirectoryNotContaining_with_String_Test extends PathsBaseTes
   @ParameterizedTest
   @ValueSource(strings = {
       "glob:**file",
-//    "glob:file",    // fails due to gh-2329
+      "glob:file",
       "regex:.*file",
-//    "regex:file",   // fails due to gh-2329
+      "regex:file",
   })
-  void should_fail_if_actual_directly_contains_any_entries_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
+  void should_fail_if_actual_contains_at_least_one_path_matching_the_given_pattern(String syntaxAndPattern) throws IOException {
     // GIVEN
     Path actual = createDirectory(tempDir.resolve("actual"));
     Path file = createFile(actual.resolve("file"));

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_with_Predicate_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_with_Predicate_Test.java
@@ -26,8 +26,6 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Paths;
 import org.assertj.core.internal.PathsSimpleBaseTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -37,11 +35,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
- * Tests for <code>{@link Paths#assertIsDirectoryRecursivelyContaining(AssertionInfo, Path, java.util.function.Predicate)}</code>
- *
  * @author David Haccoun
  */
-class Paths_assertIsDirectoryRecursivelyContaining_Predicate_Test extends PathsSimpleBaseTest {
+class Paths_assertIsDirectoryRecursivelyContaining_with_Predicate_Test extends PathsSimpleBaseTest {
 
   private static final String THE_GIVEN_FILTER_DESCRIPTION = "the given filter";
 

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_with_String_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertIsDirectoryRecursivelyContaining_with_String_Test.java
@@ -24,23 +24,18 @@ import static org.mockito.Mockito.verify;
 import java.nio.file.Path;
 import java.util.List;
 
-import org.assertj.core.api.AssertionInfo;
-import org.assertj.core.internal.Paths;
 import org.assertj.core.internal.PathsSimpleBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
- * Tests for <code>{@link Paths#assertIsDirectoryRecursivelyContaining(AssertionInfo, Path, String)}</code>
- *
  * @author David Haccoun
  */
-class Paths_assertIsDirectoryRecursivelyContaining_SyntaxAndPattern_Test extends PathsSimpleBaseTest {
+class Paths_assertIsDirectoryRecursivelyContaining_with_String_Test extends PathsSimpleBaseTest {
 
   private static final String TXT_EXTENSION_PATTERN = "regex:.+\\.txt";
-  private static final String TXT_EXTENSION_PATTERN_DESCRIPTION = format("the '%s' pattern",
-                                                                         TXT_EXTENSION_PATTERN);
+  private static final String TXT_EXTENSION_PATTERN_DESCRIPTION = format("the '%s' pattern", TXT_EXTENSION_PATTERN);
 
   @ParameterizedTest
   @ValueSource(strings = { "regex:.+oo2\\.data", "regex:.+\\.json", "regex:.+bar2\\.json" })


### PR DESCRIPTION
Fixes #2329.

- [x] Update `Path` assertions
- [x] Update `File` assertions
- [x] Align error message format between `File` and `Path` assertions: absolute or relative paths?
- [x] Evaluate `isDirectoryRecursivelyContaining` behavior change for both `File` and `Path` assertions
- [x] Update javadoc