### PR TITLE
Add hasNoExtension to Path assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1945,10 +1945,10 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
    * Path pathWithExtension = Paths.get(&quot;file.txt&quot;);
    *
    * // assertion will pass
-   * assertThat(pathWithoutExtension).hasExtension();
+   * assertThat(pathWithoutExtension).hasNoExtension();
    *
    * // assertion will fail
-   * assertThat(pathWithExtension).hasExtension();</code></pre>
+   * assertThat(pathWithExtension).hasNoExtension();</code></pre>
    *
    * @return {@code this} assertion object.
    * @throws AssertionError if the actual {@code Path} is {@code null}.

--- a/src/main/java/org/assertj/core/api/AbstractPathAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractPathAssert.java
@@ -1936,4 +1936,28 @@ public abstract class AbstractPathAssert<SELF extends AbstractPathAssert<SELF>> 
     return myself;
   }
 
+  /**
+   * Verifies that the actual {@code Path} has no extension.
+   *
+   * <p>
+   * Example:
+   * <pre><code class='java'> Path pathWithoutExtension = Paths.get(&quot;file&quot;);
+   * Path pathWithExtension = Paths.get(&quot;file.txt&quot;);
+   *
+   * // assertion will pass
+   * assertThat(pathWithoutExtension).hasExtension();
+   *
+   * // assertion will fail
+   * assertThat(pathWithExtension).hasExtension();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual {@code Path} is {@code null}.
+   * @throws AssertionError if the actual {@code Path} is not a regular file.
+   * @throws AssertionError if the actual {@code Path} does have an extension.
+   */
+  public SELF hasNoExtension() {
+    paths.assertHasNoExtension(info, actual);
+    return myself;
+  }
+
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveNoExtension.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveNoExtension.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+import java.nio.file.Path;
+
+/**
+ * Creates an error message indicating that a {@code Path} should have no extension.
+ */
+public class ShouldHaveNoExtension extends BasicErrorMessageFactory {
+
+  @VisibleForTesting
+  public static final String PATH_HAS_EXTENSION = "%nExpected actual path:%n  %s%n not to have an extension, but extension was:%n  %s";
+
+  public static ShouldHaveNoExtension shouldHaveNoExtension(Path actual, String extension) {
+    return new ShouldHaveNoExtension(actual, extension);
+  }
+
+  private ShouldHaveNoExtension(Path actual, String extension) {
+    super(PATH_HAS_EXTENSION, actual, extension);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldHaveNoExtension.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveNoExtension.java
@@ -22,7 +22,7 @@ import java.nio.file.Path;
 public class ShouldHaveNoExtension extends BasicErrorMessageFactory {
 
   @VisibleForTesting
-  public static final String PATH_HAS_EXTENSION = "%nExpected actual path:%n  %s%n not to have an extension, but extension was:%n  %s";
+  public static final String PATH_HAS_EXTENSION = "%nExpected actual path:%n  %s%n not to have an extension, but extension was: %s";
 
   public static ShouldHaveNoExtension shouldHaveNoExtension(Path actual, String extension) {
     return new ShouldHaveNoExtension(actual, extension);

--- a/src/main/java/org/assertj/core/internal/Paths.java
+++ b/src/main/java/org/assertj/core/internal/Paths.java
@@ -40,6 +40,7 @@ import static org.assertj.core.error.ShouldHaveContent.shouldHaveContent;
 import static org.assertj.core.error.ShouldHaveDigest.shouldHaveDigest;
 import static org.assertj.core.error.ShouldHaveExtension.shouldHaveExtension;
 import static org.assertj.core.error.ShouldHaveName.shouldHaveName;
+import static org.assertj.core.error.ShouldHaveNoExtension.shouldHaveNoExtension;
 import static org.assertj.core.error.ShouldHaveNoParent.shouldHaveNoParent;
 import static org.assertj.core.error.ShouldHaveParent.shouldHaveParent;
 import static org.assertj.core.error.ShouldHaveSameContent.shouldHaveSameContent;
@@ -476,6 +477,12 @@ public class Paths {
     assertIsRegularFile(info, actual);
     String extension = getExtension(actual).orElseThrow(() -> failures.failure(info, shouldHaveExtension(actual, expected)));
     if (!expected.equals(extension)) throw failures.failure(info, shouldHaveExtension(actual, extension, expected));
+  }
+
+  public void assertHasNoExtension(AssertionInfo info, Path actual) {
+    assertIsRegularFile(info, actual);
+    Optional<String> extension = getExtension(actual);
+    if (extension.isPresent()) throw failures.failure(info, shouldHaveNoExtension(actual, extension.get()));
   }
 
   private static Optional<String> getExtension(Path path) {

--- a/src/test/java/org/assertj/core/api/path/PathAssert_hasNoExtension_Test.java
+++ b/src/test/java/org/assertj/core/api/path/PathAssert_hasNoExtension_Test.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.path;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.PathAssert;
+import org.assertj.core.api.PathAssertBaseTest;
+
+class PathAssert_hasNoExtension_Test extends PathAssertBaseTest {
+
+  @Override
+  protected PathAssert invoke_api_method() {
+    return assertions.hasNoExtension();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(paths).assertHasNoExtension(getInfo(assertions), getActual(assertions));
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldHaveNoExtension_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldHaveNoExtension_create_Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveNoExtension.shouldHaveNoExtension;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+import static org.mockito.Mockito.mock;
+
+import java.nio.file.Path;
+
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+class ShouldHaveNoExtension_create_Test {
+
+  private static final TestDescription TEST_DESCRIPTION = new TestDescription("Test");
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    final Path path = mock(Path.class);
+    // WHEN
+    String actualMessage = shouldHaveNoExtension(path, "java").create(TEST_DESCRIPTION, STANDARD_REPRESENTATION);
+    // THEN
+    then(actualMessage).isEqualTo(format("[Test] " + ShouldHaveNoExtension.PATH_HAS_EXTENSION, path, "\"java\""));
+  }
+}

--- a/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoExtension_Test.java
+++ b/src/test/java/org/assertj/core/internal/paths/Paths_assertHasNoExtension_Test.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.paths;
+
+import static java.nio.file.Files.createDirectory;
+import static java.nio.file.Files.createFile;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldBeRegularFile.shouldBeRegularFile;
+import static org.assertj.core.error.ShouldExist.shouldExist;
+import static org.assertj.core.error.ShouldHaveNoExtension.shouldHaveNoExtension;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.assertj.core.internal.PathsBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class Paths_assertHasNoExtension_Test extends PathsBaseTest {
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    Path actual = null;
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    // THEN
+    then(error).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_exist() {
+    // GIVEN
+    Path actual = tempDir.resolve("non-existent");
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    // THEN
+    then(error).hasMessage(shouldExist(actual).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_a_regular_file() throws IOException {
+    // GIVEN
+    Path actual = createDirectory(tempDir.resolve("directory"));
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    // THEN
+    then(error).hasMessage(shouldBeRegularFile(actual).create());
+  }
+
+  @Test
+  void should_fail_if_actual_has_extension() throws IOException {
+    // GIVEN
+    Path actual = createFile(tempDir.resolve("file.txt"));
+    // WHEN
+    AssertionError error = expectAssertionError(() -> paths.assertHasNoExtension(info, actual));
+    // THEN
+    then(error).hasMessage(shouldHaveNoExtension(actual, "txt").create());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "file", "file." })
+  void should_pass_if_actual_has_no_extension(String filename) throws IOException {
+    // GIVEN
+    Path actual = createFile(tempDir.resolve(filename));
+    // WHEN/THEN
+    paths.assertHasNoExtension(info, actual);
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Fixes #2318
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
