### PR TITLE
Issue 2060 StringAssert: add variants with "Ignoring"

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -869,6 +869,37 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} contains all the given values
+   * , ignoring new line differences.
+   * <p>
+   * You can use one or several {@code CharSequence}s as in this example:
+   *
+   * <pre><code class='java'> // assertions succeed:
+   * assertThat(&quot;Gandalf\nthe\ngrey&quot;)
+   * .containsIgnoringNewLines(&quot;alf&quot;)
+   * .containsIgnoringNewLines(&quot;alf&quot;, &quot;grey&quot;)
+   * .containsIgnoringNewLines(&quot;thegrey&quot;)
+   * .containsIgnoringNewLines(&quot;thegr\ney&quot;)
+   * .containsIgnoringNewLines(&quot;t\nh\ne\ng\nr\ney&quot;);
+   * // assertion fails:
+   * assertThat(&quot;Gandalf\nthe\ngrey&quot;)
+   * .containsIgnoringNewLines(&quot;alF&quot;)
+   * assertThat(&quot;Gandalf\nthe\ngrey&quot;)
+   * .containsIgnoringNewLines(&quot;t\nh\ne\ng\nr\t\r\ney&quot;)</code></pre>
+   * @param values the values to look for.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given list of values is {@code null}.
+   * @throws IllegalArgumentException if the list of given values is empty.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not contain
+   * all the given values.
+   */
+  public SELF containsIgnoringNewLines(final CharSequence... values) {
+    strings.assertContainsIgnoringNewLines(info, actual, values);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} does not contain any of the given values.
    * <p>
    * Example:

--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -868,6 +868,7 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
     return myself;
   }
 
+  // CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
   /**
    * Verifies that the actual {@code CharSequence} contains all the given values
    * , ignoring new line differences.

--- a/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
@@ -166,6 +166,7 @@ public class ShouldContainCharSequence extends BasicErrorMessageFactory {
                                          actual, strings, notFound, comparisonStrategy);
   }
 
+  // CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
   /** Creates a new <code>{@link ShouldContainCharSequence}</code>.
    * @param actual  the actual value in the failed assertion.
    * @param strings the sequence of values expected to be in {@code actual}.

--- a/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainCharSequence.java
@@ -166,6 +166,39 @@ public class ShouldContainCharSequence extends BasicErrorMessageFactory {
                                          actual, strings, notFound, comparisonStrategy);
   }
 
+  /** Creates a new <code>{@link ShouldContainCharSequence}</code>.
+   * @param actual  the actual value in the failed assertion.
+   * @param strings the sequence of values expected to be in {@code actual}.
+   * @param notFound the values not found.
+   * @param comparisonWay the {@link ComparisonStrategy} to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory containsIgnoringNewLines(final CharSequence actual,
+                                                             final CharSequence sequence,
+                                                             final CharSequence[] strings,
+                                                             final Set<? extends CharSequence> notFound,
+                                                             final ComparisonStrategy comparisonWay) {
+    final String expectingActual = "Expecting actual:%n";
+    if (sequence == null) {
+      return new ShouldContainCharSequence("%n" +
+                                           expectingActual +
+                                           "  %s%n" +
+                                           "to contain (ignoring new lines):%n" +
+                                           "  %s%n" +
+                                           "but could not find:%n" +
+                                           "  %s%n" +
+                                           " %s",
+                                           actual, strings, notFound, comparisonWay);
+    }
+    return new ShouldContainCharSequence("%n" +
+                                         expectingActual +
+                                         "  %s%n" +
+                                         "to contain (ignoring new lines):%n" +
+                                         "  %s %s",
+                                         actual, sequence, comparisonWay);
+
+  }
+
   private ShouldContainCharSequence(String format, CharSequence actual, CharSequence sequence,
                                     ComparisonStrategy comparisonStrategy) {
     super(format, actual, sequence, comparisonStrategy);

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -543,7 +543,7 @@ public class Strings {
   public void assertContainsIgnoringNewLines(final AssertionInfo info, final CharSequence actual, final CharSequence... values) {
     doCommonCheckForCharSequence(info, actual, values);
     final String actualNoNewLines = removeNewLines(actual);
-    Set<CharSequence> notFound = stream(values).map(Strings::removeNewLines)
+    final Set<CharSequence> notFound = stream(values).map(Strings::removeNewLines)
                                                .filter(value -> !stringContains(actualNoNewLines, value))
                                                .collect(toCollection(LinkedHashSet::new));
 

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -35,6 +35,7 @@ import static org.assertj.core.error.ShouldBeNullOrEmpty.shouldBeNullOrEmpty;
 import static org.assertj.core.error.ShouldBeSubstring.shouldBeSubstring;
 import static org.assertj.core.error.ShouldBeUpperCase.shouldBeUpperCase;
 import static org.assertj.core.error.ShouldContainAnyOf.shouldContainAnyOf;
+import static org.assertj.core.error.ShouldContainCharSequence.containsIgnoringNewLines;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContainIgnoringCase;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContainIgnoringWhitespaces;
@@ -525,6 +526,33 @@ public class Strings {
     assertNotNull(info, actual);
     if (!actual.toString().toLowerCase().contains(sequence.toString().toLowerCase()))
       throw failures.failure(info, shouldContainIgnoringCase(actual, sequence));
+  }
+
+  /**
+   * Verifies the given {@code CharSequence} has the strings, ignoring newlines.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param values the values to look for.
+   * @throws NullPointerException if the given sequence is {@code null}.
+   * @throws IllegalArgumentException if the given values is empty.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if actual {@code CharSequence} doesn't have sequence
+   */
+  public void assertContainsIgnoringNewLines(final AssertionInfo info, final CharSequence actual, final CharSequence... values) {
+    doCommonCheckForCharSequence(info, actual, values);
+    final String actualNoNewLines = removeNewLines(actual);
+    Set<CharSequence> notFound = stream(values).map(Strings::removeNewLines)
+                                               .filter(value -> !stringContains(actualNoNewLines, value))
+                                               .collect(toCollection(LinkedHashSet::new));
+
+    if (notFound.isEmpty()) {
+      return;
+    }
+    if (values.length == 1) {
+      throw failures.failure(info, containsIgnoringNewLines(actual, values[0], null, null, comparisonStrategy));
+    }
+    throw failures.failure(info, containsIgnoringNewLines(actual, null, values, notFound, comparisonStrategy));
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -528,6 +528,7 @@ public class Strings {
       throw failures.failure(info, shouldContainIgnoringCase(actual, sequence));
   }
 
+  // CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
   /**
    * Verifies the given {@code CharSequence} has the strings, ignoring newlines.
    *

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsIgnoringNewLines_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsIgnoringNewLines_CharSequence_Test.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import org.assertj.core.api.CharSequenceAssert;
 import org.assertj.core.api.CharSequenceAssertBaseTest;
 
+// CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
 /**
  * Tests for <code>{@link
  * CharSequenceAssert#containsIgnoringNewLines(CharSequence...)}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsIgnoringNewLines_CharSequence_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_containsIgnoringNewLines_CharSequence_Test.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+
+package org.assertj.core.api.charsequence;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+/**
+ * Tests for <code>{@link
+ * CharSequenceAssert#containsIgnoringNewLines(CharSequence...)}
+ * (CharSequence...)}</code>.
+ */
+class CharSequenceAssert_containsIgnoringNewLines_CharSequence_Test extends CharSequenceAssertBaseTest {
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    CharSequenceAssert result;
+    result = assertions.containsIgnoringNewLines("Al", "Bob");
+    return result;
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertContainsIgnoringNewLines(getInfo(assertions), getActual(assertions), "Al", "Bob");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
@@ -166,14 +166,16 @@ class ShouldContainCharSequence_create_Test {
   void should_create_error_message_with_several_CharSequence_values_when_ignoring_new_lines() {
     // GIVEN
     final CharSequence[] charSequences = array("Vador", "Luke", "Solo");
-    final ErrorMessageFactory factory = containsIgnoringNewLines("Yoda\nLuke", null, charSequences, newSet("Vador", "Solo"),
+    final ErrorMessageFactory factory = containsIgnoringNewLines("Yoda" + System.lineSeparator() + "Luke", null, charSequences,
+                                                                 newSet("Vador", "Solo"),
+
                                                                  StandardComparisonStrategy.instance());
     // WHEN
     final String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  \"Yoda\nLuke\"%n" +
+                                   "  \"Yoda%nLuke\"%n" +
                                    "to contain (ignoring new lines):%n" +
                                    "  [\"Vador\", \"Luke\", \"Solo\"]%n" +
                                    "but could not find:%n" +

--- a/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
@@ -168,7 +168,6 @@ class ShouldContainCharSequence_create_Test {
     final CharSequence[] charSequences = array("Vador", "Luke", "Solo");
     final ErrorMessageFactory factory = containsIgnoringNewLines("Yoda" + System.lineSeparator() + "Luke", null, charSequences,
                                                                  newSet("Vador", "Solo"),
-
                                                                  StandardComparisonStrategy.instance());
     // WHEN
     final String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);

--- a/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
@@ -145,6 +145,7 @@ class ShouldContainCharSequence_create_Test {
                                    "  [\"Vador\", \"Solo\"]%n "));
   }
 
+  // CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
   @Test
   void should_create_error_message_with_custom_comparison_strategy_when_ignoring_new_lines() {
     // GIVEN
@@ -160,6 +161,7 @@ class ShouldContainCharSequence_create_Test {
                                    "  \"Luke\" when comparing values using CaseInsensitiveStringComparator"));
   }
 
+  // CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
   @Test
   void should_create_error_message_with_several_CharSequence_values_when_ignoring_new_lines() {
     // GIVEN

--- a/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
@@ -148,33 +148,33 @@ class ShouldContainCharSequence_create_Test {
   @Test
   void should_create_error_message_with_custom_comparison_strategy_when_ignoring_new_lines() {
     // GIVEN
-    final ErrorMessageFactory factory = containsIgnoringNewLines("Alice", "Bill", null, null,
+    final ErrorMessageFactory factory = containsIgnoringNewLines("Yoda", "Luke", null, null,
                                                                  new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
     // WHEN
     final String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  \"Alice\"%n" +
+                                   "  \"Yoda\"%n" +
                                    "to contain (ignoring new lines):%n" +
-                                   "  \"Bill\" when comparing values using CaseInsensitiveStringComparator"));
+                                   "  \"Luke\" when comparing values using CaseInsensitiveStringComparator"));
   }
 
   @Test
   void should_create_error_message_with_several_CharSequence_values_when_ignoring_new_lines() {
     // GIVEN
-    final CharSequence[] charSequences = array("Alice", "Al", "Bob");
-    final ErrorMessageFactory factory = containsIgnoringNewLines("Alice\nBo", null, charSequences, newSet("Al", "Bob"),
+    final CharSequence[] charSequences = array("Vador", "Luke", "Solo");
+    final ErrorMessageFactory factory = containsIgnoringNewLines("Yoda\nLuke", null, charSequences, newSet("Vador", "Solo"),
                                                                  StandardComparisonStrategy.instance());
     // WHEN
     final String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  \"Alice\nBo\"%n" +
+                                   "  \"Yoda\nLuke\"%n" +
                                    "to contain (ignoring new lines):%n" +
-                                   "  [\"Alice\", \"Al\", \"Bob\"]%n" +
+                                   "  [\"Vador\", \"Luke\", \"Solo\"]%n" +
                                    "but could not find:%n" +
-                                   "  [\"Al\", \"Bob\"]%n "));
+                                   "  [\"Vador\", \"Solo\"]%n "));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainCharSequence_create_Test.java
@@ -14,6 +14,7 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainCharSequence.containsIgnoringNewLines;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContain;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContainIgnoringCase;
 import static org.assertj.core.error.ShouldContainCharSequence.shouldContainIgnoringWhitespaces;
@@ -144,4 +145,36 @@ class ShouldContainCharSequence_create_Test {
                                    "  [\"Vador\", \"Solo\"]%n "));
   }
 
+  @Test
+  void should_create_error_message_with_custom_comparison_strategy_when_ignoring_new_lines() {
+    // GIVEN
+    final ErrorMessageFactory factory = containsIgnoringNewLines("Alice", "Bill", null, null,
+                                                                 new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+    // WHEN
+    final String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Alice\"%n" +
+                                   "to contain (ignoring new lines):%n" +
+                                   "  \"Bill\" when comparing values using CaseInsensitiveStringComparator"));
+  }
+
+  @Test
+  void should_create_error_message_with_several_CharSequence_values_when_ignoring_new_lines() {
+    // GIVEN
+    final CharSequence[] charSequences = array("Alice", "Al", "Bob");
+    final ErrorMessageFactory factory = containsIgnoringNewLines("Alice\nBo", null, charSequences, newSet("Al", "Bob"),
+                                                                 StandardComparisonStrategy.instance());
+    // WHEN
+    final String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Alice\nBo\"%n" +
+                                   "to contain (ignoring new lines):%n" +
+                                   "  [\"Alice\", \"Al\", \"Bob\"]%n" +
+                                   "but could not find:%n" +
+                                   "  [\"Al\", \"Bob\"]%n "));
+  }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsIgnoringNewLines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsIgnoringNewLines_Test.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+// CS427 Issue link: https://github.com/assertj/assertj-core/issues/2060
 /**
  * Tests for <code>{@link Strings#assertContainsIgnoringNewLines(AssertionInfo, CharSequence, CharSequence...)} </code>.
  */

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsIgnoringNewLines_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertContainsIgnoringNewLines_Test.java
@@ -1,0 +1,164 @@
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldContainCharSequence.containsIgnoringNewLines;
+import static org.assertj.core.internal.ErrorMessages.charSequenceToLookForIsNull;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+import static org.assertj.core.util.Sets.newLinkedHashSet;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.api.WritableAssertionInfo;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for <code>{@link Strings#assertContainsIgnoringNewLines(AssertionInfo, CharSequence, CharSequence...)} </code>.
+ */
+public class Strings_assertContainsIgnoringNewLines_Test extends StringsBaseTest {
+  private static final WritableAssertionInfo INFO = someInfo();
+
+  @ParameterizedTest
+  @ValueSource(strings = { "Al", "ice\nandBob", "Alice\nandBob", "Alice\nand\nBob" })
+  void should_pass_if_actual_contains_value_when_new_lines_are_ignored(String value) {
+    // GIVEN
+    String actual = "Alice\nand\nBob";
+    // WHEN / THEN
+    strings.assertContainsIgnoringNewLines(INFO, actual, value);
+  }
+
+  @Test
+  void should_pass_if_actual_contains_all_given_strings() {
+    // GIVEN
+    String actual = "Alice\nand\nBob";
+    String[] values = array("Ali", "ce", "a", "nd", "Bob");
+    // WHEN / THEN
+    strings.assertContainsIgnoringNewLines(INFO, actual, values);
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_value() {
+    // GIVEN
+    String actual = "Al";
+    String value = "Bob";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+
+    // THEN
+    then(assertionError).hasMessage(containsIgnoringNewLines("Al", "Bob", null, null,
+                                                             StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_value_but_in_different_case() {
+    // GIVEN
+    String actual = "Al";
+    String value = "al";
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+
+    // THEN
+    then(assertionError).hasMessage(containsIgnoringNewLines("Al", "al", null, null,
+                                                             StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_fail_if_actual_contains_value_with_new_lines_but_in_different_case() {
+    // GIVEN
+    String actual = "Alice\nand\nbob";
+    String value = "and\nBob";
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+    // THEN
+    then(assertionError).hasMessage(containsIgnoringNewLines("Alice\nand\nbob", "and\nBob", null, null,
+                                                             StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_throw_error_if_value_is_null() {
+    // GIVEN
+    String actual = "Al";
+    String value = null;
+    // WHEN / THEN
+    assertThatNullPointerException().isThrownBy(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value))
+                                    .withMessage(charSequenceToLookForIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    String actual = null;
+    String value = "Bob";
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, value));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_all_given_strings() {
+    // GIVEN
+    String actual = "Alice";
+    String[] values = array("Al", "ice", "Bob");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertContainsIgnoringNewLines(INFO, actual, values));
+    // THEN
+    then(assertionError).hasMessage(containsIgnoringNewLines(actual, null, values, newLinkedHashSet("Bob"),
+                                                             StandardComparisonStrategy.instance()).create());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = { "Al", "al", "AL", "and\nbob", "and\nBob", "and\nB\no\nb" })
+  void should_pass_if_actual_contains_value_according_to_custom_comparison_strategy(String value) {
+    // GIVEN
+    String actual = "Alice\nand\nBob";
+    // WHEN / THEN
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO, actual, value);
+  }
+
+  @Test
+  void should_pass_if_actual_contains_all_given_strings_according_to_custom_comparison_strategy() {
+    // GIVEN
+    String actual = "Alice\nand\nBob";
+    String[] values = array("Al", "iCe", "and", "Bob");
+    // WHEN / THEN
+    stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO, actual, values);
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_value_according_to_custom_comparison_strategy() {
+    // GIVEN
+    String actual = "Al";
+    String value = "Bob";
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO,
+                                                                                                                                           actual,
+                                                                                                                                           value));
+    // THEN
+    then(assertionError).hasMessage(containsIgnoringNewLines("Al", "Bob", null, null, comparisonStrategy).create());
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_contain_all_given_strings_according_to_custom_comparison_strategy() {
+    // GIVEN
+    String actual = "Alice";
+    String[] values = array("Al", "ice", "\nBob");
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> stringsWithCaseInsensitiveComparisonStrategy.assertContainsIgnoringNewLines(INFO,
+                                                                                                                                           actual,
+                                                                                                                                           values));
+    // THEN
+    then(assertionError).hasMessage(containsIgnoringNewLines(actual, null, values, newLinkedHashSet("Bob"),
+                                                             comparisonStrategy).create());
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes  #2060 (partially)
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
