### PR TITLE
Added possibility to override error messages for the recursive comparison

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -2245,7 +2245,7 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
   @Deprecated
   @CheckReturnValue
   public <T> SELF usingComparatorForElementFieldsWithType(Comparator<T> comparator, Class<T> type) {
-    getComparatorsForElementPropertyOrFieldTypes().put(type, comparator);
+    getComparatorsForElementPropertyOrFieldTypes().registerComparator(type, comparator);
     return myself;
   }
 
@@ -2281,8 +2281,8 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
       usingElementComparator(new ExtendedByTypesComparator(getComparatorsByType()));
     }
 
-    getComparatorsForElementPropertyOrFieldTypes().put(type, comparator);
-    getComparatorsByType().put(type, comparator);
+    getComparatorsForElementPropertyOrFieldTypes().registerComparator(type, comparator);
+    getComparatorsByType().registerComparator(type, comparator);
 
     return myself;
   }

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -1922,7 +1922,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   @Deprecated
   @CheckReturnValue
   public <C> SELF usingComparatorForElementFieldsWithType(Comparator<C> comparator, Class<C> type) {
-    getComparatorsForElementPropertyOrFieldTypes().put(type, comparator);
+    getComparatorsForElementPropertyOrFieldTypes().registerComparator(type, comparator);
     return myself;
   }
 
@@ -1958,8 +1958,8 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
     if (arrays.getComparator() == null) {
       usingElementComparator(new ExtendedByTypesComparator(getComparatorsByType()));
     }
-    getComparatorsForElementPropertyOrFieldTypes().put(type, comparator);
-    getComparatorsByType().put(type, comparator);
+    getComparatorsForElementPropertyOrFieldTypes().registerComparator(type, comparator);
+    getComparatorsByType().registerComparator(type, comparator);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectAssert.java
@@ -603,7 +603,7 @@ public abstract class AbstractObjectAssert<SELF extends AbstractObjectAssert<SEL
    */
   @CheckReturnValue
   public <T> SELF usingComparatorForType(Comparator<? super T> comparator, Class<T> type) {
-    getComparatorsByType().put(type, comparator);
+    getComparatorsByType().registerComparator(type, comparator);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -2048,7 +2048,7 @@ public class AtomicReferenceArrayAssert<T>
   @CheckReturnValue
   public <C> AtomicReferenceArrayAssert<T> usingComparatorForElementFieldsWithType(Comparator<C> comparator,
                                                                                    Class<C> type) {
-    getComparatorsForElementPropertyOrFieldTypes().put(type, comparator);
+    getComparatorsForElementPropertyOrFieldTypes().registerComparator(type, comparator);
     return myself;
   }
 
@@ -2083,8 +2083,8 @@ public class AtomicReferenceArrayAssert<T>
       usingElementComparator(new ExtendedByTypesComparator(getComparatorsByType()));
     }
 
-    getComparatorsForElementPropertyOrFieldTypes().put(type, comparator);
-    getComparatorsByType().put(type, comparator);
+    getComparatorsForElementPropertyOrFieldTypes().registerComparator(type, comparator);
+    getComparatorsByType().registerComparator(type, comparator);
 
     return myself;
   }
@@ -2196,13 +2196,14 @@ public class AtomicReferenceArrayAssert<T>
    * <p>
    * Another point worth mentioning: <b>elements order does matter if the expected iterable is ordered</b>, for example comparing a {@code Set<Person>} to a {@code List<Person>} fails as {@code List} is ordered and {@code Set} is not.<br>
    * The ordering can be ignored by calling {@link RecursiveComparisonAssert#ignoringCollectionOrder ignoringCollectionOrder} allowing ordered/unordered iterable comparison, note that {@link RecursiveComparisonAssert#ignoringCollectionOrder ignoringCollectionOrder} is applied recursively on any nested iterable fields, if this behavior is too generic,
-   * use the more fine grained {@link RecursiveComparisonAssert#ignoringCollectionOrderInFields(String...) ignoringCollectionOrderInFields} or
+   * use the more fine-grained {@link RecursiveComparisonAssert#ignoringCollectionOrderInFields(String...)
+   * ignoringCollectionOrderInFields} or
    * {@link RecursiveComparisonAssert#ignoringCollectionOrderInFieldsMatchingRegexes(String...) ignoringCollectionOrderInFieldsMatchingRegexes}.
    *
    * @return {@code this} assertion object.
    * @since 2.7.0 / 3.7.0 - breaking change in 3.20.0
    * @see RecursiveComparisonConfiguration
-   * @see usingRecursiveFieldByFieldElementComparator(RecursiveComparisonConfiguration)
+   * @see #usingRecursiveFieldByFieldElementComparator(RecursiveComparisonConfiguration)
    */
   @CheckReturnValue
   public AtomicReferenceArrayAssert<T> usingRecursiveFieldByFieldElementComparator() {

--- a/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonKeyDifference.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/ComparisonKeyDifference.java
@@ -42,7 +42,7 @@ public class ComparisonKeyDifference extends ComparisonDifference {
     UnambiguousRepresentation unambiguousRepresentation = new UnambiguousRepresentation(representation, actual, expected);
     UnambiguousRepresentation unambiguousKeyRepresentation = new UnambiguousRepresentation(representation, actualKey,
                                                                                            expectedKey);
-    return format(TEMPLATE + "%n" + TEMPLATE_FOR_KEY_DIFFERENCE,
+    return format(DEFAULT_TEMPLATE + "%n" + TEMPLATE_FOR_KEY_DIFFERENCE,
                   fieldPathDescription(),
                   unambiguousRepresentation.getActual(),
                   unambiguousRepresentation.getExpected(),

--- a/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
@@ -74,7 +74,7 @@ public final class DualValue {
 
   @Override
   public String toString() {
-    return format("DualValue [fielLocation=%s, actual=%s, expected=%s]", fieldLocation, actual, expected);
+    return format("DualValue [fieldLocation=%s, actual=%s, expected=%s]", fieldLocation, actual, expected);
   }
 
   public List<String> getDecomposedPath() {

--- a/src/main/java/org/assertj/core/api/recursive/comparison/FieldComparators.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/FieldComparators.java
@@ -12,85 +12,55 @@
  */
 package org.assertj.core.api.recursive.comparison;
 
-import static java.lang.String.format;
-import static org.assertj.core.util.Strings.join;
-
-import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.TreeMap;
 import java.util.stream.Stream;
-
-import org.assertj.core.util.VisibleForTesting;
 
 /**
  * An internal holder of the comparators for fields described by their path without element index.
  * <p>
  * Examples: {@code name.first} or {@code names.first} but not {@code names[1].first} or {@code names.[1].first}
  */
-public class FieldComparators {
-
-  @VisibleForTesting
-  Map<String, Comparator<?>> fieldComparators;
-
-  public FieldComparators() {
-    fieldComparators = new TreeMap<>();
-  }
+public class FieldComparators extends FieldHolder<Comparator<?>> {
 
   /**
-   * Puts the {@code comparator} for the given {@code clazz}.
+   * Puts the {@code comparator} for the given {@code fieldLocation}.
    *
    * @param fieldLocation the FieldLocation where to apply the comparator
-   * @param comparator the comparator it self
+   * @param comparator the comparator itself
    */
   public void registerComparator(String fieldLocation, Comparator<?> comparator) {
-    fieldComparators.put(fieldLocation, comparator);
+    super.put(fieldLocation, comparator);
   }
 
   /**
-   * @return {@code true} is there are registered comparators, {@code false} otherwise
+   * Checks, whether an any comparator is associated with the giving field location.
+   *
+   * @param fieldLocation the field location which association need to check
+   * @return is field location contain a custom comparator
    */
-  public boolean isEmpty() {
-    return fieldComparators.isEmpty();
-  }
-
-  @Override
-  public int hashCode() {
-    return fieldComparators.hashCode();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    return obj instanceof FieldComparators && Objects.equals(fieldComparators, ((FieldComparators) obj).fieldComparators);
-  }
-
-  @Override
-  public String toString() {
-    List<String> registeredComparatorsDescription = new ArrayList<>();
-    for (Entry<String, Comparator<?>> fieldComparator : this.fieldComparators.entrySet()) {
-      registeredComparatorsDescription.add(formatRegisteredComparator(fieldComparator));
-    }
-    return format("{%s}", join(registeredComparatorsDescription).with(", "));
-  }
-
-  private static String formatRegisteredComparator(Entry<String, Comparator<?>> fieldComparator) {
-    return format("%s -> %s", fieldComparator, fieldComparator.getValue());
-  }
-
   public boolean hasComparatorForField(String fieldLocation) {
     // TODO sanitize here?
-    return fieldComparators.containsKey(fieldLocation);
+    return super.hasEntity(fieldLocation);
   }
 
+  /**
+   * Retrieves a custom comparator, which is associated with the giving field location. If this location does not
+   * associate with any custom comparators - this method returns null.
+   *
+   * @param fieldLocation the field location that has to be associated with a comparator
+   * @return a custom comparator or null
+   */
   public Comparator<?> getComparatorForField(String fieldLocation) {
-    return fieldComparators.get(fieldLocation);
+    return super.get(fieldLocation);
   }
 
+  /**
+   * Returns a sequence of associated field-comparator pairs.
+   *
+   * @return sequence of field-comparator pairs
+   */
   public Stream<Entry<String, Comparator<?>>> comparatorByFields() {
-    return fieldComparators.entrySet().stream();
+    return super.entryByField();
   }
-
 }

--- a/src/main/java/org/assertj/core/api/recursive/comparison/FieldHolder.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/FieldHolder.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.lang.String.format;
+import static org.assertj.core.util.Strings.join;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+/**
+ * An abstract field holder which provides to pair a specific entities for fields described by their path without
+ * element index.
+ *
+ * @param <T> entity type
+ */
+abstract class FieldHolder<T> {
+
+  protected final Map<String, T> fieldHolder;
+
+  public FieldHolder() {
+    fieldHolder = new TreeMap<>();
+  }
+
+  /**
+   * Pairs the giving {@code entity} with the {@code fieldLocation}.
+   *
+   * @param fieldLocation the field location where to apply the giving entity
+   * @param entity the entity to pair
+   */
+  public void put(String fieldLocation, T entity) {
+    fieldHolder.put(fieldLocation, entity);
+  }
+
+  /**
+   * Retrieves a specific entity which is associated with the giving {@code filedLocation} from the field holder, if it
+   * presents. Otherwise, this method returns {@code null}.
+   *
+   * @param fieldLocation the field location which has to be associated with an entity
+   * @return entity or null
+   */
+  public T get(String fieldLocation) {
+    return fieldHolder.get(fieldLocation);
+  }
+
+  /**
+   * Checks, whether an any entity associated with the giving field location.
+   *
+   * @param fieldLocation the field location which association need to check
+   * @return is entity associated with field location
+   */
+  public boolean hasEntity(String fieldLocation) {
+    return fieldHolder.containsKey(fieldLocation);
+  }
+
+  /**
+   * @return {@code true} is there are registered entities, {@code false} otherwise
+   */
+  public boolean isEmpty() {
+    return fieldHolder.isEmpty();
+  }
+
+  /**
+   * Returns a sequence of all field-entry pairs which the current holder supplies.
+   *
+   * @return sequence of field-entry pairs
+   */
+  public Stream<Entry<String, T>> entryByField() {
+    return fieldHolder.entrySet().stream();
+  }
+
+  @Override
+  public String toString() {
+    List<String> registeredEntitiesDescription = new ArrayList<>();
+    for (Entry<String, T> entry : this.fieldHolder.entrySet()) {
+      registeredEntitiesDescription.add(formatRegisteredEntity(entry));
+    }
+    return format("{%s}", join(registeredEntitiesDescription).with(", "));
+  }
+
+  private static <T> String formatRegisteredEntity(Entry<String, T> entry) {
+    return format("%s -> %s", entry.getKey(), entry.getValue());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    FieldHolder<?> that = (FieldHolder<?>) o;
+    return fieldHolder.equals(that.fieldHolder);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fieldHolder);
+  }
+}

--- a/src/main/java/org/assertj/core/api/recursive/comparison/FieldMessages.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/FieldMessages.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import java.util.Map.Entry;
+import java.util.stream.Stream;
+
+/**
+ * An internal holder of the custom messages for fields described by their path without element index.
+ */
+public class FieldMessages extends FieldHolder<String> {
+
+  /**
+   * Pairs the giving error {@code message} with the {@code fieldLocation}.
+   *
+   * @param fieldLocation the field location where to apply the giving error message
+   * @param message the error message
+   */
+  public void registerMessage(String fieldLocation, String message) {
+    super.put(fieldLocation, message);
+  }
+
+  /**
+   * Checks, whether an any custom message is associated with the giving field location.
+   *
+   * @param fieldLocation the field location which association need to check
+   * @return is field location contain a custom message
+   */
+  public boolean hasMessageForField(String fieldLocation) {
+    return super.hasEntity(fieldLocation);
+  }
+
+  /**
+   * Retrieves a custom message, which is associated with the giving field location. If this location does not
+   * associate with any custom message - this method returns null.
+   *
+   * @param fieldLocation the field location that has to be associated with a message
+   * @return a custom message or null
+   */
+  public String getMessageForField(String fieldLocation) {
+    return super.get(fieldLocation);
+  }
+
+  /**
+   * Returns a sequence of associated field-message pairs.
+   *
+   * @return sequence of field-message pairs
+   */
+  public Stream<Entry<String, String>> messageByFields() {
+    return super.entryByField();
+  }
+}

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -14,13 +14,16 @@ package org.assertj.core.api.recursive.comparison;
 
 import static java.lang.String.format;
 import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.configuration.ConfigurationProvider.CONFIGURATION_PROVIDER;
 import static org.assertj.core.internal.TypeComparators.defaultTypeComparators;
 import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
+import static org.assertj.core.util.Strings.formatIfArgs;
 import static org.assertj.core.util.introspection.PropertyOrFieldSupport.COMPARISON;
 
 import java.util.ArrayList;
@@ -38,6 +41,7 @@ import java.util.stream.Stream;
 import org.assertj.core.api.RecursiveComparisonAssert;
 import org.assertj.core.internal.Objects;
 import org.assertj.core.internal.TypeComparators;
+import org.assertj.core.internal.TypeMessages;
 import org.assertj.core.presentation.Representation;
 import org.assertj.core.util.Strings;
 import org.assertj.core.util.VisibleForTesting;
@@ -75,6 +79,10 @@ public class RecursiveComparisonConfiguration {
   private TypeComparators typeComparators = defaultTypeComparators();
   private FieldComparators fieldComparators = new FieldComparators();
 
+  // registered messages section
+  private TypeMessages typeMessages = new TypeMessages();
+  private FieldMessages fieldMessages = new FieldMessages();
+
   private RecursiveComparisonConfiguration(Builder builder) {
     this.strictTypeChecking = builder.strictTypeChecking;
     this.ignoreAllActualNullFields = builder.ignoreAllActualNullFields;
@@ -93,6 +101,8 @@ public class RecursiveComparisonConfiguration {
     ignoreCollectionOrderInFieldsMatchingRegexes(builder.ignoredCollectionOrderInFieldsMatchingRegexes);
     this.typeComparators = builder.typeComparators;
     this.fieldComparators = builder.fieldComparators;
+    this.fieldMessages = builder.fieldMessages;
+    this.typeMessages = builder.typeMessages;
   }
 
   public RecursiveComparisonConfiguration() {}
@@ -103,6 +113,14 @@ public class RecursiveComparisonConfiguration {
 
   public Comparator<?> getComparatorForField(String fieldName) {
     return fieldComparators.getComparatorForField(fieldName);
+  }
+
+  public boolean hasCustomMessageForField(String fieldName) {
+    return fieldMessages.hasMessageForField(fieldName);
+  }
+
+  public String getMessageForField(String fieldName) {
+    return fieldMessages.getMessageForField(fieldName);
   }
 
   public FieldComparators getFieldComparators() {
@@ -118,7 +136,15 @@ public class RecursiveComparisonConfiguration {
   }
 
   public Comparator<?> getComparatorForType(Class<?> fieldType) {
-    return typeComparators.get(fieldType);
+    return typeComparators.getComparatorForType(fieldType);
+  }
+
+  public boolean hasCustomMessageForType(Class<?> fieldType) {
+    return typeMessages.hasMessageForType(fieldType);
+  }
+
+  public String getMessageForType(Class<?> fieldType) {
+    return typeMessages.getMessageForType(fieldType);
   }
 
   public TypeComparators getTypeComparators() {
@@ -397,7 +423,8 @@ public class RecursiveComparisonConfiguration {
   /**
    * Registers the given {@link Comparator} to compare the fields with the given type.
    * <p>
-   * Comparators registered with this method have less precedence than comparators registered with {@link #registerComparatorForFields(Comparator, String...)}.
+   * Comparators registered with this method have less precedence than comparators registered with
+   * {@link #registerComparatorForFields(Comparator, String...)}.
    * <p>
    * Note that registering a {@link Comparator} for a given type will override the previously registered BiPredicate/Comparator (if any).
    * <p>
@@ -410,13 +437,14 @@ public class RecursiveComparisonConfiguration {
    */
   public <T> void registerComparatorForType(Comparator<? super T> comparator, Class<T> type) {
     requireNonNull(comparator, "Expecting a non null Comparator");
-    typeComparators.put(type, comparator);
+    typeComparators.registerComparator(type, comparator);
   }
 
   /**
    * Registers the given {@link BiPredicate} to compare the fields with the given type.
    * <p>
-   * BiPredicates specified with this method have less precedence than the ones registered with {@link #registerEqualsForFields(BiPredicate, String...)}
+   * BiPredicates specified with this method have less precedence than the ones registered with
+   * {@link #registerEqualsForFields(BiPredicate, String...)}
    * or comparators registered with {@link #registerComparatorForFields(Comparator, String...)}.
    * <p>
    * Note that registering a {@link BiPredicate} for a given type will override the previously registered BiPredicate/Comparator (if any).
@@ -480,6 +508,92 @@ public class RecursiveComparisonConfiguration {
   }
 
   /**
+   * Registers the giving message which would be shown when differences in the given fields while comparison occurred.
+   * <p>
+   * The fields must be specified from the root object, for example if {@code Foo} has a {@code Bar} field and both
+   * have an {@code id} field, one can register a message for Foo and Bar's {@code id} by calling:
+   * <pre><code class='java'> registerErrorMessageForFields("some message", "foo.id", "foo.bar.id")</code></pre>
+   * <p>
+   * Messages registered with this method have precedence over the ones registered with
+   * {@link #registerErrorMessageForType(String, Class)} or the messages registered with
+   * {@link #registerErrorMessageForType(String, List, Class)}.
+   * <p>
+   * In case of {@code null} as message the default error message will be used (See
+   * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+   *
+   * @param message the error message that will be thrown when comparison error occurred
+   * @param fieldLocations the field locations the error message should be used for
+   */
+  public void registerErrorMessageForFields(String message, String... fieldLocations) {
+    registerErrorMessageForFields(message, emptyList(), fieldLocations);
+  }
+
+  /**
+   * Registers the giving message which would be shown when differences in the given fields while comparison occurred.
+   * <p>
+   * The fields must be specified from the root object, for example if {@code Foo} has a {@code Bar} field and both
+   * have an {@code id} field, one can register a message for Foo and Bar's {@code id} by calling:
+   * <pre><code class='java'> registerErrorMessageForFields("some message", List.of("arg1", "arg2"), "foo.id", "foo.bar.id")
+   * </code></pre>
+   * <p>
+   * Messages registered with this method have precedence over the ones registered with
+   * {@link #registerErrorMessageForType(String, Class)} or the messages registered with
+   * {@link #registerErrorMessageForType(String, List, Class)}.
+   * <p>
+   * In case of {@code null} as message the default error message will be used (See
+   * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+   *
+   * @param message the error message that will be thrown when comparison error occurred
+   * @param args message arguments
+   * @param fieldLocations the field locations the error message should be used for
+   * @throws NullPointerException if the giving list of arguments is null
+   */
+  public void registerErrorMessageForFields(String message, List<Object> args, String... fieldLocations) {
+    requireNonNull(args, "Arguments list must not be null");
+    String errorMessage = formatIfArgs(message, args.toArray());
+    Stream.of(fieldLocations).forEach(fieldLocation -> fieldMessages.registerMessage(fieldLocation, errorMessage));
+  }
+
+  /**
+   * Registers the giving message which would be shown when differences for the giving type while comparison
+   * occurred.
+   * <p>
+   * Message registered with this method have less precedence than the ones registered with
+   * {@link #registerErrorMessageForFields(String, String...)} or the message registered with
+   * {@link #registerErrorMessageForFields(String, List, String...)}.
+   * <p>
+   * In case of {@code null} as message the default error message will be used (See
+   * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+   *
+   * @param message the error message that will be thrown when comparison error occurred
+   * @param clazz the type the error message should be used for
+   */
+  public void registerErrorMessageForType(String message, Class<?> clazz) {
+    registerErrorMessageForType(message, emptyList(), clazz);
+  }
+
+  /**
+   * Registers the giving message which would be shown when differences for the giving type while comparison
+   * occurred.
+   * <p>
+   * Message registered with this method have less precedence than the ones registered with
+   * {@link #registerErrorMessageForFields(String, String...)} or the message registered with
+   * {@link #registerErrorMessageForFields(String, List, String...)}.
+   * <p>
+   * In case of {@code null} as message the default error message will be used (See
+   * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+   *
+   * @param message the error message that will be thrown when comparison error occurred
+   * @param args message arguments
+   * @param clazz the type the error message should be used for
+   * @throws NullPointerException if the giving list of arguments is null
+   */
+  public void registerErrorMessageForType(String message, List<Object> args, Class<?> clazz) {
+    requireNonNull(args, "Arguments list must not be null");
+    typeMessages.registerMessage(clazz, formatIfArgs(message, args.toArray()));
+  }
+
+  /**
    * Sets whether the recursive comparison will check that actual's type is compatible with expected's type (the same applies for each field).
    * Compatible means that the expected's type is the same or a subclass of actual's type.
    * <p>
@@ -524,10 +638,12 @@ public class RecursiveComparisonConfiguration {
   public int hashCode() {
     return java.util.Objects.hash(fieldComparators, ignoreAllActualEmptyOptionalFields, ignoreAllActualNullFields,
                                   ignoreAllExpectedNullFields, ignoreAllOverriddenEquals, ignoreCollectionOrder,
-                                  ignoredCollectionOrderInFields, ignoredCollectionOrderInFieldsMatchingRegexes, ignoredFields,
-                                  ignoredFieldsRegexes, ignoredOverriddenEqualsForFields, ignoredOverriddenEqualsForTypes,
+                                  ignoredCollectionOrderInFields, ignoredCollectionOrderInFieldsMatchingRegexes,
+                                  ignoredFields,
+                                  ignoredFieldsRegexes, ignoredOverriddenEqualsForFields,
+                                  ignoredOverriddenEqualsForTypes,
                                   ignoredOverriddenEqualsForFieldsMatchingRegexes, ignoredTypes, strictTypeChecking,
-                                  typeComparators, comparedFields);
+                                  typeComparators, comparedFields, fieldMessages, typeMessages);
   }
 
   @Override
@@ -550,10 +666,13 @@ public class RecursiveComparisonConfiguration {
            && java.util.Objects.equals(ignoredOverriddenEqualsForTypes, other.ignoredOverriddenEqualsForTypes)
            && java.util.Objects.equals(ignoredOverriddenEqualsForFieldsMatchingRegexes,
                                        other.ignoredOverriddenEqualsForFieldsMatchingRegexes)
-           && java.util.Objects.equals(ignoredTypes, other.ignoredTypes) && strictTypeChecking == other.strictTypeChecking
+           && java.util.Objects.equals(ignoredTypes, other.ignoredTypes)
+           && strictTypeChecking == other.strictTypeChecking
            && java.util.Objects.equals(typeComparators, other.typeComparators)
            && java.util.Objects.equals(ignoredCollectionOrderInFieldsMatchingRegexes,
-                                       other.ignoredCollectionOrderInFieldsMatchingRegexes);
+                                       other.ignoredCollectionOrderInFieldsMatchingRegexes)
+           && java.util.Objects.equals(fieldMessages, other.fieldMessages)
+           && java.util.Objects.equals(typeMessages, other.typeMessages);
   }
 
   public String multiLineDescription(Representation representation) {
@@ -572,6 +691,8 @@ public class RecursiveComparisonConfiguration {
     describeRegisteredComparatorByTypes(description);
     describeRegisteredComparatorForFields(description);
     describeTypeCheckingStrictness(description);
+    describeRegisteredErrorMessagesForFields(description);
+    describeRegisteredErrorMessagesForTypes(description);
     return description.toString();
   }
 
@@ -662,7 +783,7 @@ public class RecursiveComparisonConfiguration {
   }
 
   @VisibleForTesting
-  boolean shouldIgnoreOverriddenEqualsOf(Class<? extends Object> clazz) {
+  boolean shouldIgnoreOverriddenEqualsOf(Class<?> clazz) {
     return matchesAnIgnoredOverriddenEqualsRegex(clazz) || matchesAnIgnoredOverriddenEqualsType(clazz);
   }
 
@@ -676,6 +797,7 @@ public class RecursiveComparisonConfiguration {
     if (!ignoredFieldsRegexes.isEmpty())
       description.append(format("- the fields matching the following regexes were ignored in the comparison: %s%n",
                                 describeRegexes(ignoredFieldsRegexes)));
+
   }
 
   private void describeIgnoredFields(StringBuilder description) {
@@ -699,7 +821,8 @@ public class RecursiveComparisonConfiguration {
 
   private void describeIgnoreAllActualEmptyOptionalFields(StringBuilder description) {
     if (getIgnoreAllActualEmptyOptionalFields())
-      description.append(format("- all actual empty optional fields were ignored in the comparison (including Optional, OptionalInt, OptionalLong and OptionalDouble)%n"));
+      description.append(format(
+          "- all actual empty optional fields were ignored in the comparison (including Optional, OptionalInt, OptionalLong and OptionalDouble)%n"));
   }
 
   private void describeIgnoreAllExpectedNullFields(StringBuilder description) {
@@ -754,15 +877,15 @@ public class RecursiveComparisonConfiguration {
 
   private void describeIgnoredCollectionOrderInFieldsMatchingRegexes(StringBuilder description) {
     if (!ignoredCollectionOrderInFieldsMatchingRegexes.isEmpty())
-      description.append(format("- collection order was ignored in the fields matching the following regexes in the comparison: %s%n",
-                                describeRegexes(ignoredCollectionOrderInFieldsMatchingRegexes)));
+      description.append(
+          format("- collection order was ignored in the fields matching the following regexes in the comparison: %s%n",
+                 describeRegexes(ignoredCollectionOrderInFieldsMatchingRegexes)));
   }
 
   private boolean matchesAnIgnoredOverriddenEqualsRegex(Class<?> clazz) {
     if (ignoredOverriddenEqualsForFieldsMatchingRegexes.isEmpty()) return false; // shortcut
     String canonicalName = clazz.getCanonicalName();
-    return ignoredOverriddenEqualsForFieldsMatchingRegexes.stream()
-                                                          .anyMatch(regex -> regex.matcher(canonicalName).matches());
+    return ignoredOverriddenEqualsForFieldsMatchingRegexes.stream().anyMatch(regex -> regex.matcher(canonicalName).matches());
   }
 
   private boolean matchesAnIgnoredOverriddenEqualsType(Class<?> clazz) {
@@ -888,9 +1011,42 @@ public class RecursiveComparisonConfiguration {
 
   private void describeTypeCheckingStrictness(StringBuilder description) {
     String str = strictTypeChecking
-        ? "- actual and expected objects and their fields were considered different when of incompatible types (i.e. expected type does not extend actual's type) even if all their fields match, for example a Person instance will never match a PersonDto (call strictTypeChecking(false) to change that behavior).%n"
-        : "- actual and expected objects and their fields were compared field by field recursively even if they were not of the same type, this allows for example to compare a Person to a PersonDto (call strictTypeChecking(true) to change that behavior).%n";
+        ?
+        "- actual and expected objects and their fields were considered different when of incompatible types (i.e. expected type does not extend actual's type) even if all their fields match, for example a Person instance will never match a PersonDto (call strictTypeChecking(false) to change that behavior).%n"
+        :
+        "- actual and expected objects and their fields were compared field by field recursively even if they were not of the same type, this allows for example to compare a Person to a PersonDto (call strictTypeChecking(true) to change that behavior).%n";
     description.append(format(str));
+  }
+
+  private void describeRegisteredErrorMessagesForFields(StringBuilder description) {
+    if (!fieldMessages.isEmpty()) {
+      description.append(format("- these fields had overridden error messages:%n"));
+      describeErrorMessagesForFields(description);
+      if (!typeMessages.isEmpty()) {
+        description.append(format("- field custom messages take precedence over type messages.%n"));
+      }
+    }
+  }
+
+  private void describeErrorMessagesForFields(StringBuilder description) {
+    String fields = fieldMessages.messageByFields()
+                                 .map(Entry::getKey)
+                                 .collect(joining(DEFAULT_DELIMITER));
+    description.append(format("%s %s%n", INDENT_LEVEL_2, fields));
+  }
+
+  private void describeRegisteredErrorMessagesForTypes(StringBuilder description) {
+    if (!typeMessages.isEmpty()) {
+      description.append("- these types had overridden error messages:%n");
+      describeErrorMessagesForType(description);
+    }
+  }
+
+  private void describeErrorMessagesForType(StringBuilder description) {
+    String types = typeMessages.messageByTypes()
+                               .map(it -> it.getKey().getName())
+                               .collect(joining(DEFAULT_DELIMITER));
+    description.append(format("%s %s%n", INDENT_LEVEL_2, types));
   }
 
   /**
@@ -922,6 +1078,8 @@ public class RecursiveComparisonConfiguration {
     private String[] ignoredCollectionOrderInFieldsMatchingRegexes = {};
     private TypeComparators typeComparators = defaultTypeComparators();
     private FieldComparators fieldComparators = new FieldComparators();
+    private FieldMessages fieldMessages = new FieldMessages();
+    private TypeMessages typeMessages = new TypeMessages();
 
     private Builder() {}
 
@@ -1144,7 +1302,7 @@ public class RecursiveComparisonConfiguration {
      */
     public <T> Builder withComparatorForType(Comparator<? super T> comparator, Class<T> type) {
       requireNonNull(comparator, "Expecting a non null Comparator");
-      this.typeComparators.put(type, comparator);
+      this.typeComparators.registerComparator(type, comparator);
       return this;
     }
 
@@ -1217,6 +1375,99 @@ public class RecursiveComparisonConfiguration {
      */
     public Builder withEqualsForFields(BiPredicate<?, ?> equals, String... fields) {
       return withComparatorForFields(toComparator(equals), fields);
+    }
+
+    /**
+     * Registers the giving message which would be shown when differences in the given fields while comparison occurred.
+     * <p>
+     * The fields must be specified from the root object, for example if {@code Foo} has a {@code Bar} field and both
+     * have an {@code id} field, one can register a message for Foo and Bar's {@code id} by calling:
+     * <pre><code class='java'> withErrorMessageForFields("some message", "foo.id", "foo.bar.id")</code></pre>
+     * <p>
+     * Messages registered with this method have precedence over the ones registered with
+     * {@link #withErrorMessageForType(String, Class)} or the messages registered with
+     * {@link #withErrorMessageForType(String, List, Class)}.
+     * <p>
+     * In case of {@code null} as message the default error message will be used (See
+     * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+     *
+     * @param message the error message that will be thrown when comparison error occurred.
+     * @param fields the fields the error message should be used for.
+     * @return this builder.
+     * @throws NullPointerException if the giving list of arguments is null.
+     */
+    public Builder withErrorMessageForFields(String message, String... fields) {
+      return withErrorMessageForFields(message, emptyList(), fields);
+    }
+
+    /**
+     * Registers the giving message which would be shown when differences in the given fields while comparison occurred.
+     * <p>
+     * The fields must be specified from the root object, for example if {@code Foo} has a {@code Bar} field and both
+     * have an {@code id} field, one can register a message for Foo and Bar's {@code id} by calling:
+     * <pre><code class='java'> withErrorMessageForFields("some message", List.of("arg1", "arg2"), "foo.id", "foo.bar.id")
+     * </code></pre>
+     * <p>
+     * Messages registered with this method have precedence over the ones registered with
+     * {@link #withErrorMessageForType(String, Class)} or the messages registered with
+     * {@link #withErrorMessageForType(String, List, Class)}.
+     * <p>
+     * In case of {@code null} as message the default error message will be used (See
+     * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+     *
+     * @param message the error message that will be thrown when comparison error occurred.
+     * @param args message arguments.
+     * @param fields the fields the error message should be used for.
+     * @return this builder.
+     * @throws NullPointerException if the giving list of arguments is null.
+     */
+    public Builder withErrorMessageForFields(String message, List<Object> args, String... fields) {
+      requireNonNull(args, "Arguments list must not be null");
+      String errorMessage = formatIfArgs(message, args.toArray());
+      Stream.of(fields).forEach(fieldLocation -> fieldMessages.registerMessage(fieldLocation, errorMessage));
+      return this;
+    }
+
+    /**
+     * Registers the giving message which would be shown when differences for the giving type while comparison
+     * occurred.
+     * <p>
+     * Message registered with this method have less precedence than the ones registered with
+     * {@link #withErrorMessageForFields(String, String...)} or the message registered with
+     * {@link #withErrorMessageForFields(String, List, String...)}.
+     * <p>
+     * In case of {@code null} as message the default error message will be used (See
+     * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+     *
+     * @param message the error message that will be thrown when comparison error occurred
+     * @param type the type the error message should be used for
+     * @return this builder
+     */
+    public Builder withErrorMessageForType(String message, Class<?> type) {
+      return withErrorMessageForType(message, emptyList(), type);
+    }
+
+    /**
+     * Registers the giving message which would be shown when differences for the giving type while comparison
+     * occurred.
+     * <p>
+     * Message registered with this method have less precedence than the ones registered with
+     * {@link #withErrorMessageForFields(String, String...)} or the message registered with
+     * {@link #withErrorMessageForFields(String, List, String...)}.
+     * <p>
+     * In case of {@code null} as message the default error message will be used (See
+     * {@link ComparisonDifference#DEFAULT_TEMPLATE}).
+     *
+     * @param message the error message that will be thrown when comparison error occurred
+     * @param args message arguments
+     * @param type the type the error message should be used for
+     * @return this builder
+     * @throws NullPointerException if the giving list of arguments is null
+     */
+    public Builder withErrorMessageForType(String message, List<Object> args, Class<?> type) {
+      requireNonNull(args, "Arguments list must not be null");
+      this.typeMessages.registerMessage(type, formatIfArgs(message, args.toArray()));
+      return this;
     }
 
     public RecursiveComparisonConfiguration build() {

--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonDifferenceCalculator.java
@@ -55,8 +55,9 @@ import org.assertj.core.internal.DeepDifference;
 public class RecursiveComparisonDifferenceCalculator {
 
   private static final String DIFFERENT_ACTUAL_AND_EXPECTED_FIELD_TYPES = "expected field is %s but actual field is not (%s)";
-  private static final String ACTUAL_NOT_ORDERED_COLLECTION = "expected field is an ordered collection but actual field is not (%s), ordered collections are: "
-                                                              + describeOrderedCollectionTypes();
+  private static final String ACTUAL_NOT_ORDERED_COLLECTION =
+      "expected field is an ordered collection but actual field is not (%s), ordered collections are: "
+      + describeOrderedCollectionTypes();
 
   private static final String VALUE_FIELD_NAME = "value";
   private static final String STRICT_TYPE_ERROR = "the fields are considered different since the comparison enforces strict type check and %s is not a subtype of %s";
@@ -79,11 +80,11 @@ public class RecursiveComparisonDifferenceCalculator {
     }
 
     void addDifference(DualValue dualValue) {
-      differences.add(new ComparisonDifference(dualValue));
+      differences.add(new ComparisonDifference(dualValue, null, getCustomErrorMessage(dualValue)));
     }
 
     void addDifference(DualValue dualValue, String description) {
-      differences.add(new ComparisonDifference(dualValue, description));
+      differences.add(new ComparisonDifference(dualValue, description, getCustomErrorMessage(dualValue)));
     }
 
     void addKeyDifference(DualValue parentDualValue, Object actualKey, Object expectedKey) {
@@ -157,6 +158,20 @@ public class RecursiveComparisonDifferenceCalculator {
       return isRootObject || noCustomComparisonForDualValue;
     }
 
+    private String getCustomErrorMessage(DualValue dualValue) {
+      String fieldName = dualValue.getConcatenatedPath();
+
+      if (recursiveComparisonConfiguration.hasCustomMessageForField(fieldName)) {
+        return recursiveComparisonConfiguration.getMessageForField(fieldName);
+      }
+
+      Class<?> fieldType = dualValue.actual != null ? dualValue.actual.getClass() : dualValue.expected.getClass();
+      if (recursiveComparisonConfiguration.hasCustomMessageForType(fieldType)) {
+        return recursiveComparisonConfiguration.getMessageForType(fieldType);
+      }
+
+      return null;
+    }
   }
 
   /**
@@ -691,8 +706,9 @@ public class RecursiveComparisonDifferenceCalculator {
   }
 
   private static ComparisonDifference expectedAndActualTypeDifference(Object actual, Object expected) {
-    String additionalInformation = format("actual and expected are considered different since the comparison enforces strict type check and expected type %s is not a subtype of actual type %s",
-                                          expected.getClass().getName(), actual.getClass().getName());
+    String additionalInformation = format(
+        "actual and expected are considered different since the comparison enforces strict type check and expected type %s is not a subtype of actual type %s",
+        expected.getClass().getName(), actual.getClass().getName());
     return rootComparisonDifference(actual, expected, additionalInformation);
   }
 

--- a/src/main/java/org/assertj/core/internal/DeepDifference.java
+++ b/src/main/java/org/assertj/core/internal/DeepDifference.java
@@ -345,7 +345,7 @@ public class DeepDifference {
     if (comparatorByPropertyOrField.containsKey(fieldName)) return true;
     // we know that dualKey.key1 != dualKey.key2 at this point, so one the key is not null
     Class<?> keyType = dualKey.key1 != null ? dualKey.key1.getClass() : dualKey.key2.getClass();
-    return comparatorByType.get(keyType) != null;
+    return comparatorByType.getComparatorForType(keyType) != null;
   }
 
   private static Deque<DualKey> initStack(Object a, Object b, List<String> parentPath,

--- a/src/main/java/org/assertj/core/internal/ExtendedByTypesComparator.java
+++ b/src/main/java/org/assertj/core/internal/ExtendedByTypesComparator.java
@@ -55,7 +55,7 @@ public class ExtendedByTypesComparator implements Comparator<Object> {
     if (actual == null || other == null) return NOT_EQUAL;
 
     @SuppressWarnings("rawtypes")
-    Comparator comparatorByType = comparatorsByType == null ? null : comparatorsByType.get(actual.getClass());
+    Comparator comparatorByType = comparatorsByType == null ? null : comparatorsByType.getComparatorForType(actual.getClass());
     if (comparatorByType != null) {
       return other.getClass().isInstance(actual) ? comparatorByType.compare(actual, other) : NOT_EQUAL;
     }

--- a/src/main/java/org/assertj/core/internal/Objects.java
+++ b/src/main/java/org/assertj/core/internal/Objects.java
@@ -703,7 +703,7 @@ public class Objects {
     if (fieldComparator != null) return fieldComparator.compare(actualFieldValue, otherFieldValue) == 0;
     // check if a type comparators exist for the field type
     Class fieldType = actualFieldValue != null ? actualFieldValue.getClass() : otherFieldValue.getClass();
-    Comparator typeComparator = comparatorByType.get(fieldType);
+    Comparator typeComparator = comparatorByType.getComparatorForType(fieldType);
     if (typeComparator != null) return typeComparator.compare(actualFieldValue, otherFieldValue) == 0;
     // default comparison using equals
     return deepEquals(actualFieldValue, otherFieldValue);

--- a/src/main/java/org/assertj/core/internal/TypeHolder.java
+++ b/src/main/java/org/assertj/core/internal/TypeHolder.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.util.Strings.join;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.stream.Stream;
+
+import org.assertj.core.util.ClassNameComparator;
+import org.assertj.core.util.introspection.ClassUtils;
+
+/**
+ * An abstract type holder which provides to pair a specific entities for types.
+ *
+ * @param <T> entity type
+ */
+abstract class TypeHolder<T> {
+
+  private static final Comparator<Class<?>> DEFAULT_CLASS_COMPARATOR = ClassNameComparator.INSTANCE;
+
+  protected final Map<Class<?>, T> typeHolder;
+
+  public TypeHolder() {
+    this(DEFAULT_CLASS_COMPARATOR);
+  }
+
+  public TypeHolder(Comparator<Class<?>> comparator) {
+    typeHolder = new TreeMap<>(requireNonNull(comparator, "Comparator must not be null"));
+  }
+
+  /**
+   * This method returns the most relevant entity for the given class. The most relevant entity is the
+   * entity which is registered for the class that is closest in the inheritance chain of the given {@code clazz}.
+   * The order of checks is the following:
+   * 1. If there is a registered entity for {@code clazz} then this one is used
+   * 2. We check if there is a registered entity for a superclass of {@code clazz}
+   * 3. We check if there is a registered entity for an interface of {@code clazz}
+   *
+   * @param clazz the class for which to find a entity
+   * @return the most relevant entity, or {@code null} if on entity could be found
+   */
+  public T get(Class<?> clazz) {
+    Class<?> relevantType = getRelevantClass(clazz);
+    return relevantType == null ? null : typeHolder.get(relevantType);
+  }
+
+  /**
+   * Puts the {@code entity} for the given {@code clazz}.
+   *
+   * @param clazz the class for the comparator
+   * @param entity the entity itself
+   */
+  public void put(Class<?> clazz, T entity) {
+    typeHolder.put(clazz, entity);
+  }
+
+  /**
+   * Checks, whether an entity is associated with the giving type.
+   *
+   * @param type the type for which to check an entity
+   * @return is the giving type associated with any entity
+   */
+  public boolean hasEntity(Class<?> type) {
+    return get(type) != null;
+  }
+
+  /**
+   * @return {@code true} is there are registered entities, {@code false} otherwise
+   */
+  public boolean isEmpty() {
+    return typeHolder.isEmpty();
+  }
+
+  /**
+   * Removes all registered entities.
+   */
+  public void clear() {
+    typeHolder.clear();
+  }
+
+  /**
+   * Returns a sequence of all type-entity pairs which the current holder supplies.
+   *
+   * @return sequence of field-entity pairs
+   */
+  public Stream<Entry<Class<?>, T>> entityByTypes() {
+    return typeHolder.entrySet().stream();
+  }
+
+  /**
+   * Returns the most relevant class for the given type from the giving collection of types.
+   * <p>
+   * The order of checks is the following:
+   * <ol>
+   * <li>If there is a registered message for {@code clazz} then this one is used</li>
+   * <li>We check if there is a registered message for a superclass of {@code clazz}</li>
+   * <li>We check if there is a registered message for an interface of {@code clazz}</li>
+   * </ol>
+   * If there is no relevant type in the giving collection - {@code null} will be returned.
+   *
+   * @param cls type to find a relevant class.
+   * @return the most relevant class.
+   */
+  private Class<?> getRelevantClass(Class<?> cls) {
+    Set<Class<?>> keys = typeHolder.keySet();
+    if (keys.contains(cls)) {
+      return cls;
+    }
+
+    for (Class<?> superClass : ClassUtils.getAllSuperclasses(cls)) {
+      if (keys.contains(superClass)) {
+        return superClass;
+      }
+    }
+
+    for (Class<?> interfaceClass : ClassUtils.getAllInterfaces(cls)) {
+      if (keys.contains(interfaceClass)) {
+        return interfaceClass;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    TypeHolder<?> that = (TypeHolder<?>) o;
+    return typeHolder.equals(that.typeHolder);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(typeHolder);
+  }
+
+  @Override
+  public String toString() {
+    List<String> registeredEntitiesDescription = new ArrayList<>();
+    for (Entry<Class<?>, T> entry : this.typeHolder.entrySet()) {
+      registeredEntitiesDescription.add(formatRegisteredEntity(entry));
+    }
+    return format("{%s}", join(registeredEntitiesDescription).with(", "));
+  }
+
+  private static <T> String formatRegisteredEntity(Entry<Class<?>, T> entry) {
+    return format("%s -> %s", entry.getKey().getSimpleName(), entry.getValue());
+  }
+}

--- a/src/main/java/org/assertj/core/internal/TypeMessages.java
+++ b/src/main/java/org/assertj/core/internal/TypeMessages.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * An internal holder of the custom message for type. It is used to store messages for registered classes.
+ * When looking for a message for a given class the holder returns the most relevant comparator.
+ */
+public class TypeMessages extends TypeHolder<String> {
+
+  /**
+   * This method returns the most relevant error message for the given class. The most relevant message is the
+   * message which is registered for the class that is closest in the inheritance chain of the given {@code clazz}.
+   * The order of checks is the following:
+   * 1. If there is a registered message for {@code clazz} then this one is used
+   * 2. We check if there is a registered message for a superclass of {@code clazz}
+   * 3. We check if there is a registered message for an interface of {@code clazz}
+   *
+   * @param clazz the class for which to find an error message
+   * @return the most relevant error message, or {@code null} if no message could be found
+   */
+  public String getMessageForType(Class<?> clazz) {
+    return super.get(clazz);
+  }
+
+  /**
+   * Checks, whether an any custom error message is associated with the giving type.
+   *
+   * @param type the type for which to check a error message
+   * @return is the giving type associated with any custom error message
+   */
+  public boolean hasMessageForType(Class<?> type) {
+    return super.hasEntity(type);
+  }
+
+  /**
+   * Puts the {@code message} for the given {@code clazz}.
+   *
+   * @param clazz the class for the error message
+   * @param message the error message itself
+   * @param <T> the type of the objects to associate with the message for
+   */
+  public <T> void registerMessage(Class<T> clazz, String message) {
+    super.put(clazz, message);
+  }
+
+  /**
+   * Returns a sequence of all type-message pairs which the current holder supplies.
+   *
+   * @return sequence of field-message pairs
+   */
+  public Stream<Map.Entry<Class<?>, String>> messageByTypes() {
+    return super.entityByTypes();
+  }
+}

--- a/src/main/java/org/assertj/core/util/ClassNameComparator.java
+++ b/src/main/java/org/assertj/core/util/ClassNameComparator.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import java.util.Comparator;
+
+public class ClassNameComparator implements Comparator<Class<?>> {
+
+    public static final ClassNameComparator INSTANCE = new ClassNameComparator();
+
+    @Override
+    public int compare(Class<?> class1, Class<?> class2) {
+        return class1.getName().compareTo(class2.getName());
+    }
+}

--- a/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
+++ b/src/main/java/org/assertj/core/util/introspection/ClassUtils.java
@@ -43,43 +43,42 @@ public class ClassUtils {
    * <p>
    * Gets a {@code List} of all interfaces implemented by the given class and its superclasses.
    * </p>
-   * 
+   *
    * <p>
    * The order is determined by looking through each interface in turn as declared in the source file and following its
    * hierarchy up. Then each superclass is considered in the same way. Later duplicates are ignored, so the order is
    * maintained.
    * </p>
-   * 
+   *
    * @param cls the class to look up, may be {@code null}
    * @return the {@code List} of interfaces in order, {@code null} if null input
    */
   public static List<Class<?>> getAllInterfaces(Class<?> cls) {
     if (cls == null) return null;
-  
+
     LinkedHashSet<Class<?>> interfacesFound = new LinkedHashSet<>();
     getAllInterfaces(cls, interfacesFound);
-  
+
     return new ArrayList<>(interfacesFound);
   }
 
   /**
    * Get the interfaces for the specified class.
-   * 
+   *
    * @param cls the class to look up, may be {@code null}
    * @param interfacesFound the {@code Set} of interfaces for the class
    */
   static void getAllInterfaces(Class<?> cls, HashSet<Class<?>> interfacesFound) {
     while (cls != null) {
       Class<?>[] interfaces = cls.getInterfaces();
-  
+
       for (Class<?> i : interfaces) {
         if (interfacesFound.add(i)) {
           getAllInterfaces(i, interfacesFound);
         }
       }
-  
+
       cls = cls.getSuperclass();
     }
   }
-
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extractingResultOf_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extractingResultOf_Test.java
@@ -112,8 +112,8 @@ class IterableAssert_extractingResultOf_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -136,8 +136,8 @@ class IterableAssert_extractingResultOf_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extractingResultOf_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extractingResultOf_with_SortedSet_Test.java
@@ -114,8 +114,8 @@ class IterableAssert_extractingResultOf_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -138,8 +138,8 @@ class IterableAssert_extractingResultOf_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_Test.java
@@ -55,7 +55,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for <code>{@link AbstractIterableAssert#extracting(String)}</code> and
  * <code>{@link AbstractIterableAssert#extracting(String...)}</code>.
- * 
+ *
  * @author Joel Costigliola
  * @author Mateusz Haligowski
  */
@@ -94,35 +94,35 @@ class IterableAssert_extracting_Test {
   @Test
   void should_allow_assertions_on_property_values_extracted_from_given_iterable() {
     assertThat(jedis).extracting("age")
-                     .as("extract property backed by a private field")
-                     .containsOnly(800, 26);
+      .as("extract property backed by a private field")
+      .containsOnly(800, 26);
     assertThat(jedis).extracting("adult")
-                     .as("extract pure property")
-                     .containsOnly(true, true);
+      .as("extract pure property")
+      .containsOnly(true, true);
     assertThat(jedis).extracting("name.first")
-                     .as("nested property")
-                     .containsOnly("Yoda", "Luke");
+      .as("nested property")
+      .containsOnly("Yoda", "Luke");
     assertThat(jedis).extracting("name")
-                     .as("extract field that is also a property")
-                     .containsOnly(new Name("Yoda"), new Name("Luke", "Skywalker"));
+      .as("extract field that is also a property")
+      .containsOnly(new Name("Yoda"), new Name("Luke", "Skywalker"));
     assertThat(jedis).extracting("name", Name.class)
-                     .as("extract field that is also a property but specifying the extracted type")
-                     .containsOnly(new Name("Yoda"), new Name("Luke", "Skywalker"));
+      .as("extract field that is also a property but specifying the extracted type")
+      .containsOnly(new Name("Yoda"), new Name("Luke", "Skywalker"));
   }
 
   @Test
   void should_allow_assertions_on_null_property_values_extracted_from_given_iterable() {
     yoda.name.setFirst(null);
     assertThat(jedis).extracting("name.first")
-                     .as("not null property but null nested property")
-                     .containsOnly(null, "Luke");
+      .as("not null property but null nested property")
+      .containsOnly(null, "Luke");
     yoda.setName(null);
     assertThat(jedis).extracting("name.first")
-                     .as("extract nested property when top property is null")
-                     .containsOnly(null, "Luke");
+      .as("extract nested property when top property is null")
+      .containsOnly(null, "Luke");
     assertThat(jedis).extracting("name")
-                     .as("null property")
-                     .containsOnly(null, new Name("Luke", "Skywalker"));
+      .as("null property")
+      .containsOnly(null, new Name("Luke", "Skywalker"));
   }
 
   @Test
@@ -141,7 +141,7 @@ class IterableAssert_extracting_Test {
     List<TolkienCharacter> elves = null;
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(elves).extracting(TolkienCharacter::getName,
-                                                                                            TolkienCharacter::getRace));
+      TolkienCharacter::getRace));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -149,33 +149,33 @@ class IterableAssert_extracting_Test {
   @Test
   void should_allow_assertions_on_field_values_extracted_from_given_iterable() {
     assertThat(jedis).extracting("id")
-                     .as("extract field")
-                     .containsOnly(1L, 2L);
+      .as("extract field")
+      .containsOnly(1L, 2L);
     assertThat(jedis).extracting("surname")
-                     .as("null field")
-                     .containsNull();
+      .as("null field")
+      .containsNull();
     assertThat(jedis).extracting("surname.first")
-                     .as("null nested field")
-                     .containsNull();
+      .as("null nested field")
+      .containsNull();
     yoda.surname = new Name();
     assertThat(jedis).extracting("surname.first")
-                     .as("not null field but null nested field")
-                     .containsNull();
+      .as("not null field but null nested field")
+      .containsNull();
     yoda.surname = new Name("Master");
     assertThat(jedis).extracting("surname.first")
-                     .as("nested field")
-                     .containsOnly("Master", null);
+      .as("nested field")
+      .containsOnly("Master", null);
     assertThat(jedis).extracting("surname", Name.class)
-                     .as("extract field specifying the extracted type")
-                     .containsOnly(new Name("Master"), null);
+      .as("extract field specifying the extracted type")
+      .containsOnly(new Name("Master"), null);
   }
 
   @Test
   void should_allow_assertions_on_property_values_extracted_from_given_iterable_with_extracted_type_defined() {
     // extract field that is also a property and check generic for comparator.
     assertThat(jedis).extracting("name", Name.class)
-                     .usingElementComparator((o1, o2) -> o1.getFirst().compareTo(o2.getFirst()))
-                     .containsOnly(new Name("Yoda"), new Name("Luke", "Skywalker"));
+      .usingElementComparator((o1, o2) -> o1.getFirst().compareTo(o2.getFirst()))
+      .containsOnly(new Name("Yoda"), new Name("Luke", "Skywalker"));
   }
 
   @Test
@@ -186,16 +186,16 @@ class IterableAssert_extracting_Test {
   @Test
   void should_allow_assertions_on_multiple_extracted_values_from_given_iterable() {
     assertThat(jedis).extracting("name.first", "age", "id")
-                     .containsOnly(tuple("Yoda", 800, 1L),
-                                   tuple("Luke", 26, 2L));
+      .containsOnly(tuple("Yoda", 800, 1L),
+        tuple("Luke", 26, 2L));
   }
 
   @Test
   void should_throw_error_if_one_property_or_field_can_not_be_extracted() {
     assertThatExceptionOfType(IntrospectionError.class).isThrownBy(() -> {
       assertThat(jedis).extracting("unknown", "age", "id")
-                       .containsOnly(tuple("Yoda", 800, 1L),
-                                     tuple("Luke", 26, 2L));
+        .containsOnly(tuple("Yoda", 800, 1L),
+          tuple("Luke", 26, 2L));
     });
   }
 
@@ -222,21 +222,21 @@ class IterableAssert_extracting_Test {
   @Test
   void should_allow_assertions_on_extractor_assertions_extracted_from_given_array() {
     assertThat(jedis).extracting(input -> input.getName().getFirst())
-                     .containsOnly("Yoda", "Luke");
+      .containsOnly("Yoda", "Luke");
   }
 
   @Test
   void should_allow_extracting_by_toString_method() {
     assertThat(jedis).extracting(Extractors.toStringMethod())
-                     .containsOnly("Employee[id=1, name=Name[first='Yoda', last='null'], age=800]",
-                                   "Employee[id=2, name=Name[first='Luke', last='Skywalker'], age=26]");
+      .containsOnly("Employee[id=1, name=Name[first='Yoda', last='null'], age=800]",
+        "Employee[id=2, name=Name[first='Luke', last='Skywalker'], age=26]");
   }
 
   @Test
   void should_allow_assertions_by_using_function_extracted_from_given_iterable() {
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName)
-                                   .contains("Boromir", "Gandalf", "Frodo")
-                                   .doesNotContain("Sauron", "Elrond");
+      .contains("Boromir", "Gandalf", "Frodo")
+      .doesNotContain("Sauron", "Elrond");
   }
 
   @Test
@@ -253,164 +253,164 @@ class IterableAssert_extracting_Test {
     Function<? super TolkienCharacter, Integer> age = TolkienCharacter::getAge;
 
     assertThat(fellowshipOfTheRing).extracting(name, age)
-                                   .containsOnly(tuple("Frodo", 33),
-                                                 tuple("Sam", 38),
-                                                 tuple("Gandalf", 2020),
-                                                 tuple("Legolas", 1000),
-                                                 tuple("Pippin", 28),
-                                                 tuple("Gimli", 139),
-                                                 tuple("Aragorn", 87),
-                                                 tuple("Boromir", 37));
+      .containsOnly(tuple("Frodo", 33),
+        tuple("Sam", 38),
+        tuple("Gandalf", 2020),
+        tuple("Legolas", 1000),
+        tuple("Pippin", 28),
+        tuple("Gimli", 139),
+        tuple("Aragorn", 87),
+        tuple("Boromir", 37));
   }
 
   @Test
   void should_allow_assertions_on_two_extracted_values_from_given_iterable_by_using_a_function() {
 
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName,
-                                               TolkienCharacter::getAge)
-                                   .containsOnly(tuple("Frodo", 33),
-                                                 tuple("Sam", 38),
-                                                 tuple("Gandalf", 2020),
-                                                 tuple("Legolas", 1000),
-                                                 tuple("Pippin", 28),
-                                                 tuple("Gimli", 139),
-                                                 tuple("Aragorn", 87),
-                                                 tuple("Boromir", 37));
+        TolkienCharacter::getAge)
+      .containsOnly(tuple("Frodo", 33),
+        tuple("Sam", 38),
+        tuple("Gandalf", 2020),
+        tuple("Legolas", 1000),
+        tuple("Pippin", 28),
+        tuple("Gimli", 139),
+        tuple("Aragorn", 87),
+        tuple("Boromir", 37));
   }
 
   @Test
   void should_allow_assertions_on_three_extracted_values_from_given_iterable_by_using_a_function() {
 
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName,
-                                               TolkienCharacter::getAge,
-                                               TolkienCharacter::getRace)
-                                   .containsOnly(tuple("Frodo", 33, TolkienCharacter.Race.HOBBIT),
-                                                 tuple("Sam", 38, HOBBIT),
-                                                 tuple("Gandalf", 2020, MAIA),
-                                                 tuple("Legolas", 1000, ELF),
-                                                 tuple("Pippin", 28, HOBBIT),
-                                                 tuple("Gimli", 139, DWARF),
-                                                 tuple("Aragorn", 87, MAN),
-                                                 tuple("Boromir", 37, MAN));
+        TolkienCharacter::getAge,
+        TolkienCharacter::getRace)
+      .containsOnly(tuple("Frodo", 33, TolkienCharacter.Race.HOBBIT),
+        tuple("Sam", 38, HOBBIT),
+        tuple("Gandalf", 2020, MAIA),
+        tuple("Legolas", 1000, ELF),
+        tuple("Pippin", 28, HOBBIT),
+        tuple("Gimli", 139, DWARF),
+        tuple("Aragorn", 87, MAN),
+        tuple("Boromir", 37, MAN));
   }
 
   @Test
   void should_allow_assertions_on_four_extracted_values_from_given_iterable_by_using_a_function() {
 
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName,
-                                               TolkienCharacter::getAge,
-                                               TolkienCharacter::getRace,
-                                               character -> character.name)
-                                   .containsOnly(tuple("Frodo", 33, HOBBIT, "Frodo"),
-                                                 tuple("Sam", 38, HOBBIT, "Sam"),
-                                                 tuple("Gandalf", 2020, MAIA, "Gandalf"),
-                                                 tuple("Legolas", 1000, ELF, "Legolas"),
-                                                 tuple("Pippin", 28, HOBBIT, "Pippin"),
-                                                 tuple("Gimli", 139, DWARF, "Gimli"),
-                                                 tuple("Aragorn", 87, MAN, "Aragorn"),
-                                                 tuple("Boromir", 37, MAN, "Boromir"));
+        TolkienCharacter::getAge,
+        TolkienCharacter::getRace,
+        character -> character.name)
+      .containsOnly(tuple("Frodo", 33, HOBBIT, "Frodo"),
+        tuple("Sam", 38, HOBBIT, "Sam"),
+        tuple("Gandalf", 2020, MAIA, "Gandalf"),
+        tuple("Legolas", 1000, ELF, "Legolas"),
+        tuple("Pippin", 28, HOBBIT, "Pippin"),
+        tuple("Gimli", 139, DWARF, "Gimli"),
+        tuple("Aragorn", 87, MAN, "Aragorn"),
+        tuple("Boromir", 37, MAN, "Boromir"));
   }
 
   @Test
   void should_allow_assertions_on_five_extracted_values_from_given_iterable_by_using_a_function() {
 
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName,
-                                               TolkienCharacter::getAge,
-                                               TolkienCharacter::getRace,
-                                               character -> character.name,
-                                               character -> character.age)
-                                   .containsOnly(tuple("Frodo", 33, HOBBIT, "Frodo", 33),
-                                                 tuple("Sam", 38, HOBBIT, "Sam", 38),
-                                                 tuple("Gandalf", 2020, MAIA, "Gandalf", 2020),
-                                                 tuple("Legolas", 1000, ELF, "Legolas", 1000),
-                                                 tuple("Pippin", 28, HOBBIT, "Pippin", 28),
-                                                 tuple("Gimli", 139, DWARF, "Gimli", 139),
-                                                 tuple("Aragorn", 87, MAN, "Aragorn", 87),
-                                                 tuple("Boromir", 37, MAN, "Boromir", 37));
+        TolkienCharacter::getAge,
+        TolkienCharacter::getRace,
+        character -> character.name,
+        character -> character.age)
+      .containsOnly(tuple("Frodo", 33, HOBBIT, "Frodo", 33),
+        tuple("Sam", 38, HOBBIT, "Sam", 38),
+        tuple("Gandalf", 2020, MAIA, "Gandalf", 2020),
+        tuple("Legolas", 1000, ELF, "Legolas", 1000),
+        tuple("Pippin", 28, HOBBIT, "Pippin", 28),
+        tuple("Gimli", 139, DWARF, "Gimli", 139),
+        tuple("Aragorn", 87, MAN, "Aragorn", 87),
+        tuple("Boromir", 37, MAN, "Boromir", 37));
   }
 
   @Test
   void should_allow_assertions_on_more_than_five_extracted_values_from_given_iterable_by_using_a_function() {
 
     assertThat(fellowshipOfTheRing).extracting(TolkienCharacter::getName,
-                                               TolkienCharacter::getAge,
-                                               TolkienCharacter::getRace,
-                                               character -> character.name,
-                                               character -> character.age,
-                                               character -> character.race)
-                                   .containsOnly(tuple("Frodo", 33, HOBBIT, "Frodo", 33, HOBBIT),
-                                                 tuple("Sam", 38, HOBBIT, "Sam", 38, HOBBIT),
-                                                 tuple("Gandalf", 2020, MAIA, "Gandalf", 2020, MAIA),
-                                                 tuple("Legolas", 1000, ELF, "Legolas", 1000, ELF),
-                                                 tuple("Pippin", 28, HOBBIT, "Pippin", 28, HOBBIT),
-                                                 tuple("Gimli", 139, DWARF, "Gimli", 139, DWARF),
-                                                 tuple("Aragorn", 87, MAN, "Aragorn", 87, MAN),
-                                                 tuple("Boromir", 37, MAN, "Boromir", 37, MAN));
+        TolkienCharacter::getAge,
+        TolkienCharacter::getRace,
+        character -> character.name,
+        character -> character.age,
+        character -> character.race)
+      .containsOnly(tuple("Frodo", 33, HOBBIT, "Frodo", 33, HOBBIT),
+        tuple("Sam", 38, HOBBIT, "Sam", 38, HOBBIT),
+        tuple("Gandalf", 2020, MAIA, "Gandalf", 2020, MAIA),
+        tuple("Legolas", 1000, ELF, "Legolas", 1000, ELF),
+        tuple("Pippin", 28, HOBBIT, "Pippin", 28, HOBBIT),
+        tuple("Gimli", 139, DWARF, "Gimli", 139, DWARF),
+        tuple("Aragorn", 87, MAN, "Aragorn", 87, MAN),
+        tuple("Boromir", 37, MAN, "Boromir", 37, MAN));
   }
 
   @Test
   void should_use_property_field_names_as_description_when_extracting_simple_value_list() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).extracting("name.first").isEmpty())
-                                                   .withMessageContaining("[Extracted: name.first]");
+      .withMessageContaining("[Extracted: name.first]");
   }
 
   @Test
   void should_use_property_field_names_as_description_when_extracting_typed_simple_value_list() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).extracting("name.first", String.class)
-                                                                                      .isEmpty())
-                                                   .withMessageContaining("[Extracted: name.first]");
+        .isEmpty())
+      .withMessageContaining("[Extracted: name.first]");
   }
 
   @Test
   void should_use_property_field_names_as_description_when_extracting_tuples_list() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).extracting("name.first", "name.last")
-                                                                                      .isEmpty())
-                                                   .withMessageContaining("[Extracted: name.first, name.last]");
+        .isEmpty())
+      .withMessageContaining("[Extracted: name.first, name.last]");
   }
 
   @Test
   void should_keep_existing_description_if_set_when_extracting_typed_simple_value_list() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).as("check employees first name")
-                                                                                      .extracting("name.first",
-                                                                                                  String.class)
-                                                                                      .isEmpty())
-                                                   .withMessageContaining("[check employees first name]");
+        .extracting("name.first",
+          String.class)
+        .isEmpty())
+      .withMessageContaining("[check employees first name]");
   }
 
   @Test
   void should_keep_existing_description_if_set_when_extracting_tuples_list() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).as("check employees name")
-                                                                                      .extracting("name.first",
-                                                                                                  "name.last")
-                                                                                      .isEmpty())
-                                                   .withMessageContaining("[check employees name]");
+        .extracting("name.first",
+          "name.last")
+        .isEmpty())
+      .withMessageContaining("[check employees name]");
   }
 
   @Test
   void should_keep_existing_description_if_set_when_extracting_simple_value_list() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).as("check employees first name")
-                                                                                      .extracting("name.first")
-                                                                                      .isEmpty())
-                                                   .withMessageContaining("[check employees first name]");
+        .extracting("name.first")
+        .isEmpty())
+      .withMessageContaining("[check employees first name]");
   }
 
   @SuppressWarnings("deprecation")
   @Test
   void should_keep_existing_description_if_set_when_extracting_using_extractor() {
     assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(jedis).as("check employees first name")
-                                                                                      .extracting(new Extractor<Employee, String>() {
-                                                                                        @Override
-                                                                                        public String extract(Employee input) {
-                                                                                          return input.getName().getFirst();
-                                                                                        }
-                                                                                      }).isEmpty())
-                                                   .withMessageContaining("[check employees first name]");
+        .extracting(new Extractor<Employee, String>() {
+          @Override
+          public String extract(Employee input) {
+            return input.getName().getFirst();
+          }
+        }).isEmpty())
+      .withMessageContaining("[check employees first name]");
   }
 
   @Test
   void should_extract_tuples_according_to_given_functions() {
     assertThat(jedis).extracting(firstNameFunction, lastNameFunction)
-                     .contains(tuple("Yoda", null), tuple("Luke", "Skywalker"));
+      .contains(tuple("Yoda", null), tuple("Luke", "Skywalker"));
   }
 
   @SuppressWarnings("deprecation")
@@ -419,21 +419,22 @@ class IterableAssert_extracting_Test {
     // WHEN
     // not all comparators are used but we want to test that they are passed correctly after extracting
     AbstractListAssert<?, ?, ?, ?> assertion = assertThat(jedis).as("test description")
-                                                                .withFailMessage("error message")
-                                                                .withRepresentation(UNICODE_REPRESENTATION)
-                                                                .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
-                                                                                                          "foo")
-                                                                .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
-                                                                                                         Timestamp.class)
-                                                                .usingComparatorForType(ALWAY_EQUALS_TUPLE, Tuple.class)
-                                                                .extracting(firstNameFunction, lastNameFunction)
-                                                                .contains(tuple("YODA", null), tuple("Luke", "Skywalker"));
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
+        "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
+        Timestamp.class)
+      .usingComparatorForType(ALWAY_EQUALS_TUPLE, Tuple.class)
+      .extracting(firstNameFunction, lastNameFunction)
+      .contains(tuple("YODA", null), tuple("Luke", "Skywalker"));
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -443,21 +444,22 @@ class IterableAssert_extracting_Test {
     // WHEN
     // not all comparators are used but we want to test that they are passed correctly after extracting
     AbstractListAssert<?, ?, ?, ?> assertion = assertThat(jedis).as("test description")
-                                                                .withFailMessage("error message")
-                                                                .withRepresentation(UNICODE_REPRESENTATION)
-                                                                .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
-                                                                                                          "foo")
-                                                                .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
-                                                                                                         Timestamp.class)
-                                                                .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
-                                                                .extracting("name.first")
-                                                                .contains("YODA", "Luke");
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
+        "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
+        Timestamp.class)
+      .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
+      .extracting("name.first")
+      .contains("YODA", "Luke");
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -467,21 +469,22 @@ class IterableAssert_extracting_Test {
     // WHEN
     // not all comparators are used but we want to test that they are passed correctly after extracting
     AbstractListAssert<?, ?, ?, ?> assertion = assertThat(jedis).as("test description")
-                                                                .withFailMessage("error message")
-                                                                .withRepresentation(UNICODE_REPRESENTATION)
-                                                                .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
-                                                                                                          "foo")
-                                                                .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
-                                                                                                         Timestamp.class)
-                                                                .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
-                                                                .extracting("name.first", String.class)
-                                                                .contains("YODA", "Luke");
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
+        "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
+        Timestamp.class)
+      .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
+      .extracting("name.first", String.class)
+      .contains("YODA", "Luke");
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -491,21 +494,22 @@ class IterableAssert_extracting_Test {
     // WHEN
     // not all comparators are used but we want to test that they are passed correctly after extracting
     AbstractListAssert<?, ?, ?, ?> assertion = assertThat(jedis).as("test description")
-                                                                .withFailMessage("error message")
-                                                                .withRepresentation(UNICODE_REPRESENTATION)
-                                                                .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
-                                                                                                          "foo")
-                                                                .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
-                                                                                                         Timestamp.class)
-                                                                .usingComparatorForType(ALWAY_EQUALS_TUPLE, Tuple.class)
-                                                                .extracting("name.first", "name.last")
-                                                                .contains(tuple("YODA", null), tuple("Luke", "Skywalker"));
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
+        "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
+        Timestamp.class)
+      .usingComparatorForType(ALWAY_EQUALS_TUPLE, Tuple.class)
+      .extracting("name.first", "name.last")
+      .contains(tuple("YODA", null), tuple("Luke", "Skywalker"));
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -515,21 +519,22 @@ class IterableAssert_extracting_Test {
     // WHEN
     // not all comparators are used but we want to test that they are passed correctly after extracting
     AbstractListAssert<?, ?, ?, ?> assertion = assertThat(jedis).as("test description")
-                                                                .withFailMessage("error message")
-                                                                .withRepresentation(UNICODE_REPRESENTATION)
-                                                                .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
-                                                                                                          "foo")
-                                                                .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
-                                                                                                         Timestamp.class)
-                                                                .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
-                                                                .extracting(byName("name.first"))
-                                                                .contains("YODA", "Luke");
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING,
+        "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP,
+        Timestamp.class)
+      .usingComparatorForType(ALWAY_EQUALS_STRING, String.class)
+      .extracting(byName("name.first"))
+      .contains("YODA", "Luke");
     // THEN
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
@@ -450,8 +450,8 @@ class IterableAssert_extracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -473,8 +473,8 @@ class IterableAssert_extracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -496,8 +496,8 @@ class IterableAssert_extracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -519,8 +519,8 @@ class IterableAssert_extracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -542,8 +542,8 @@ class IterableAssert_extracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -565,8 +565,8 @@ class IterableAssert_extracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_Test.java
@@ -87,25 +87,25 @@ class IterableAssert_flatExtracting_Test {
   @Test
   void should_allow_assertions_on_joined_lists_when_extracting_children_with_extractor() {
     assertThat(list(homer, fred)).flatExtracting(childrenExtractor)
-                                 .containsOnly(bart, lisa, maggie, pebbles);
+      .containsOnly(bart, lisa, maggie, pebbles);
   }
 
   @Test
   void should_allow_assertions_on_joined_lists_when_extracting_children() {
     assertThat(list(homer, fred)).flatExtracting(children)
-                                 .containsOnly(bart, lisa, maggie, pebbles);
+      .containsOnly(bart, lisa, maggie, pebbles);
   }
 
   @Test
   void should_allow_assertions_on_empty_result_lists_with_extractor() {
     assertThat(list(bart, lisa, maggie)).flatExtracting(childrenExtractor)
-                                        .isEmpty();
+      .isEmpty();
   }
 
   @Test
   void should_allow_assertions_on_empty_result_lists() {
     assertThat(list(bart, lisa, maggie)).flatExtracting(children)
-                                        .isEmpty();
+      .isEmpty();
   }
 
   @Test
@@ -191,8 +191,8 @@ class IterableAssert_flatExtracting_Test {
     List<CartoonCharacter> cartoonCharacters = list(homer);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(cartoonCharacters).as("expected description")
-                                                                                            .flatExtracting(childrenExtractor)
-                                                                                            .isEmpty());
+      .flatExtracting(childrenExtractor)
+      .isEmpty());
     // THEN
     then(assertionError).hasMessageContaining("[expected description]");
   }
@@ -203,8 +203,8 @@ class IterableAssert_flatExtracting_Test {
     List<CartoonCharacter> cartoonCharacters = list(homer);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(cartoonCharacters).as("expected description")
-                                                                                            .flatExtracting(children)
-                                                                                            .isEmpty());
+      .flatExtracting(children)
+      .isEmpty());
     // THEN
     then(assertionError).hasMessageContaining("[expected description]");
   }
@@ -215,8 +215,8 @@ class IterableAssert_flatExtracting_Test {
     List<CartoonCharacter> cartoonCharacters = list(homer);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(cartoonCharacters).as("expected description")
-                                                                                            .flatExtracting("children")
-                                                                                            .isEmpty());
+      .flatExtracting("children")
+      .isEmpty());
     // THEN
     then(assertionError).hasMessageContaining("[expected description]");
   }
@@ -227,8 +227,8 @@ class IterableAssert_flatExtracting_Test {
     List<CartoonCharacter> cartoonCharacters = list(homer);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(cartoonCharacters).as("expected description")
-                                                                                            .flatExtracting("children", "name")
-                                                                                            .isEmpty());
+      .flatExtracting("children", "name")
+      .isEmpty());
     // THEN
     then(assertionError).hasMessageContaining("[expected description]");
   }
@@ -239,8 +239,8 @@ class IterableAssert_flatExtracting_Test {
     List<CartoonCharacter> cartoonCharacters = list(homer);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(cartoonCharacters).as("expected description")
-                                                                                            .flatExtracting(children, children)
-                                                                                            .isEmpty());
+      .flatExtracting(children, children)
+      .isEmpty());
     // THEN
     then(assertionError).hasMessageContaining("[expected description]");
   }
@@ -251,9 +251,9 @@ class IterableAssert_flatExtracting_Test {
     List<CartoonCharacter> cartoonCharacters = list(homer);
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(cartoonCharacters).as("expected description")
-                                                                                            .flatExtracting(throwingExtractor,
-                                                                                                            throwingExtractor)
-                                                                                            .isEmpty());
+      .flatExtracting(throwingExtractor,
+        throwingExtractor)
+      .isEmpty());
     // THEN
     then(assertionError).hasMessageContaining("[expected description]");
   }
@@ -267,21 +267,23 @@ class IterableAssert_flatExtracting_Test {
     // not all comparators are used but we want to test that they are passed correctly after extracting
     // @format:off
     AbstractListAssert<?, ?, ?, ?> assertion
-            = assertThat(list(homer, fred)).as("test description")
-                                                   .withFailMessage("error message")
-                                                   .withRepresentation(UNICODE_REPRESENTATION)
-                                                   .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
-                                                   .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
-                                                   .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
-                                                   .flatExtracting(childrenExtractor)
-                                                   .contains(bart, lisa, new CartoonCharacter("Unknown"));
+      = assertThat(list(homer, fred)).as("test description")
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
+      .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
+      .flatExtracting(childrenExtractor)
+      .contains(bart, lisa, new CartoonCharacter("Unknown"));
     // @format:on
     // THEN
     then(assertion.descriptionText()).isEqualTo("test description");
     then(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     then(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    then(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    then(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    then(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class))
+      .isSameAs(cartoonCharacterAlwaysEqualComparator);
+    then(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     then(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -294,21 +296,23 @@ class IterableAssert_flatExtracting_Test {
     // not all comparators are used but we want to test that they are passed correctly after extracting
     // @format:off
     AbstractListAssert<?, ?, ?, ?> assertion
-            = assertThat(list(homer, fred)).as("test description")
-                                                   .withFailMessage("error message")
-                                                   .withRepresentation(UNICODE_REPRESENTATION)
-                                                   .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
-                                                   .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
-                                                   .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
-                                                   .flatExtracting(children)
-                                                   .contains(bart, lisa, new CartoonCharacter("Unknown"));
+      = assertThat(list(homer, fred)).as("test description")
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
+      .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
+      .flatExtracting(children)
+      .contains(bart, lisa, new CartoonCharacter("Unknown"));
     // @format:on
     // THEN
     then(assertion.descriptionText()).isEqualTo("test description");
     then(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     then(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    then(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    then(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    then(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class))
+      .isSameAs(cartoonCharacterAlwaysEqualComparator);
+    then(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     then(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -321,21 +325,23 @@ class IterableAssert_flatExtracting_Test {
     // not all comparators are used but we want to test that they are passed correctly after extracting
     // @format:off
     AbstractListAssert<?, ?, ?, ?> assertion
-           = assertThat(list(homer, fred)).as("test description")
-                                                  .withFailMessage("error message")
-                                                  .withRepresentation(UNICODE_REPRESENTATION)
-                                                  .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
-                                                  .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
-                                                  .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
-                                                  .flatExtracting(childrenThrowingExtractor)
-                                                  .contains(bart, lisa, new CartoonCharacter("Unknown"));
+      = assertThat(list(homer, fred)).as("test description")
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
+      .usingComparatorForType(cartoonCharacterAlwaysEqualComparator, CartoonCharacter.class)
+      .flatExtracting(childrenThrowingExtractor)
+      .contains(bart, lisa, new CartoonCharacter("Unknown"));
     // @format:on
     // THEN
     then(assertion.descriptionText()).isEqualTo("test description");
     then(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     then(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    then(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    then(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    then(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class))
+      .isSameAs(cartoonCharacterAlwaysEqualComparator);
+    then(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     then(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_SortedSet_Test.java
@@ -236,8 +236,8 @@ class IterableAssert_flatExtracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -262,8 +262,8 @@ class IterableAssert_flatExtracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -288,8 +288,8 @@ class IterableAssert_flatExtracting_with_SortedSet_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_String_parameter_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_String_parameter_Test.java
@@ -106,8 +106,8 @@ class IterableAssert_flatExtracting_with_String_parameter_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -130,8 +130,8 @@ class IterableAssert_flatExtracting_with_String_parameter_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 }

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_multiple_extractors_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_flatExtracting_with_multiple_extractors_Test.java
@@ -65,12 +65,12 @@ class IterableAssert_flatExtracting_with_multiple_extractors_Test {
   @Test
   void should_allow_assertions_on_multiple_extracted_values_flattened_in_a_single_list() {
     assertThat(fellowshipOfTheRing).flatExtracting("age", "name")
-                                   .as("extract ages and names")
-                                   .containsSequence(33, "Frodo", 38, "Sam");
+      .as("extract ages and names")
+      .containsSequence(33, "Frodo", 38, "Sam");
 
     assertThat(fellowshipOfTheRing).flatExtracting(age, name)
-                                   .as("extract ages and names")
-                                   .contains(33, "Frodo", 38, "Sam");
+      .as("extract ages and names")
+      .contains(33, "Frodo", 38, "Sam");
   }
 
   @Test
@@ -133,21 +133,23 @@ class IterableAssert_flatExtracting_with_multiple_extractors_Test {
     // not all comparators are used but we want to test that they are passed correctly after extracting
     // @format:off
     AbstractListAssert<?, ?, ?, ?> assertion
-                 = assertThat(fellowshipOfTheRing).as("test description")
-                                                  .withFailMessage("error message")
-                                                  .withRepresentation(UNICODE_REPRESENTATION)
-                                                  .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
-                                                  .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
-                                                  .usingComparatorForType(CaseInsensitiveStringComparator.instance, String.class)
-                                                  .flatExtracting(age, name)
-                                                  .contains(33, "frodo", 38, "SAM");
+      = assertThat(fellowshipOfTheRing).as("test description")
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
+      .usingComparatorForType(CaseInsensitiveStringComparator.instance, String.class)
+      .flatExtracting(age, name)
+      .contains(33, "frodo", 38, "SAM");
     // @format:on
     // THEN
     then(assertion.descriptionText()).isEqualTo("test description");
     then(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     then(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    then(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    then(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    then(comparatorsByTypeOf(assertion).getComparatorForType(String.class))
+      .isSameAs(CaseInsensitiveStringComparator.instance);
+    then(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     then(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -158,21 +160,23 @@ class IterableAssert_flatExtracting_with_multiple_extractors_Test {
     // not all comparators are used but we want to test that they are passed correctly after extracting
     // @format:off
     AbstractListAssert<?, ?, ?, ?> assertion
-           = assertThat(fellowshipOfTheRing).as("test description")
-                                            .withFailMessage("error message")
-                                            .withRepresentation(UNICODE_REPRESENTATION)
-                                            .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
-                                            .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
-                                            .usingComparatorForType(CaseInsensitiveStringComparator.instance, String.class)
-                                            .flatExtracting(ageThrowingExtractor, nameThrowingExtractor)
-                                            .contains(33, "frodo", 38, "SAM");
+      = assertThat(fellowshipOfTheRing).as("test description")
+      .withFailMessage("error message")
+      .withRepresentation(UNICODE_REPRESENTATION)
+      .usingComparatorForElementFieldsWithNames(ALWAY_EQUALS_STRING, "foo")
+      .usingComparatorForElementFieldsWithType(ALWAY_EQUALS_TIMESTAMP, Timestamp.class)
+      .usingComparatorForType(CaseInsensitiveStringComparator.instance, String.class)
+      .flatExtracting(ageThrowingExtractor, nameThrowingExtractor)
+      .contains(33, "frodo", 38, "SAM");
     // @format:on
     // THEN
     then(assertion.descriptionText()).isEqualTo("test description");
     then(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     then(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    then(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    then(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    then(comparatorsByTypeOf(assertion).getComparatorForType(String.class))
+      .isSameAs(CaseInsensitiveStringComparator.instance);
+    then(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class))
+      .isSameAs(ALWAY_EQUALS_TIMESTAMP);
     then(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 }

--- a/src/test/java/org/assertj/core/api/list/ListAssert_assertionState_propagation_with_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/list/ListAssert_assertionState_propagation_with_extracting_Test.java
@@ -68,8 +68,8 @@ class ListAssert_assertionState_propagation_with_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -91,8 +91,8 @@ class ListAssert_assertionState_propagation_with_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -114,8 +114,8 @@ class ListAssert_assertionState_propagation_with_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -137,8 +137,8 @@ class ListAssert_assertionState_propagation_with_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -160,8 +160,8 @@ class ListAssert_assertionState_propagation_with_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -183,8 +183,8 @@ class ListAssert_assertionState_propagation_with_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_Test.java
+++ b/src/test/java/org/assertj/core/api/object/ObjectAssert_extracting_with_Function_Test.java
@@ -116,7 +116,7 @@ class ObjectAssert_extracting_with_Function_Test {
     then(result.descriptionText()).isEqualTo("test description");
     then(result.info.overridingErrorMessage()).isEqualTo("error message");
     then(result.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
-    then(comparatorsByTypeOf(result).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    then(comparatorsByTypeOf(result).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
     then(comparatorByPropertyOrFieldOf(result).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
     then(comparatorOf(result).getComparator()).isSameAs(ALWAY_EQUALS);
   }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extractingResultOf_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extractingResultOf_Test.java
@@ -112,8 +112,8 @@ class ObjectArrayAssert_extractingResultOf_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -136,8 +136,8 @@ class ObjectArrayAssert_extractingResultOf_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(CaseInsensitiveStringComparator.instance);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_extracting_Test.java
@@ -364,8 +364,8 @@ class ObjectArrayAssert_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -387,8 +387,8 @@ class ObjectArrayAssert_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -410,8 +410,8 @@ class ObjectArrayAssert_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -433,8 +433,8 @@ class ObjectArrayAssert_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(Tuple.class)).isSameAs(ALWAY_EQUALS_TUPLE);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -456,8 +456,8 @@ class ObjectArrayAssert_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -479,8 +479,8 @@ class ObjectArrayAssert_extracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(String.class)).isSameAs(ALWAY_EQUALS_STRING);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(String.class)).isSameAs(ALWAY_EQUALS_STRING);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_Test.java
@@ -170,8 +170,8 @@ class ObjectArrayAssert_flatExtracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -196,8 +196,8 @@ class ObjectArrayAssert_flatExtracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 
@@ -222,8 +222,8 @@ class ObjectArrayAssert_flatExtracting_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 }

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_with_String_parameter_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_flatExtracting_with_String_parameter_Test.java
@@ -102,8 +102,8 @@ class ObjectArrayAssert_flatExtracting_with_String_parameter_Test {
     assertThat(assertion.descriptionText()).isEqualTo("test description");
     assertThat(assertion.info.representation()).isEqualTo(UNICODE_REPRESENTATION);
     assertThat(assertion.info.overridingErrorMessage()).isEqualTo("error message");
-    assertThat(comparatorsByTypeOf(assertion).get(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
-    assertThat(comparatorForElementFieldsWithTypeOf(assertion).get(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
+    assertThat(comparatorsByTypeOf(assertion).getComparatorForType(CartoonCharacter.class)).isSameAs(cartoonCharacterAlwaysEqualComparator);
+    assertThat(comparatorForElementFieldsWithTypeOf(assertion).getComparatorForType(Timestamp.class)).isSameAs(ALWAY_EQUALS_TIMESTAMP);
     assertThat(comparatorForElementFieldsWithNamesOf(assertion).get("foo")).isSameAs(ALWAY_EQUALS_STRING);
   }
 }

--- a/src/test/java/org/assertj/core/api/recursive/comparison/FieldMessages_registerMessage_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/FieldMessages_registerMessage_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static org.assertj.core.api.BDDSoftAssertions.thenSoftly;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FieldMessages_registerMessage_Test {
+
+  private FieldMessages fieldMessages;
+
+  @BeforeEach
+  void setUp() {
+    fieldMessages = new FieldMessages();
+  }
+
+  @Test
+  void should_register_message_for_a_given_fieldLocation() {
+    // GIVEN
+    String fieldLocation = "foo";
+    String message = "some message";
+    // WHEN
+    fieldMessages.registerMessage(fieldLocation, message);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(fieldMessages.hasMessageForField(fieldLocation)).isTrue();
+      softly.then(fieldMessages.getMessageForField(fieldLocation)).isEqualTo(message);
+      softly.then(fieldMessages.isEmpty()).isFalse();
+    });
+  }
+
+  @Test
+  void should_return_negative_values_for_field_location_without_message() {
+    // GIVEN
+    String fieldLocation = "foo";
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(fieldMessages.hasMessageForField(fieldLocation)).isFalse();
+      softly.then(fieldMessages.getMessageForField(fieldLocation)).isNull();
+      softly.then(fieldMessages.isEmpty()).isTrue();
+    });
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withErrorMessageForFields_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withErrorMessageForFields_Test.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.Lists.list;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
+import org.assertj.core.internal.objects.data.Person;
+import org.junit.jupiter.api.Test;
+
+class RecursiveComparisonAssert_isEqualTo_withErrorMessageForFields_Test extends
+    RecursiveComparisonAssert_isEqualTo_BaseTest {
+
+  private static final String ERROR_MESSAGE_DESCRIPTION_FOR_FIELDS = "- these fields had overridden error messages:";
+  private static final String ERROR_MESSAGE_PRECEDENCE_DESCRIPTION_FOR_FIELDS = "- field custom messages take "
+                                                                                + "precedence over type messages.";
+
+  @Test
+  void should_be_able_to_set_custom_error_message_for_specific_fields() {
+    // GIVEN
+    Person actual = new Person("Valera");
+    actual.age = OptionalInt.of(15);
+
+    Person expected = new Person("John");
+    expected.age = OptionalInt.of(15);
+
+    String message = "Name must be the same";
+    String fieldLocation = "name";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison()
+                                                                                 .withErrorMessageForFields(message,
+                                                                                                            fieldLocation)
+                                                                                 .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContainingAll(message, ERROR_MESSAGE_DESCRIPTION_FOR_FIELDS, "- " + fieldLocation);
+  }
+
+  @Test
+  void should_be_able_to_set_custom_error_message_with_arguments_for_specific_fields() {
+    // GIVEN
+    String actualName = "Valera";
+    String expectedName = "John";
+
+    Person actual = new Person(actualName);
+    actual.age = OptionalInt.of(15);
+
+    Person expected = new Person(expectedName);
+    expected.age = OptionalInt.of(15);
+
+    String fieldLocation = "name";
+    String message = "Name must be the same:%n - Actual name is %s%n - Expected name is %s";
+    List<Object> args = list(actualName, expectedName);
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison()
+                                                                                 .withErrorMessageForFields(message,
+                                                                                                            args,
+                                                                                                            fieldLocation)
+                                                                                 .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContainingAll(format(message, args.toArray()), ERROR_MESSAGE_DESCRIPTION_FOR_FIELDS,
+                                                 "- " + fieldLocation);
+  }
+
+  @Test
+  void field_message_should_take_precedence_over_type_message() {
+    // GIVEN
+    Person actual = new Person("Valera");
+    actual.age = OptionalInt.of(15);
+
+    Person expected = new Person("John");
+    expected.age = OptionalInt.of(15);
+
+    String fieldMessage = "Name must be the same";
+    String fieldLocation = "name";
+
+    String typeMessage = "Type message has to be ignored";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison()
+                                                                                 .withErrorMessageForFields(
+                                                                                     fieldMessage,
+                                                                                     fieldLocation)
+                                                                                 .withErrorMessageForType(typeMessage,
+                                                                                                          String.class)
+                                                                                 .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContainingAll(fieldMessage,
+                                                 ERROR_MESSAGE_DESCRIPTION_FOR_FIELDS,
+                                                 "- " + fieldLocation,
+                                                 ERROR_MESSAGE_PRECEDENCE_DESCRIPTION_FOR_FIELDS)
+                        .hasMessageNotContainingAny(typeMessage);
+  }
+
+  @Test
+  void field_message_with_arguments_should_take_precedence_over_type_message() {
+    // GIVEN
+    String actualName = "Valera";
+    String expectedName = "John";
+
+    Person actual = new Person(actualName);
+    actual.age = OptionalInt.of(15);
+
+    Person expected = new Person(expectedName);
+    expected.age = OptionalInt.of(15);
+
+    String fieldLocation = "name";
+    String fieldMessage = "Name must be the same:%n - Actual name is %s%n - Expected name is %s";
+    List<Object> args = list(actualName, expectedName);
+
+    String typeMessage = "Type message has to be ignored";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison()
+                                                                                 .withErrorMessageForFields(
+                                                                                     fieldMessage,
+                                                                                     args,
+                                                                                     fieldLocation)
+                                                                                 .withErrorMessageForType(typeMessage,
+                                                                                                          String.class)
+                                                                                 .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContainingAll(format(fieldMessage, args.toArray()),
+                                                 ERROR_MESSAGE_DESCRIPTION_FOR_FIELDS,
+                                                 "- " + fieldLocation,
+                                                 ERROR_MESSAGE_PRECEDENCE_DESCRIPTION_FOR_FIELDS)
+                        .hasMessageNotContainingAny(typeMessage);
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withErrorMessageForType_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_withErrorMessageForType_Test.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.Lists.list;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+import org.assertj.core.api.RecursiveComparisonAssert_isEqualTo_BaseTest;
+import org.assertj.core.internal.objects.data.Person;
+import org.junit.jupiter.api.Test;
+
+class RecursiveComparisonAssert_isEqualTo_withErrorMessageForType_Test extends
+    RecursiveComparisonAssert_isEqualTo_BaseTest {
+
+  private static final String ERROR_MESSAGE_DESCRIPTION_FOR_TYPE = "- these types had overridden error messages:";
+
+  @Test
+  void should_be_able_to_set_custom_error_message_for_specific_type() {
+    // GIVEN
+    Person actual = new Person("Valera");
+    actual.age = OptionalInt.of(15);
+
+    Person expected = new Person("John");
+    expected.age = OptionalInt.of(15);
+
+    String message = "Name must be the same";
+    Class<String> type = String.class;
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison()
+                                                                                 .withErrorMessageForType(message,
+                                                                                                          type)
+                                                                                 .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContainingAll(message,
+                                                 ERROR_MESSAGE_DESCRIPTION_FOR_TYPE,
+                                                 "- " + type.getName());
+  }
+
+  @Test
+  void should_be_able_to_set_custom_error_message_with_arguments_for_specific_type() {
+    // GIVEN
+    String actualName = "Valera";
+    String expectedName = "John";
+
+    Person actual = new Person(actualName);
+    actual.age = OptionalInt.of(15);
+
+    Person expected = new Person(expectedName);
+    expected.age = OptionalInt.of(15);
+
+    String message = "Name must be the same:%n - Actual name is %s%n - Expected name is %s";
+    List<Object> args = list(actualName, expectedName);
+    Class<String> type = String.class;
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).usingRecursiveComparison()
+                                                                                 .withErrorMessageForType(message,
+                                                                                                          args,
+                                                                                                          type)
+                                                                                 .isEqualTo(expected));
+
+    // THEN
+    then(assertionError).hasMessageContainingAll(format(message, args.toArray()),
+                                                 ERROR_MESSAGE_DESCRIPTION_FOR_TYPE,
+                                                 "- " + type.getName());
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_fieldMessages_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_fieldMessages_Test.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDSoftAssertions.thenSoftly;
+import static org.assertj.core.util.Lists.list;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecursiveComparisonConfiguration_fieldMessages_Test {
+
+  private RecursiveComparisonConfiguration recursiveComparisonConfiguration;
+
+  @BeforeEach
+  void setUp() {
+    recursiveComparisonConfiguration = new RecursiveComparisonConfiguration();
+  }
+
+  @Test
+  void should_register_custom_message_for_fields() {
+    // GIVEN
+    String message = "field message";
+    String fieldLocation = "field_1";
+    // WHEN
+    recursiveComparisonConfiguration.registerErrorMessageForFields(message, fieldLocation);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(recursiveComparisonConfiguration.hasCustomMessageForField(fieldLocation)).isTrue();
+      softly.then(recursiveComparisonConfiguration.getMessageForField(fieldLocation)).isEqualTo(message);
+    });
+  }
+
+  @Test
+  void should_register_custom_message_with_arguments_for_field() {
+    // GIVEN
+    String message = "field message with arguments %s and %s";
+    List<Object> args = list("one", "two");
+    String fieldLocation = "field_1";
+    // WHEN
+    recursiveComparisonConfiguration.registerErrorMessageForFields(message, args, fieldLocation);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(recursiveComparisonConfiguration.hasCustomMessageForField(fieldLocation)).isTrue();
+      softly.then(recursiveComparisonConfiguration.getMessageForField(fieldLocation))
+            .isEqualTo(format(message, args.toArray()));
+    });
+  }
+
+  @Test
+  void should_throw_NPE_if_arguments_list_is_null() {
+    // GIVEN
+    String message = "field message";
+    String fieldLocation = "field_1";
+    List<Object> args = null;
+    // WHEN
+    Throwable throwable = catchThrowable(
+        () -> recursiveComparisonConfiguration.registerErrorMessageForFields(message, args, fieldLocation));
+    // THEN
+    then(throwable).isInstanceOf(NullPointerException.class).hasMessage("Arguments list must not be null");
+  }
+}

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_typeMessages_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_typeMessages_Test.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.recursive.comparison;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDSoftAssertions.thenSoftly;
+import static org.assertj.core.util.Lists.list;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RecursiveComparisonConfiguration_typeMessages_Test {
+
+  private RecursiveComparisonConfiguration recursiveComparisonConfiguration;
+
+  @BeforeEach
+  void setUp() {
+    recursiveComparisonConfiguration = new RecursiveComparisonConfiguration();
+  }
+
+  @Test
+  void should_register_custom_message_for_type() {
+    // GIVEN
+    String message = "field message";
+    Class<String> type = String.class;
+    // WHEN
+    recursiveComparisonConfiguration.registerErrorMessageForType(message, type);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(recursiveComparisonConfiguration.hasCustomMessageForType(type)).isTrue();
+      softly.then(recursiveComparisonConfiguration.getMessageForType(type)).isEqualTo(message);
+    });
+  }
+
+  @Test
+  void should_register_custom_message_with_arguments_for_type() {
+    // GIVEN
+    String message = "field message with arguments %s and %s";
+    List<Object> args = list("one", "two");
+    Class<String> type = String.class;
+    // WHEN
+    recursiveComparisonConfiguration.registerErrorMessageForType(message, args, type);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(recursiveComparisonConfiguration.hasCustomMessageForType(type)).isTrue();
+      softly.then(recursiveComparisonConfiguration.getMessageForType(type)).isEqualTo(format(message, args.toArray()));
+    });
+  }
+
+  @Test
+  void should_throw_NPE_if_arguments_list_is_null() {
+    // GIVEN
+    String message = "field message";
+    Class<String> type = String.class;
+    List<Object> args = null;
+    // WHEN
+    Throwable throwable = catchThrowable(
+        () -> recursiveComparisonConfiguration.registerErrorMessageForType(message, args, type));
+    // THEN
+    then(throwable).isInstanceOf(NullPointerException.class).hasMessage("Arguments list must not be null");
+  }
+}

--- a/src/test/java/org/assertj/core/error/uri/ShouldHaveNoHost_create_Test.java
+++ b/src/test/java/org/assertj/core/error/uri/ShouldHaveNoHost_create_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
 package org.assertj.core.error.uri;
 
 import static java.lang.String.format;

--- a/src/test/java/org/assertj/core/internal/DeepDifference_Test.java
+++ b/src/test/java/org/assertj/core/internal/DeepDifference_Test.java
@@ -156,7 +156,7 @@ class DeepDifference_Test {
   @Test
   void testUnorderedCollectionWithCustomComparatorsByType() {
     TypeComparators comparatorsWithBigDecimalComparator = new TypeComparators();
-    comparatorsWithBigDecimalComparator.put(BigDecimal.class, BIG_DECIMAL_COMPARATOR);
+    comparatorsWithBigDecimalComparator.registerComparator(BigDecimal.class, BIG_DECIMAL_COMPARATOR);
 
     Set<BigDecimal> a = newLinkedHashSet(new BigDecimal("1.0"), new BigDecimal("3"), new BigDecimal("2"), new BigDecimal("4"));
     Set<BigDecimal> b = newLinkedHashSet(new BigDecimal("4"), new BigDecimal("1"), new BigDecimal("2.0"), new BigDecimal("3"));
@@ -319,7 +319,7 @@ class DeepDifference_Test {
     }
 
     TypeComparators typeComparators = new TypeComparators();
-    typeComparators.put(Map.class, new AlwaysEqualMapComparator());
+    typeComparators.registerComparator(Map.class, new AlwaysEqualMapComparator());
     assertThat(DeepDifference.determineDifferences(a, b, noFieldComparators(), typeComparators)).isEmpty();
   }
 

--- a/src/test/java/org/assertj/core/internal/ExtendedByTypesComparator_compareTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/ExtendedByTypesComparator_compareTo_Test.java
@@ -38,7 +38,7 @@ class ExtendedByTypesComparator_compareTo_Test {
 
   @BeforeAll
   public static void beforeClass() {
-    COMPARATORS_BY_TYPE.put(BigDecimal.class, new BigDecimalComparator());
+    COMPARATORS_BY_TYPE.registerComparator(BigDecimal.class, new BigDecimalComparator());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/assertj/core/internal/ExtendedByTypesComparator_toString_Test.java
+++ b/src/test/java/org/assertj/core/internal/ExtendedByTypesComparator_toString_Test.java
@@ -48,7 +48,7 @@ class ExtendedByTypesComparator_toString_Test {
     FieldByFieldComparator fieldByFieldComparator = new FieldByFieldComparator(comparatorByField,
                                                                                defaultTypeComparators());
     TypeComparators comparatorsByType = new TypeComparators();
-    comparatorsByType.put(BigDecimal.class, new BigDecimalComparator());
+    comparatorsByType.registerComparator(BigDecimal.class, new BigDecimalComparator());
     ExtendedByTypesComparator actual = new ExtendedByTypesComparator(fieldByFieldComparator, comparatorsByType);
     // THEN
     assertThat(actual).hasToString(format("field/property by field/property comparator on all fields/properties%n"

--- a/src/test/java/org/assertj/core/internal/TypeComparators_Test.java
+++ b/src/test/java/org/assertj/core/internal/TypeComparators_Test.java
@@ -35,11 +35,11 @@ class TypeComparators_Test {
   void should_return_exact_match() {
     Comparator<Foo> fooComparator = newComparator();
     Comparator<Bar> barComparator = newComparator();
-    typeComparators.put(Foo.class, fooComparator);
-    typeComparators.put(Bar.class, barComparator);
+    typeComparators.registerComparator(Foo.class, fooComparator);
+    typeComparators.registerComparator(Bar.class, barComparator);
 
-    Comparator<?> foo = typeComparators.get(Foo.class);
-    Comparator<?> bar = typeComparators.get(Bar.class);
+    Comparator<?> foo = typeComparators.getComparatorForType(Foo.class);
+    Comparator<?> bar = typeComparators.getComparatorForType(Bar.class);
     assertThat(foo).isEqualTo(fooComparator);
     assertThat(bar).isEqualTo(barComparator);
   }
@@ -47,10 +47,10 @@ class TypeComparators_Test {
   @Test
   void should_return_parent_comparator() {
     Comparator<Bar> barComparator = newComparator();
-    typeComparators.put(Bar.class, barComparator);
+    typeComparators.registerComparator(Bar.class, barComparator);
 
-    Comparator<?> foo = typeComparators.get(Foo.class);
-    Comparator<?> bar = typeComparators.get(Bar.class);
+    Comparator<?> foo = typeComparators.getComparatorForType(Foo.class);
+    Comparator<?> bar = typeComparators.getComparatorForType(Bar.class);
     assertThat(foo).isEqualTo(bar);
     assertThat(bar).isEqualTo(barComparator);
   }
@@ -63,17 +63,17 @@ class TypeComparators_Test {
     Comparator<I1> i1Comparator = newComparator();
     Comparator<I2> i2Comparator = newComparator();
     Comparator<Foo> fooComparator = newComparator();
-    typeComparators.put(I3.class, i3Comparator);
-    typeComparators.put(I4.class, i4Comparator);
-    typeComparators.put(I1.class, i1Comparator);
-    typeComparators.put(I2.class, i2Comparator);
-    typeComparators.put(Foo.class, fooComparator);
+    typeComparators.registerComparator(I3.class, i3Comparator);
+    typeComparators.registerComparator(I4.class, i4Comparator);
+    typeComparators.registerComparator(I1.class, i1Comparator);
+    typeComparators.registerComparator(I2.class, i2Comparator);
+    typeComparators.registerComparator(Foo.class, fooComparator);
 
-    Comparator<?> foo = typeComparators.get(Foo.class);
-    Comparator<?> bar = typeComparators.get(Bar.class);
-    Comparator<?> i3 = typeComparators.get(I3.class);
-    Comparator<?> i4 = typeComparators.get(I4.class);
-    Comparator<?> i5 = typeComparators.get(I5.class);
+    Comparator<?> foo = typeComparators.getComparatorForType(Foo.class);
+    Comparator<?> bar = typeComparators.getComparatorForType(Bar.class);
+    Comparator<?> i3 = typeComparators.getComparatorForType(I3.class);
+    Comparator<?> i4 = typeComparators.getComparatorForType(I4.class);
+    Comparator<?> i5 = typeComparators.getComparatorForType(I5.class);
     assertThat(foo).isEqualTo(fooComparator);
     assertThat(bar).isEqualTo(i3Comparator);
     assertThat(i3).isEqualTo(i3Comparator);
@@ -87,11 +87,11 @@ class TypeComparators_Test {
     Comparator<I3> i3Comparator = newComparator();
     Comparator<I4> i4Comparator = newComparator();
     Comparator<Foo> fooComparator = newComparator();
-    typeComparators.put(I3.class, i3Comparator);
-    typeComparators.put(I4.class, i4Comparator);
-    typeComparators.put(Foo.class, fooComparator);
+    typeComparators.registerComparator(I3.class, i3Comparator);
+    typeComparators.registerComparator(I4.class, i4Comparator);
+    typeComparators.registerComparator(Foo.class, fooComparator);
 
-    Comparator<?> i5 = typeComparators.get(I5.class);
+    Comparator<?> i5 = typeComparators.getComparatorForType(I5.class);
     assertThat(i5).isNull();
   }
 

--- a/src/test/java/org/assertj/core/internal/TypeComparators_hasComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/TypeComparators_hasComparator_Test.java
@@ -30,7 +30,7 @@ class TypeComparators_hasComparator_Test {
 
   @Test
   void should_find_comparator() {
-    typeComparators.put(Foo.class, newComparator());
+    typeComparators.registerComparator(Foo.class, newComparator());
     // WHEN
     boolean comparatorFound = typeComparators.hasComparatorForType(Foo.class);
     // THEN
@@ -39,7 +39,7 @@ class TypeComparators_hasComparator_Test {
 
   @Test
   void should_find_parent_comparator() {
-    typeComparators.put(Bar.class, newComparator());
+    typeComparators.registerComparator(Bar.class, newComparator());
     // WHEN
     boolean comparatorFound = typeComparators.hasComparatorForType(Foo.class);
     // THEN
@@ -52,9 +52,9 @@ class TypeComparators_hasComparator_Test {
     Comparator<I3> i3Comparator = newComparator();
     Comparator<I4> i4Comparator = newComparator();
     Comparator<Foo> fooComparator = newComparator();
-    typeComparators.put(I3.class, i3Comparator);
-    typeComparators.put(I4.class, i4Comparator);
-    typeComparators.put(Foo.class, fooComparator);
+    typeComparators.registerComparator(I3.class, i3Comparator);
+    typeComparators.registerComparator(I4.class, i4Comparator);
+    typeComparators.registerComparator(Foo.class, fooComparator);
     // WHEN
     boolean comparatorFound = typeComparators.hasComparatorForType(I5.class);
     // THEN

--- a/src/test/java/org/assertj/core/internal/TypeMessages_registerMessage_Test.java
+++ b/src/test/java/org/assertj/core/internal/TypeMessages_registerMessage_Test.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.BDDSoftAssertions.thenSoftly;
+
+class TypeMessages_registerMessage_Test {
+
+  private TypeMessages typeMessages;
+
+  @BeforeEach
+  void setUp() {
+    typeMessages = new TypeMessages();
+  }
+
+  @Test
+  void should_register_message_for_specific_type() {
+    // GIVEN
+    Class<String> type = String.class;
+    String message = "type message";
+    // WHEN
+    typeMessages.registerMessage(type, message);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(typeMessages.hasMessageForType(type)).isTrue();
+      softly.then(typeMessages.getMessageForType(String.class)).isEqualTo(message);
+      softly.then(typeMessages.isEmpty()).isFalse();
+    });
+  }
+
+  @Test
+  void should_return_negative_results_for_type_without_message() {
+    // GIVEN
+    Class<String> type = String.class;
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(typeMessages.hasMessageForType(type)).isFalse();
+      softly.then(typeMessages.getMessageForType(String.class)).isNull();
+      softly.then(typeMessages.isEmpty()).isTrue();
+    });
+  }
+
+  @Test
+  void should_return_most_relevant_message() {
+    // GIVEN
+    String message = "type message";
+    // WHEN
+    typeMessages.registerMessage(Foo.class, message);
+    // THEN
+    thenSoftly(softly -> {
+      softly.then(typeMessages.hasMessageForType(Bar.class)).isTrue();
+      softly.then(typeMessages.getMessageForType(Bar.class)).isEqualTo(message);
+    });
+  }
+
+  private interface Foo {
+
+  }
+
+  private interface Bar extends Foo {
+
+  }
+}

--- a/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingFieldByFieldRecursive_Test.java
+++ b/src/test/java/org/assertj/core/internal/objects/Objects_assertIsEqualToComparingFieldByFieldRecursive_Test.java
@@ -404,7 +404,7 @@ public class Objects_assertIsEqualToComparingFieldByFieldRecursive_Test extends 
     other.dateOfBirth = new Date(1000L);
 
     TypeComparators typeComparators = new TypeComparators();
-    typeComparators.put(Timestamp.class, SYMMETRIC_DATE_COMPARATOR);
+    typeComparators.registerComparator(Timestamp.class, SYMMETRIC_DATE_COMPARATOR);
 
     objects.assertIsEqualToComparingFieldByFieldRecursively(someInfo(), actual, other, noFieldComparators(),
                                                             typeComparators);


### PR DESCRIPTION
Added possibility to override a error message for a specific fields/types for the recursive comparison.

This functionality especially useful for custom equals/comparators. For example:
```java
class Foo {

    private final Integer bar;

     private Foo(Integer bar) {
             this.bar = bar;
      }
}

Foo actual = new Foo(1);
Foo expected = new Foo(1);

BiPredicate<Integer, Integer> greaterThan = (a, e) -> Objects.equals(a, e + 1);

Assertions.assertThat(actual)
                .usingRecursiveComparison()
                .withEqualsForFields(greaterThan, "bar")
                .isEqualTo(expected);
```
This code snippet would throw a error with a description:

```
when recursively comparing field by field, but found the following difference:

field/property 'bar' differ:
- actual value  : 1 (Integer@3f3c7bdb)
- expected value: 1 (Integer@3f3c7bdb)
```

Looks silly, doesn't it?

This pull request provides to override the description:
```java
class Foo {

    private final Integer bar;

     private Foo(Integer bar) {
             this.bar = bar;
      }
}

Foo actual = new Foo(1);
Foo expected = new Foo(1);

BiPredicate<Integer, Integer> greaterThan = (a, e) -> Objects.equals(a, e + 1);
String message = "Property bar of expected object must be incremented by 1";

Assertions.assertThat(actual)
                .usingRecursiveComparison()
                .withEqualsForFields(greaterThan, "bar")
                .withErrorMessageForFields(message, "bar")
                .isEqualTo(expected);
```
And the result message for this field will be overridden.

```
when recursively comparing field by field, but found the following difference:

Property bar of expected object must be incremented by 1
```

#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : YES 
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
