### PR TITLE
Added hasNoHost to AbstractUriAssert and AbstractUrlAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -133,6 +133,24 @@ public abstract class AbstractUriAssert<SELF extends AbstractUriAssert<SELF>> ex
   }
 
   /**
+   * Verifies that the actual {@code URI} has no host.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // This assertion succeeds:
+   * assertThat(new URI("file:///home/user/Documents/hello-world.txt")).hasNoHost();
+   *
+   * // This assertion fails:
+   * assertThat(new URI("http://helloworld.org:8080/index.html")).hasNoHost();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual has a host.
+   */
+  public SELF hasNoHost() {
+    uris.assertHasNoHost(info, actual);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code URI} has the expected authority.
    * <p>
    * Examples:

--- a/src/main/java/org/assertj/core/api/AbstractUriAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUriAssert.java
@@ -143,7 +143,8 @@ public abstract class AbstractUriAssert<SELF extends AbstractUriAssert<SELF>> ex
    * assertThat(new URI("http://helloworld.org:8080/index.html")).hasNoHost();</code></pre>
    *
    * @return {@code this} assertion object.
-   * @throws AssertionError if the actual has a host.
+   * @throws AssertionError if actual has a host.
+   * @since 3.22.0
    */
   public SELF hasNoHost() {
     uris.assertHasNoHost(info, actual);

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -155,6 +155,24 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
   }
 
   /**
+   * Verifies that the actual {@code URL} has the expected host.
+   * <p>
+   * Examples:
+   * <pre><code class='java'> // This assertion succeeds:
+   * assertThat(new URL("file:///home/user/Documents/hello-world.txt")).hasNoHost();
+   *
+   * // This assertion fails:
+   * assertThat(new URL("http://helloworld.org:8080/index.html")).hasNoHost();</code></pre>
+   *
+   * @return {@code this} assertion object.
+   * @throws AssertionError if the actual host is not equal to the expected host.
+   */
+  public SELF hasNoHost() {
+    urls.assertHasNoHost(info, actual);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code URL} has the expected authority.
    * <p>
    * Examples:

--- a/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractUrlAssert.java
@@ -155,7 +155,7 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
   }
 
   /**
-   * Verifies that the actual {@code URL} has the expected host.
+   * Verifies that the actual {@code URL} has no host.
    * <p>
    * Examples:
    * <pre><code class='java'> // This assertion succeeds:
@@ -165,7 +165,8 @@ public abstract class AbstractUrlAssert<SELF extends AbstractUrlAssert<SELF>> ex
    * assertThat(new URL("http://helloworld.org:8080/index.html")).hasNoHost();</code></pre>
    *
    * @return {@code this} assertion object.
-   * @throws AssertionError if the actual host is not equal to the expected host.
+   * @throws AssertionError if actual has a host.
+   * @since 3.22.0
    */
   public SELF hasNoHost() {
     urls.assertHasNoHost(info, actual);

--- a/src/main/java/org/assertj/core/error/uri/ShouldHaveNoHost.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldHaveNoHost.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error.uri;
+
+import java.net.URI;
+import java.net.URL;
+import org.assertj.core.error.BasicErrorMessageFactory;
+import org.assertj.core.error.ErrorMessageFactory;
+
+public class ShouldHaveNoHost extends BasicErrorMessageFactory {
+
+  private static final String SHOULD_HAVE_NO_HOST = "Expected no host to be present for <%s>, but found: <%s>";
+
+  public static ErrorMessageFactory shouldHaveNoHost(URI actual) {
+    return new ShouldHaveNoHost(actual);
+  }
+
+  private ShouldHaveNoHost(URI actual) {
+    super(SHOULD_HAVE_NO_HOST, actual, null, actual.getHost());
+  }
+
+  public static ErrorMessageFactory shouldHaveNoHost(URL actual) {
+    return new ShouldHaveNoHost(actual);
+  }
+
+  private ShouldHaveNoHost(URL actual) {
+    super(SHOULD_HAVE_NO_HOST, actual, null, actual.getHost());
+  }
+}

--- a/src/main/java/org/assertj/core/error/uri/ShouldHaveNoHost.java
+++ b/src/main/java/org/assertj/core/error/uri/ShouldHaveNoHost.java
@@ -14,26 +14,28 @@ package org.assertj.core.error.uri;
 
 import java.net.URI;
 import java.net.URL;
+
 import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 
 public class ShouldHaveNoHost extends BasicErrorMessageFactory {
 
-  private static final String SHOULD_HAVE_NO_HOST = "Expected no host to be present for <%s>, but found: <%s>";
+  private static final String SHOULD_HAVE_NO_HOST = "%n" +
+                                                    "Expecting no host for:%n" +
+                                                    "  %s%n" +
+                                                    "but found:%n" +
+                                                    "  %s";
 
   public static ErrorMessageFactory shouldHaveNoHost(URI actual) {
-    return new ShouldHaveNoHost(actual);
-  }
-
-  private ShouldHaveNoHost(URI actual) {
-    super(SHOULD_HAVE_NO_HOST, actual, null, actual.getHost());
+    return new ShouldHaveNoHost(actual, actual.getHost());
   }
 
   public static ErrorMessageFactory shouldHaveNoHost(URL actual) {
-    return new ShouldHaveNoHost(actual);
+    return new ShouldHaveNoHost(actual, actual.getHost());
   }
 
-  private ShouldHaveNoHost(URL actual) {
-    super(SHOULD_HAVE_NO_HOST, actual, null, actual.getHost());
+  private ShouldHaveNoHost(Object actual, String host) {
+    super(SHOULD_HAVE_NO_HOST, actual, host);
   }
+
 }

--- a/src/main/java/org/assertj/core/internal/Uris.java
+++ b/src/main/java/org/assertj/core/internal/Uris.java
@@ -75,14 +75,13 @@ public class Uris {
 
   public void assertHasHost(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
-    requireNonNull(expected, "The expected host should not be null.");
+    requireNonNull(expected, "The expected host should not be null");
     if (!Objects.equals(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
   }
 
   public void assertHasNoHost(AssertionInfo info, URI actual) {
     assertNotNull(info, actual);
-    if (actual.getHost() != null && !actual.getHost().isEmpty())
-      throw failures.failure(info, shouldHaveNoHost(actual));
+    if (actual.getHost() != null) throw failures.failure(info, shouldHaveNoHost(actual));
   }
 
   public void assertHasAuthority(AssertionInfo info, URI actual, String expected) {

--- a/src/main/java/org/assertj/core/internal/Uris.java
+++ b/src/main/java/org/assertj/core/internal/Uris.java
@@ -12,9 +12,11 @@
  */
 package org.assertj.core.internal;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
 import static org.assertj.core.error.uri.ShouldHaveFragment.shouldHaveFragment;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
+import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameters;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
@@ -73,7 +75,14 @@ public class Uris {
 
   public void assertHasHost(AssertionInfo info, URI actual, String expected) {
     assertNotNull(info, actual);
+    requireNonNull(expected, "The expected host should not be null.");
     if (!Objects.equals(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
+  }
+
+  public void assertHasNoHost(AssertionInfo info, URI actual) {
+    assertNotNull(info, actual);
+    if (actual.getHost() != null && !actual.getHost().isEmpty())
+      throw failures.failure(info, shouldHaveNoHost(actual));
   }
 
   public void assertHasAuthority(AssertionInfo info, URI actual, String expected) {

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -82,14 +82,13 @@ public class Urls {
 
   public void assertHasHost(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
-    requireNonNull(expected, "The expected host should not be null.");
+    requireNonNull(expected, "The expected host should not be null");
     if (!Objects.equals(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
   }
 
   public void assertHasNoHost(AssertionInfo info, URL actual) {
     assertNotNull(info, actual);
-    if (actual.getHost() != null && !actual.getHost().isEmpty())
-      throw failures.failure(info, shouldHaveNoHost(actual));
+    if (actual.getHost() != null && !actual.getHost().isEmpty()) throw failures.failure(info, shouldHaveNoHost(actual));
   }
 
   public void assertHasAuthority(AssertionInfo info, URL actual, String expected) {

--- a/src/main/java/org/assertj/core/internal/Urls.java
+++ b/src/main/java/org/assertj/core/internal/Urls.java
@@ -13,10 +13,12 @@
 package org.assertj.core.internal;
 
 import static java.util.Objects.deepEquals;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.error.uri.ShouldBeEqualToWithSortedQueryParameters.shouldBeEqualToWithSortedQueryParameters;
 import static org.assertj.core.error.uri.ShouldHaveAnchor.shouldHaveAnchor;
 import static org.assertj.core.error.uri.ShouldHaveAuthority.shouldHaveAuthority;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
+import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameter;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveNoParameters;
 import static org.assertj.core.error.uri.ShouldHaveParameter.shouldHaveParameter;
@@ -80,7 +82,14 @@ public class Urls {
 
   public void assertHasHost(AssertionInfo info, URL actual, String expected) {
     assertNotNull(info, actual);
+    requireNonNull(expected, "The expected host should not be null.");
     if (!Objects.equals(actual.getHost(), expected)) throw failures.failure(info, shouldHaveHost(actual, expected));
+  }
+
+  public void assertHasNoHost(AssertionInfo info, URL actual) {
+    assertNotNull(info, actual);
+    if (actual.getHost() != null && !actual.getHost().isEmpty())
+      throw failures.failure(info, shouldHaveNoHost(actual));
   }
 
   public void assertHasAuthority(AssertionInfo info, URL actual, String expected) {

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoHost_Test.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.uri;
+
+import org.assertj.core.api.UriAssert;
+import org.assertj.core.api.UriAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test for <code>{@link org.assertj.core.api.UriAssert#hasNoHost()}</code>.
+ */
+class UriAssert_hasNoHost_Test extends UriAssertBaseTest {
+  @Override
+  protected UriAssert invoke_api_method() {
+    return assertions.hasNoHost();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(uris).assertHasNoHost(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/api/uri/UriAssert_hasNoHost_Test.java
@@ -12,15 +12,13 @@
  */
 package org.assertj.core.api.uri;
 
+import static org.mockito.Mockito.verify;
+
 import org.assertj.core.api.UriAssert;
 import org.assertj.core.api.UriAssertBaseTest;
 
-import static org.mockito.Mockito.verify;
-
-/**
- * Test for <code>{@link org.assertj.core.api.UriAssert#hasNoHost()}</code>.
- */
 class UriAssert_hasNoHost_Test extends UriAssertBaseTest {
+
   @Override
   protected UriAssert invoke_api_method() {
     return assertions.hasNoHost();
@@ -30,4 +28,5 @@ class UriAssert_hasNoHost_Test extends UriAssertBaseTest {
   protected void verify_internal_effects() {
     verify(uris).assertHasNoHost(getInfo(assertions), getActual(assertions));
   }
+
 }

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoHost_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.url;
+
+import org.assertj.core.api.UrlAssert;
+import org.assertj.core.api.UrlAssertBaseTest;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test for <code>{@link org.assertj.core.api.UrlAssert#hasNoHost()}</code>.
+ */
+class UrlAssert_hasNoHost_Test extends UrlAssertBaseTest {
+
+  @Override
+  protected UrlAssert invoke_api_method() {
+    return assertions.hasNoHost();
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(urls).assertHasNoHost(getInfo(assertions), getActual(assertions));
+  }
+}

--- a/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/api/url/UrlAssert_hasNoHost_Test.java
@@ -12,14 +12,11 @@
  */
 package org.assertj.core.api.url;
 
+import static org.mockito.Mockito.verify;
+
 import org.assertj.core.api.UrlAssert;
 import org.assertj.core.api.UrlAssertBaseTest;
 
-import static org.mockito.Mockito.verify;
-
-/**
- * Test for <code>{@link org.assertj.core.api.UrlAssert#hasNoHost()}</code>.
- */
 class UrlAssert_hasNoHost_Test extends UrlAssertBaseTest {
 
   @Override
@@ -31,4 +28,5 @@ class UrlAssert_hasNoHost_Test extends UrlAssertBaseTest {
   protected void verify_internal_effects() {
     verify(urls).assertHasNoHost(getInfo(assertions), getActual(assertions));
   }
+
 }

--- a/src/test/java/org/assertj/core/error/uri/ShouldHaveNoHost_create_Test.java
+++ b/src/test/java/org/assertj/core/error/uri/ShouldHaveNoHost_create_Test.java
@@ -1,0 +1,47 @@
+package org.assertj.core.error.uri;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import org.assertj.core.error.ErrorMessageFactory;
+import org.assertj.core.internal.TestDescription;
+import org.junit.jupiter.api.Test;
+
+class ShouldHaveNoHost_create_Test {
+
+  @Test
+  void should_create_error_message_with_URI() throws URISyntaxException {
+    // GIVEN
+    ErrorMessageFactory underTest = shouldHaveNoHost(new URI("https://example.com"));
+    // WHEN
+    String message = underTest.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting no host for:%n" +
+                                   "  https://example.com%n" +
+                                   "but found:%n" +
+                                   "  \"example.com\""));
+  }
+
+  @Test
+  void should_create_error_message_with_URL() throws MalformedURLException {
+    // GIVEN
+    ErrorMessageFactory underTest = shouldHaveNoHost(new URL("https://example.com"));
+    // WHEN
+    String message = underTest.create(new TestDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting no host for:%n" +
+                                   "  https://example.com%n" +
+                                   "but found:%n" +
+                                   "  \"example.com\""));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasHost_Test.java
@@ -12,17 +12,14 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 
-import java.net.URISyntaxException;
-import java.net.URL;
 import org.assertj.core.internal.UrisBaseTest;
 import org.junit.jupiter.api.Test;
 
@@ -31,50 +28,53 @@ class Uris_assertHasHost_Test extends UrisBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
-    URI uri = null;
-    String expectedHost = "www.helloworld.org";
+    URI actual = null;
+    String expected = "www.helloworld.org";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> uris.assertHasHost(info, uri, expectedHost));
+    AssertionError assertionError = expectAssertionError(() -> uris.assertHasHost(info, actual, expected));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
 
   @Test
-  void should_fail_if_expected_host_is_null() throws URISyntaxException {
+  void should_fail_if_expected_is_null() {
     // GIVEN
-    URI uri = new URI("https://example.com");
-    String expectedHost = null;
+    URI actual = URI.create("http://www.helloworld.org");
+    String expected = null;
     // WHEN
-    thenThrownBy(() -> uris.assertHasHost(info, uri, expectedHost))
-      .isInstanceOf(NullPointerException.class);
+    Throwable thrown = catchThrowable(() -> uris.assertHasHost(info, actual, expected));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage("The expected host should not be null");
   }
 
   @Test
   void should_pass_if_actual_URI_has_the_given_host() {
     // GIVEN
-    URI uri = URI.create("http://www.helloworld.org");
-    String expectedHost = "www.helloworld.org";
+    URI actual = URI.create("http://www.helloworld.org");
+    String expected = "www.helloworld.org";
     // WHEN/THEN
-    uris.assertHasHost(info, uri, expectedHost);
+    uris.assertHasHost(info, actual, expected);
   }
 
   @Test
   void should_pass_if_actual_URI_with_path_has_the_given_host() {
     // GIVEN
-    URI uri = URI.create("http://www.helloworld.org/pages");
-    String expectedHost = "www.helloworld.org";
+    URI actual = URI.create("http://www.helloworld.org/pages");
+    String expected = "www.helloworld.org";
     // WHEN/THEN
-    uris.assertHasHost(info, uri, expectedHost);
+    uris.assertHasHost(info, actual, expected);
   }
 
   @Test
   void should_fail_if_actual_URI_has_not_the_expected_host() {
     // GIVEN
-    URI uri = URI.create("http://example.com/pages/");
-    String expectedHost = "example.org";
+    URI actual = URI.create("http://example.com/pages/");
+    String expected = "example.org";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> uris.assertHasHost(info, uri, expectedHost));
+    AssertionError assertionError = expectAssertionError(() -> uris.assertHasHost(info, actual, expected));
     // THEN
-    then(assertionError).hasMessage(shouldHaveHost(uri, expectedHost).create());
+    then(assertionError).hasMessage(shouldHaveHost(actual, expected).create());
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasHost_Test.java
@@ -13,12 +13,16 @@
 package org.assertj.core.internal.urls;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 
+import java.net.URISyntaxException;
+import java.net.URL;
 import org.assertj.core.internal.UrisBaseTest;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +37,16 @@ class Uris_assertHasHost_Test extends UrisBaseTest {
     AssertionError assertionError = expectAssertionError(() -> uris.assertHasHost(info, uri, expectedHost));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_expected_host_is_null() throws URISyntaxException {
+    // GIVEN
+    URI uri = new URI("https://example.com");
+    String expectedHost = null;
+    // WHEN
+    thenThrownBy(() -> uris.assertHasHost(info, uri, expectedHost))
+      .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoHost_Test.java
@@ -12,44 +12,53 @@
  */
 package org.assertj.core.internal.urls;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import org.assertj.core.internal.UrisBaseTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.stream.Stream;
+
+import org.assertj.core.internal.UrisBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Uris_assertHasNoHost_Test extends UrisBaseTest {
 
   @Test
-  void should_fail_if_host_is_present() throws URISyntaxException {
+  void should_fail_if_actual_is_null() {
     // GIVEN
-    URI uri = new URI("https://example.com");
+    URI actual = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> uris.assertHasNoHost(info, uri));
+    AssertionError assertionError = expectAssertionError(() -> uris.assertHasNoHost(info, actual));
     // THEN
-    then(assertionError).hasMessage(shouldHaveNoHost(uri).create());
+    then(assertionError).hasMessage(actualIsNull());
   }
 
   @Test
-  void should_pass_if_no_host_present_via_str_constructor() throws URISyntaxException {
+  void should_fail_if_host_is_present() throws URISyntaxException {
     // GIVEN
-    URI uri = new URI("file:///etc/lsb-release");
-    // WHEN/THEN
-    uris.assertHasNoHost(info, uri);
+    URI actual = new URI("https://example.com");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertHasNoHost(info, actual));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveNoHost(actual).create());
   }
 
   @ParameterizedTest
-  @NullAndEmptySource
-  void should_pass_if_host_is_explicitly_missing(String host) throws URISyntaxException {
-    // GIVEN
-    URI uri = new URI("file", host, "/etc/lsb-release", null);
+  @MethodSource("uris_with_no_host")
+  void should_pass_if_host_is_not_present(URI actual) {
     // WHEN/THEN
-    uris.assertHasNoHost(info, uri);
+    uris.assertHasNoHost(info, actual);
   }
+
+  private static Stream<URI> uris_with_no_host() throws URISyntaxException {
+    return Stream.of(new URI("file:///etc/lsb-release"),
+                     new URI("file", "", "/etc/lsb-release", null),
+                     new URI("file", null, "/etc/lsb-release", null));
+  }
+
 }

--- a/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Uris_assertHasNoHost_Test.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.assertj.core.internal.UrisBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class Uris_assertHasNoHost_Test extends UrisBaseTest {
+
+  @Test
+  void should_fail_if_host_is_present() throws URISyntaxException {
+    // GIVEN
+    URI uri = new URI("https://example.com");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> uris.assertHasNoHost(info, uri));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveNoHost(uri).create());
+  }
+
+  @Test
+  void should_pass_if_no_host_present_via_str_constructor() throws URISyntaxException {
+    // GIVEN
+    URI uri = new URI("file:///etc/lsb-release");
+    // WHEN/THEN
+    uris.assertHasNoHost(info, uri);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void should_pass_if_host_is_explicitly_missing(String host) throws URISyntaxException {
+    // GIVEN
+    URI uri = new URI("file", host, "/etc/lsb-release", null);
+    // WHEN/THEN
+    uris.assertHasNoHost(info, uri);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasHost_Test.java
@@ -12,8 +12,8 @@
  */
 package org.assertj.core.internal.urls;
 
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -29,49 +29,53 @@ class Urls_assertHasHost_Test extends UrlsBaseTest {
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
-    URL url = null;
-    String expectedHost = "www.helloworld.org";
+    URL actual = null;
+    String expected = "www.helloworld.org";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> urls.assertHasHost(info, url, expectedHost));
+    AssertionError assertionError = expectAssertionError(() -> urls.assertHasHost(info, actual, expected));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
 
   @Test
-  void should_fail_if_expected_host_is_null() throws MalformedURLException {
+  void should_fail_if_expected_is_null() throws MalformedURLException {
     // GIVEN
-    URL url = new URL("https://example.com");
-    String expectedHost = null;
+    URL actual = new URL("https://example.com");
+    String expected = null;
     // WHEN
-    thenThrownBy(() -> urls.assertHasHost(info, url, expectedHost)).isInstanceOf(NullPointerException.class);
+    Throwable thrown = catchThrowable(() -> urls.assertHasHost(info, actual, expected));
+    // THEN
+    then(thrown).isInstanceOf(NullPointerException.class)
+                .hasMessage("The expected host should not be null");
   }
 
   @Test
   void should_pass_if_actual_URL_has_the_given_host() throws MalformedURLException {
     // GIVEN
-    URL url = new URL("http://www.helloworld.org");
-    String expectedHost = "www.helloworld.org";
+    URL actual = new URL("http://www.helloworld.org");
+    String expected = "www.helloworld.org";
     // WHEN/THEN
-    urls.assertHasHost(info, url, expectedHost);
+    urls.assertHasHost(info, actual, expected);
   }
 
   @Test
   void should_pass_if_actual_URL_with_path_has_the_given_host() throws MalformedURLException {
     // GIVEN
-    URL url = new URL("http://www.helloworld.org/pages");
-    String expectedHost = "www.helloworld.org";
+    URL actual = new URL("http://www.helloworld.org/pages");
+    String expected = "www.helloworld.org";
     // WHEN/THEN
-    urls.assertHasHost(info, url, expectedHost);
+    urls.assertHasHost(info, actual, expected);
   }
 
   @Test
   void should_fail_if_actual_URL_has_not_the_expected_host() throws MalformedURLException {
     // GIVEN
-    URL url = new URL("http://example.com/pages/");
-    String expectedHost = "example.org";
+    URL actual = new URL("http://example.com/pages/");
+    String expected = "example.org";
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> urls.assertHasHost(info, url, expectedHost));
+    AssertionError assertionError = expectAssertionError(() -> urls.assertHasHost(info, actual, expected));
     // THEN
-    then(assertionError).hasMessage(shouldHaveHost(url, expectedHost).create());
+    then(assertionError).hasMessage(shouldHaveHost(actual, expected).create());
   }
+
 }

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasHost_Test.java
@@ -13,6 +13,7 @@
 package org.assertj.core.internal.urls;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.assertj.core.error.uri.ShouldHaveHost.shouldHaveHost;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
@@ -34,6 +35,15 @@ class Urls_assertHasHost_Test extends UrlsBaseTest {
     AssertionError assertionError = expectAssertionError(() -> urls.assertHasHost(info, url, expectedHost));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_fail_if_expected_host_is_null() throws MalformedURLException {
+    // GIVEN
+    URL url = new URL("https://example.com");
+    String expectedHost = null;
+    // WHEN
+    thenThrownBy(() -> urls.assertHasHost(info, url, expectedHost)).isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoHost_Test.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.urls;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.assertj.core.internal.UrlsBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+
+class Urls_assertHasNoHost_Test extends UrlsBaseTest {
+
+  @Test
+  void should_fail_if_host_present() throws MalformedURLException {
+    // GIVEN
+    URL url = new URL("https://example.com");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertHasNoHost(info, url));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveNoHost(url).create());
+  }
+
+  @Test
+  void should_pass_if_no_host_present() throws MalformedURLException {
+    // GIVEN
+    URL url = new URL("file:///etc/lsb-release");
+    // WHEN/THEN
+    urls.assertHasNoHost(info, url);
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void should_pass_if_host_is_explicitly_missing(String host) throws MalformedURLException {
+    // GIVEN
+    URL url = new URL("file", host, "/etc/lsb-release");
+    // WHEN/THEN
+    urls.assertHasNoHost(info, url);
+  }
+}

--- a/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoHost_Test.java
+++ b/src/test/java/org/assertj/core/internal/urls/Urls_assertHasNoHost_Test.java
@@ -12,43 +12,53 @@
  */
 package org.assertj.core.internal.urls;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import org.assertj.core.internal.UrlsBaseTest;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.uri.ShouldHaveNoHost.shouldHaveNoHost;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.stream.Stream;
+
+import org.assertj.core.internal.UrlsBaseTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class Urls_assertHasNoHost_Test extends UrlsBaseTest {
 
   @Test
-  void should_fail_if_host_present() throws MalformedURLException {
+  void should_fail_if_actual_is_null() {
     // GIVEN
-    URL url = new URL("https://example.com");
+    URL actual = null;
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> urls.assertHasNoHost(info, url));
+    AssertionError assertionError = expectAssertionError(() -> urls.assertHasNoHost(info, actual));
     // THEN
-    then(assertionError).hasMessage(shouldHaveNoHost(url).create());
+    then(assertionError).hasMessage(actualIsNull());
   }
 
   @Test
-  void should_pass_if_no_host_present() throws MalformedURLException {
+  void should_fail_if_host_present() throws MalformedURLException {
     // GIVEN
-    URL url = new URL("file:///etc/lsb-release");
-    // WHEN/THEN
-    urls.assertHasNoHost(info, url);
+    URL actual = new URL("https://example.com");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> urls.assertHasNoHost(info, actual));
+    // THEN
+    then(assertionError).hasMessage(shouldHaveNoHost(actual).create());
   }
 
   @ParameterizedTest
-  @NullAndEmptySource
-  void should_pass_if_host_is_explicitly_missing(String host) throws MalformedURLException {
-    // GIVEN
-    URL url = new URL("file", host, "/etc/lsb-release");
+  @MethodSource("urls_with_no_host")
+  void should_pass_if_host_is_not_present(URL actual) {
     // WHEN/THEN
-    urls.assertHasNoHost(info, url);
+    urls.assertHasNoHost(info, actual);
   }
+
+  private static Stream<URL> urls_with_no_host() throws MalformedURLException {
+    return Stream.of(new URL("file:///etc/lsb-release"),
+                     new URL("file", "", "/etc/lsb-release"),
+                     new URL("file", null, "/etc/lsb-release"));
+  }
+
 }


### PR DESCRIPTION
Both java.net.URI and java.net.URL have the ability to have null
hosts set (for example in URIs that point to file-system objects,
or custom URI schemes that may be non-standard).

To match the rest of this API where methods exist to provide checks
for no fragments, queries, parameters, etc being set, this provides
host visibility checking.