### PR TITLE
Fix JavaDoc for containsExactlyInAnyOrderElementsOf

### DIFF
--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -208,10 +208,10 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * Iterable&lt;Ring&gt; elvesRingsDifferentOrder = newArrayList(nenya, narya, vilya, vilya);
    *
    * // assertion will pass
-   * assertThat(elvesRings).containsExactlyInAnyOrder(elvesRingsDifferentOrder);
+   * assertThat(elvesRings).containsExactlyInAnyOrderElementsOf(elvesRingsDifferentOrder);
    *
    * // assertion will fail as vilya is contained twice in elvesRings.
-   * assertThat(elvesRings).containsExactlyInAnyOrder(elvesRingsSomeMissing);</code></pre>
+   * assertThat(elvesRings).containsExactlyInAnyOrderElementsOf(elvesRingsSomeMissing);</code></pre>
    * <p>
    * If you want to directly specify the elements to check, use {@link #containsExactlyInAnyOrder(Object...) containsExactlyInAnyOrder(Object...)} instead.
    *


### PR DESCRIPTION
#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : NA
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Fixed inconsistency between document and code.
