### PR TITLE
Add IgnoringCase variants of startsWith and endsWith (#2449)

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractCharSequenceAssert.java
@@ -1012,6 +1012,29 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
+   * Verifies that the actual {@code CharSequence} starts with the given prefix, ignoring case considerations.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(&quot;Gandalf the grey&quot;).startsWithIgnoringCase(&quot;Gandalf&quot;);
+   * assertThat(&quot;Gandalf the grey&quot;).startsWithIgnoringCase(&quot;gandalf&quot;);
+   *
+   * // assertion will fail
+   * assertThat(&quot;Gandalf the grey&quot;).startsWithIgnoringCase(&quot;grey&quot;);</code></pre>
+   *
+   * @param prefix the given prefix.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given prefix is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not start with the given prefix, ignoring case.
+   * @since 3.22.0
+   */
+  public SELF startsWithIgnoringCase(CharSequence prefix) {
+    strings.assertStartsWithIgnoringCase(info, actual, prefix);
+    return myself;
+  }
+
+  /**
    * Verifies that the actual {@code CharSequence} does not start with the given prefix.
    * <p>
    * Example:
@@ -1035,7 +1058,31 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
   }
 
   /**
-   * Verifies that the actual {@code CharSequence} ends with the given suffix.
+   * Verifies that the actual {@code CharSequence} does not start with the given prefix, ignoring case considerations.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(&quot;Gandalf the grey&quot;).doesNotStartWithIgnoringCase(&quot;fro&quot;);
+   * assertThat(&quot;Gandalf the grey&quot;).doesNotStartWithIgnoringCase(&quot;grey&quot;);
+   *
+   * // assertions will fail
+   * assertThat(&quot;Gandalf the grey&quot;).doesNotStartWithIgnoringCase(&quot;Gandalf&quot;);
+   * assertThat(&quot;Gandalf the grey&quot;).doesNotStartWithIgnoringCase(&quot;gandalf&quot;);</code></pre>
+   *
+   * @param prefix the given prefix.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given prefix is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} starts with the given prefix, ignoring case.
+   * @since 3.22.0
+   */
+  public SELF doesNotStartWithIgnoringCase(CharSequence prefix) {
+    strings.assertDoesNotStartWithIgnoringCase(info, actual, prefix);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} ends with the given suffix, ignoring case considerations.
    * <p>
    * Example:
    * <pre><code class='java'> // assertion will pass
@@ -1052,6 +1099,29 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    */
   public SELF endsWith(CharSequence suffix) {
     strings.assertEndsWith(info, actual, suffix);
+    return myself;
+  }
+
+  /**
+   * Verifies that the actual {@code CharSequence} ends with the given suffix, ignoring case considerations.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertions will pass
+   * assertThat(&quot;Frodo&quot;).endsWithIgnoringCase(&quot;do&quot;);
+   * assertThat(&quot;Frodo&quot;).endsWithIgnoringCase(&quot;DO&quot;);
+   *
+   * // assertion will fail
+   * assertThat(&quot;Frodo&quot;).endsWithIgnoringCase(&quot;Fro&quot;);</code></pre>
+   *
+   * @param suffix the given suffix.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given suffix is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not end with the given suffix, ignoring case.
+   * @since 3.22.0
+   */
+  public SELF endsWithIgnoringCase(CharSequence suffix) {
+    strings.assertEndsWithIgnoringCase(info, actual, suffix);
     return myself;
   }
 
@@ -1074,6 +1144,28 @@ public abstract class AbstractCharSequenceAssert<SELF extends AbstractCharSequen
    */
   public SELF doesNotEndWith(CharSequence suffix) {
     strings.assertDoesNotEndWith(info, actual, suffix);
+    return myself;
+  }
+
+/**
+   * Verifies that the actual {@code CharSequence} does not end with the given suffix, ignoring case considerations.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // assertion will pass
+   * assertThat(&quot;Frodo&quot;).doesNotEndWithIgnoringCase(&quot;Fro&quot;);
+   *
+   * // assertions will fail
+   * assertThat(&quot;Frodo&quot;).doesNotEndWithIgnoringCase(&quot;do&quot;);
+   * assertThat(&quot;Frodo&quot;).doesNotEndWithIgnoringCase(&quot;DO&quot;);</code></pre>
+   *
+   * @param suffix the given suffix.
+   * @return {@code this} assertion object.
+   * @throws NullPointerException if the given suffix is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} ends with the given suffix, ignoring case.
+   */
+  public SELF doesNotEndWithIgnoringCase(CharSequence suffix) {
+    strings.assertDoesNotEndWithIgnoringCase(info, actual, suffix);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/error/ShouldEndWithIgnoringCase.java
+++ b/src/main/java/org/assertj/core/error/ShouldEndWithIgnoringCase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.ComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that {@link CharSequence} ends with a given value
+ * (ignoring case considerations) failed.
+ *
+ * @since 3.22.0
+ */
+public class ShouldEndWithIgnoringCase extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldEndWithIgnoringCase}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected the value or sequence of values that {@code actual} is expected to end with, ignoring case.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldEndWithIgnoringCase(CharSequence actual, CharSequence expected,
+                                                              ComparisonStrategy comparisonStrategy) {
+    return new ShouldEndWithIgnoringCase(actual, expected, comparisonStrategy);
+  }
+
+  private ShouldEndWithIgnoringCase(Object actual, Object expected, ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nto end with (ignoring case):%n  %s%n%s", actual, expected, comparisonStrategy);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldNotEndWithIgnoringCase.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotEndWithIgnoringCase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.ComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that {@link CharSequence} does not end with a
+ * given value (ignoring case considerations) failed.
+ *
+ * @since 3.22.0
+ */
+public class ShouldNotEndWithIgnoringCase extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotEndWithIgnoringCase}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected the value or sequence of values that {@code actual} is expected to not end with, ignoring case.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotEndWithIgnoringCase(CharSequence actual, CharSequence expected,
+                                                                 ComparisonStrategy comparisonStrategy) {
+    return new ShouldNotEndWithIgnoringCase(actual, expected, comparisonStrategy);
+  }
+
+  private ShouldNotEndWithIgnoringCase(Object actual, Object expected, ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nnot to end with (ignoring case):%n  %s%n%s", actual, expected, comparisonStrategy);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldNotStartWithIgnoringCase.java
+++ b/src/main/java/org/assertj/core/error/ShouldNotStartWithIgnoringCase.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.ComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies {@link CharSequence} does not start with a
+ * given value (ignoring case considerations) failed.
+ *
+ * @since 3.22.0
+ */
+public class ShouldNotStartWithIgnoringCase extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldNotStartWithIgnoringCase}</code>.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected the value or sequence of values that {@code actual} is expected not to start with, ignoring case.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldNotStartWithIgnoringCase(CharSequence actual, CharSequence expected,
+                                                                   ComparisonStrategy comparisonStrategy) {
+    return new ShouldNotStartWithIgnoringCase(actual, expected, comparisonStrategy);
+  }
+
+  private ShouldNotStartWithIgnoringCase(Object actual, Object expected, ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nnot to start with (ignoring case):%n  %s%n%s", actual, expected, comparisonStrategy);
+  }
+}

--- a/src/main/java/org/assertj/core/error/ShouldStartWithIgnoringCase.java
+++ b/src/main/java/org/assertj/core/error/ShouldStartWithIgnoringCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.internal.ComparisonStrategy;
+
+/**
+ * Creates an error message indicating that an assertion that verifies {@link CharSequence} starts with a given value
+ * (ignoring case considerations) failed.
+ *
+ * @since 3.22.0
+ */
+public class ShouldStartWithIgnoringCase extends BasicErrorMessageFactory {
+
+  /**
+   * Creates a new <code>{@link ShouldStartWithIgnoringCase}</code>.
+   * @param actual the actual value in the failed assertion.
+   * @param expected the value or sequence of values that {@code actual} is expected to start with, ignoring case.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   */
+  public static ErrorMessageFactory shouldStartWithIgnoringCase(CharSequence actual, CharSequence expected,
+                                                                ComparisonStrategy comparisonStrategy) {
+    return new ShouldStartWithIgnoringCase(actual, expected, comparisonStrategy);
+  }
+
+  private ShouldStartWithIgnoringCase(CharSequence actual, CharSequence expected, ComparisonStrategy comparisonStrategy) {
+    super("%nExpecting actual:%n  %s%nto start with (ignoring case):%n  %s%n%s", actual, expected, comparisonStrategy);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -46,6 +46,7 @@ import static org.assertj.core.error.ShouldContainPattern.shouldContainPattern;
 import static org.assertj.core.error.ShouldContainSequenceOfCharSequence.shouldContainSequence;
 import static org.assertj.core.error.ShouldContainSubsequenceOfCharSequence.shouldContainSubsequence;
 import static org.assertj.core.error.ShouldEndWith.shouldEndWith;
+import static org.assertj.core.error.ShouldEndWithIgnoringCase.shouldEndWithIgnoringCase;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThan.shouldHaveSizeGreaterThan;
 import static org.assertj.core.error.ShouldHaveSizeGreaterThanOrEqualTo.shouldHaveSizeGreaterThanOrEqualTo;
 import static org.assertj.core.error.ShouldHaveSizeLessThan.shouldHaveSizeLessThan;
@@ -62,9 +63,12 @@ import static org.assertj.core.error.ShouldNotContainCharSequence.shouldNotConta
 import static org.assertj.core.error.ShouldNotContainOnlyWhitespaces.shouldNotContainOnlyWhitespaces;
 import static org.assertj.core.error.ShouldNotContainPattern.shouldNotContainPattern;
 import static org.assertj.core.error.ShouldNotEndWith.shouldNotEndWith;
+import static org.assertj.core.error.ShouldNotEndWithIgnoringCase.shouldNotEndWithIgnoringCase;
 import static org.assertj.core.error.ShouldNotMatchPattern.shouldNotMatch;
 import static org.assertj.core.error.ShouldNotStartWith.shouldNotStartWith;
+import static org.assertj.core.error.ShouldNotStartWithIgnoringCase.shouldNotStartWithIgnoringCase;
 import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
+import static org.assertj.core.error.ShouldStartWithIgnoringCase.shouldStartWithIgnoringCase;
 import static org.assertj.core.internal.Arrays.assertIsArray;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsEmpty;
 import static org.assertj.core.internal.CommonErrors.arrayOfValuesToLookForIsNull;
@@ -861,6 +865,24 @@ public class Strings {
   }
 
   /**
+   * Verifies that the given {@code CharSequence} starts with the given prefix, ignoring case considerations.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param prefix the given prefix.
+   * @throws NullPointerException if the given sequence is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not start with the given prefix, ignoring case.
+   * @since 3.22.0
+   */
+  public void assertStartsWithIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence prefix) {
+    failIfPrefixIsNull(prefix);
+    assertNotNull(info, actual);
+    if (!comparisonStrategy.stringStartsWith(actual.toString().toLowerCase(), prefix.toString().toLowerCase()))
+      throw failures.failure(info, shouldStartWithIgnoringCase(actual, prefix, comparisonStrategy));
+  }
+
+  /**
    * Verifies that the given {@code CharSequence} does not start with the given prefix.
    *
    * @param info contains information about the assertion.
@@ -875,6 +897,24 @@ public class Strings {
     assertNotNull(info, actual);
     if (comparisonStrategy.stringStartsWith(actual.toString(), prefix.toString()))
       throw failures.failure(info, shouldNotStartWith(actual, prefix, comparisonStrategy));
+  }
+
+  /**
+   * Verifies that the given {@code CharSequence} does not start with the given prefix, ignoring case considerations.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param prefix the given prefix.
+   * @throws NullPointerException if the given sequence is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} starts with the given prefix, ignoring case.
+   * @since 3.22.0
+   */
+  public void assertDoesNotStartWithIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence prefix) {
+    failIfPrefixIsNull(prefix);
+    assertNotNull(info, actual);
+    if (comparisonStrategy.stringStartsWith(actual.toString().toLowerCase(), prefix.toString().toLowerCase()))
+      throw failures.failure(info, shouldNotStartWithIgnoringCase(actual, prefix, comparisonStrategy));
   }
 
   private static void failIfPrefixIsNull(CharSequence prefix) {
@@ -899,6 +939,24 @@ public class Strings {
   }
 
   /**
+   * Verifies that the given {@code CharSequence} ends with the given suffix, ignoring case considerations.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param suffix the given suffix.
+   * @throws NullPointerException if the given sequence is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} does not end with the given suffix, ignoring case.
+   * @since 3.22.0
+   */
+  public void assertEndsWithIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence suffix) {
+    failIfSuffixIsNull(suffix);
+    assertNotNull(info, actual);
+    if (!comparisonStrategy.stringEndsWith(actual.toString().toLowerCase(), suffix.toString().toLowerCase()))
+      throw failures.failure(info, shouldEndWithIgnoringCase(actual, suffix, comparisonStrategy));
+  }
+
+  /**
    * Verifies that the given {@code CharSequence} does not end with the given suffix.
    *
    * @param info contains information about the assertion.
@@ -913,6 +971,24 @@ public class Strings {
     assertNotNull(info, actual);
     if (comparisonStrategy.stringEndsWith(actual.toString(), suffix.toString()))
       throw failures.failure(info, shouldNotEndWith(actual, suffix, comparisonStrategy));
+  }
+
+  /**
+   * Verifies that the given {@code CharSequence} does not end with the given suffix, ignoring case considerations.
+   *
+   * @param info contains information about the assertion.
+   * @param actual the actual {@code CharSequence}.
+   * @param suffix the given suffix.
+   * @throws NullPointerException if the given sequence is {@code null}.
+   * @throws AssertionError if the given {@code CharSequence} is {@code null}.
+   * @throws AssertionError if the actual {@code CharSequence} ends with the given suffix, ignoring case.
+   * @since 3.22.0
+   */
+  public void assertDoesNotEndWithIgnoringCase(AssertionInfo info, CharSequence actual, CharSequence suffix) {
+    failIfSuffixIsNull(suffix);
+    assertNotNull(info, actual);
+    if (comparisonStrategy.stringEndsWith(actual.toString().toLowerCase(), suffix.toString().toLowerCase()))
+      throw failures.failure(info, shouldNotEndWithIgnoringCase(actual, suffix, comparisonStrategy));
   }
 
   private static void failIfSuffixIsNull(CharSequence suffix) {

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotEndWithIgnoringCase_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotEndWithIgnoringCase(CharSequence)}</code>.
+ */
+class CharSequenceAssert_doesNotEndWithIgnoringCase_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotEndWithIgnoringCase("suffix");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotEndWithIgnoringCase(getInfo(assertions), getActual(assertions), "suffix");
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_doesNotStartWithIgnoringCase_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#doesNotStartWithIgnoringCase(CharSequence)}</code>.
+ */
+class CharSequenceAssert_doesNotStartWithIgnoringCase_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.doesNotStartWithIgnoringCase("prefix");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertDoesNotStartWithIgnoringCase(getInfo(assertions), getActual(assertions), "prefix");
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_endsWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_endsWithIgnoringCase_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#endsWithIgnoringCase(CharSequence)}</code>.
+ */
+class CharSequenceAssert_endsWithIgnoringCase_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.endsWithIgnoringCase("suffix");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertEndsWithIgnoringCase(getInfo(assertions), getActual(assertions), "suffix");
+  }
+}

--- a/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_startsWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/api/charsequence/CharSequenceAssert_startsWithIgnoringCase_Test.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.api.charsequence;
+
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.CharSequenceAssert;
+import org.assertj.core.api.CharSequenceAssertBaseTest;
+
+/**
+ * Tests for <code>{@link CharSequenceAssert#startsWithIgnoringCase(CharSequence)}</code>.
+ */
+class CharSequenceAssert_startsWithIgnoringCase_Test extends CharSequenceAssertBaseTest {
+
+  @Override
+  protected CharSequenceAssert invoke_api_method() {
+    return assertions.startsWithIgnoringCase("prefix");
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(strings).assertStartsWithIgnoringCase(getInfo(assertions), getActual(assertions), "prefix");
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldEndWithIgnoringCase_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldEndWithIgnoringCase_create_Test.java
@@ -14,56 +14,45 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
+import static org.assertj.core.error.ShouldEndWithIgnoringCase.shouldEndWithIgnoringCase;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
-import static org.assertj.core.util.Lists.list;
 
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
-import org.assertj.core.util.CaseInsensitiveStringComparator;
-import org.junit.jupiter.api.BeforeEach;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.util.OtherStringTestComparator;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShouldStartWith#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
-class ShouldStartWith_create_Test {
-
-  private ErrorMessageFactory factory;
-
-  @BeforeEach
-  public void setUp() {
-    factory = shouldStartWith(list("Yoda", "Luke"), list("Han", "Leia"));
-  }
+class ShouldEndWithIgnoringCase_create_Test {
 
   @Test
   void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldEndWithIgnoringCase("Gandalf the grey", "gandalf",
+                                                            StandardComparisonStrategy.instance());
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  [\"Yoda\", \"Luke\"]%n" +
-                                   "to start with:%n" +
-                                   "  [\"Han\", \"Leia\"]%n"));
+                                   "  \"Gandalf the grey\"%n" +
+                                   "to end with (ignoring case):%n" +
+                                   "  \"gandalf\"%n"));
   }
 
   @Test
   void should_create_error_message_with_custom_comparison_strategy() {
     // GIVEN
-    factory = shouldStartWith(list("Yoda", "Luke"), list("Han", "Leia"),
-                              new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+    ErrorMessageFactory factory = shouldEndWithIgnoringCase("Gandalf the grey", "gandalf",
+                                                            new ComparatorBasedComparisonStrategy(new OtherStringTestComparator()));
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
-    then(message).isEqualTo(format("[Test] %n" +
-                                   "Expecting actual:%n" +
-                                   "  [\"Yoda\", \"Luke\"]%n" +
-                                   "to start with:%n" +
-                                   "  [\"Han\", \"Leia\"]%n" +
-                                   "when comparing values using CaseInsensitiveStringComparator"));
+    then(message).isEqualTo(String.format("[Test] %n" +
+                                          "Expecting actual:%n" +
+                                          "  \"Gandalf the grey\"%n" +
+                                          "to end with (ignoring case):%n" +
+                                          "  \"gandalf\"%n"
+                                          + "when comparing values using other String comparator"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldEndWith_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldEndWith_create_Test.java
@@ -38,7 +38,11 @@ class ShouldEndWith_create_Test {
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
-    then(message).isEqualTo(format("[Test] %nExpecting actual:%n  [\"Yoda\", \"Luke\"]%nto end with:%n  [\"Han\", \"Leia\"]%n"));
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  [\"Yoda\", \"Luke\"]%n" +
+                                   "to end with:%n" +
+                                   "  [\"Han\", \"Leia\"]%n"));
   }
 
   @Test
@@ -49,7 +53,11 @@ class ShouldEndWith_create_Test {
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
-    then(message).isEqualTo(String.format("[Test] %nExpecting actual:%n  [\"Yoda\", \"Luke\"]%nto end with:%n  [\"Han\", \"Leia\"]%n"
+    then(message).isEqualTo(String.format("[Test] %n" +
+                                          "Expecting actual:%n" +
+                                          "  [\"Yoda\", \"Luke\"]%n" +
+                                          "to end with:%n" +
+                                          "  [\"Han\", \"Leia\"]%n"
                                           + "when comparing values using CaseInsensitiveStringComparator"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotEndWithIgnoringCase_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotEndWithIgnoringCase_create_Test.java
@@ -14,56 +14,44 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
-import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
-import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.error.ShouldNotEndWithIgnoringCase.shouldNotEndWithIgnoringCase;
 
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.util.CaseInsensitiveStringComparator;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShouldStartWith#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
-class ShouldStartWith_create_Test {
-
-  private ErrorMessageFactory factory;
-
-  @BeforeEach
-  public void setUp() {
-    factory = shouldStartWith(list("Yoda", "Luke"), list("Han", "Leia"));
-  }
+class ShouldNotEndWithIgnoringCase_create_Test {
 
   @Test
   void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotEndWithIgnoringCase("Gandalf the grey", "GREY", StandardComparisonStrategy.instance());
     // WHEN
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  [\"Yoda\", \"Luke\"]%n" +
-                                   "to start with:%n" +
-                                   "  [\"Han\", \"Leia\"]%n"));
+                                   "  \"Gandalf the grey\"%n" +
+                                   "not to end with (ignoring case):%n" +
+                                   "  \"GREY\"%n"));
   }
 
   @Test
   void should_create_error_message_with_custom_comparison_strategy() {
     // GIVEN
-    factory = shouldStartWith(list("Yoda", "Luke"), list("Han", "Leia"),
-                              new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+    ErrorMessageFactory factory = shouldNotEndWithIgnoringCase("Gandalf the grey", "GREY",
+                                                               new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
     // WHEN
-    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  [\"Yoda\", \"Luke\"]%n" +
-                                   "to start with:%n" +
-                                   "  [\"Han\", \"Leia\"]%n" +
+                                   "  \"Gandalf the grey\"%n" +
+                                   "not to end with (ignoring case):%n" +
+                                   "  \"GREY\"%n" +
                                    "when comparing values using CaseInsensitiveStringComparator"));
   }
 }

--- a/src/test/java/org/assertj/core/error/ShouldNotStartWithIgnoringCase_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldNotStartWithIgnoringCase_create_Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotStartWithIgnoringCase.shouldNotStartWithIgnoringCase;
+
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.util.OtherStringTestComparator;
+import org.junit.jupiter.api.Test;
+
+class ShouldNotStartWithIgnoringCase_create_Test {
+
+  @Test
+  void should_create_error_message() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotStartWithIgnoringCase("Gandalf the grey", "gandalf", StandardComparisonStrategy.instance());
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Gandalf the grey\"%n" +
+                                   "not to start with (ignoring case):%n" +
+                                   "  \"gandalf\"%n"));
+  }
+
+  @Test
+  void should_create_error_message_with_custom_comparison_strategy() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldNotStartWithIgnoringCase("Gandalf the grey", "gandalf",
+                                             new ComparatorBasedComparisonStrategy(new OtherStringTestComparator()));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), new StandardRepresentation());
+    // THEN
+    then(message).isEqualTo(format("[Test] %n" +
+                                   "Expecting actual:%n" +
+                                   "  \"Gandalf the grey\"%n" +
+                                   "not to start with (ignoring case):%n" +
+                                   "  \"gandalf\"%n" +
+                                   "when comparing values using other String comparator"));
+  }
+}

--- a/src/test/java/org/assertj/core/error/ShouldStartWithIgnoringCase_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldStartWithIgnoringCase_create_Test.java
@@ -14,56 +14,46 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldStartWith.shouldStartWith;
+import static org.assertj.core.error.ShouldStartWithIgnoringCase.shouldStartWithIgnoringCase;
 import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
-import static org.assertj.core.util.Lists.list;
 
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
-import org.assertj.core.util.CaseInsensitiveStringComparator;
-import org.junit.jupiter.api.BeforeEach;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.util.OtherStringTestComparator;
 import org.junit.jupiter.api.Test;
 
-/**
- * Tests for <code>{@link ShouldStartWith#create(org.assertj.core.description.Description, org.assertj.core.presentation.Representation)}</code>.
- *
- * @author Alex Ruiz
- * @author Joel Costigliola
- */
-class ShouldStartWith_create_Test {
+class ShouldStartWithIgnoringCase_create_Test {
 
   private ErrorMessageFactory factory;
 
-  @BeforeEach
-  public void setUp() {
-    factory = shouldStartWith(list("Yoda", "Luke"), list("Han", "Leia"));
-  }
-
   @Test
   void should_create_error_message() {
+    // GIVEN
+    factory = shouldStartWithIgnoringCase("Gandalf the grey", "grey", StandardComparisonStrategy.instance());
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  [\"Yoda\", \"Luke\"]%n" +
-                                   "to start with:%n" +
-                                   "  [\"Han\", \"Leia\"]%n"));
+                                   "  \"Gandalf the grey\"%n" +
+                                   "to start with (ignoring case):%n" +
+                                   "  \"grey\"%n"));
   }
 
   @Test
   void should_create_error_message_with_custom_comparison_strategy() {
     // GIVEN
-    factory = shouldStartWith(list("Yoda", "Luke"), list("Han", "Leia"),
-                              new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.instance));
+    factory = shouldStartWithIgnoringCase("Gandalf the grey", "grey",
+                                          new ComparatorBasedComparisonStrategy(new OtherStringTestComparator()));
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n" +
                                    "Expecting actual:%n" +
-                                   "  [\"Yoda\", \"Luke\"]%n" +
-                                   "to start with:%n" +
-                                   "  [\"Han\", \"Leia\"]%n" +
-                                   "when comparing values using CaseInsensitiveStringComparator"));
+                                   "  \"Gandalf the grey\"%n" +
+                                   "to start with (ignoring case):" +
+                                   "%n  \"grey\"%n" +
+                                   "when comparing values using other String comparator"));
   }
 }

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotEndWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotEndWithIgnoringCase_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotEndWithIgnoringCase.shouldNotEndWithIgnoringCase;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.assertj.core.util.StringHashCodeTestComparator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Strings#assertDoesNotEndWithIgnoringCase(AssertionInfo, CharSequence, CharSequence)}</code>.
+ */
+class Strings_assertDoesNotEndWithIgnoringCaseIgnoringCase_Test extends StringsBaseTest {
+
+  @Test
+  void should_pass_if_actual_does_not_end_with_suffix() {
+    strings.assertDoesNotEndWithIgnoringCase(someInfo(), "Yoda", "Luke");
+    strings.assertDoesNotEndWithIgnoringCase(someInfo(), "Yoda", "Yo");
+  }
+
+  @Test
+  void should_fail_if_actual_ends_with_suffix() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotEndWithIgnoringCase(someInfo(), "Yoda", "oda"));
+    // THEN
+    then(assertionError).hasMessage(shouldNotEndWithIgnoringCase("Yoda", "oda", StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_throw_error_if_suffix_is_null() {
+    assertThatNullPointerException().isThrownBy(() -> strings.assertDoesNotEndWithIgnoringCase(someInfo(), "Yoda", null))
+                                    .withMessage("The given suffix should not be null");
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    //WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotEndWithIgnoringCase(someInfo(), null, "Yoda"));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_pass_if_actual_does_not_end_with_suffix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    Strings stringsWithHashCodeComparisonStrategy = new Strings(new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator()));
+    // WHEN/THEN
+    stringsWithHashCodeComparisonStrategy.assertDoesNotEndWithIgnoringCase(someInfo(), "Yoda", "Luke");
+  }
+
+  @Test
+  void should_fail_if_actual_ends_with_suffix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    ComparisonStrategy hashCodeComparisonStrategy = new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> new Strings(hashCodeComparisonStrategy).assertDoesNotEndWithIgnoringCase(someInfo(), "Yoda", "A"));
+    // THEN
+    then(assertionError).hasMessage(shouldNotEndWithIgnoringCase("Yoda", "A", hashCodeComparisonStrategy).create());
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotStartWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertDoesNotStartWithIgnoringCase_Test.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotStartWithIgnoringCase.shouldNotStartWithIgnoringCase;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.assertj.core.util.StringHashCodeTestComparator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Strings#assertDoesNotStartWithIgnoringCase(AssertionInfo, CharSequence, CharSequence)}</code>.
+ */
+class Strings_assertDoesNotStartWithIgnoringCase_Test extends StringsBaseTest {
+
+  @Test
+  void should_pass_if_actual_does_not_start_with_prefix() {
+    strings.assertDoesNotStartWithIgnoringCase(someInfo(), "Yoda", "Luke");
+    strings.assertDoesNotStartWithIgnoringCase(someInfo(), "Yoda", "da");
+  }
+
+  @Test
+  void should_fail_if_actual_starts_with_prefix() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotStartWithIgnoringCase(someInfo(), "Yoda", "yo"));
+    //THEN
+    then(assertionError).hasMessage(shouldNotStartWithIgnoringCase("Yoda", "yo", StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_throw_error_if_prefix_is_null() {
+    assertThatNullPointerException().isThrownBy(() -> strings.assertDoesNotStartWithIgnoringCase(someInfo(), "Yoda", null))
+                                    .withMessage("The given prefix should not be null");
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertDoesNotStartWithIgnoringCase(someInfo(), null, "Yoda"));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_pass_if_actual_does_not_start_with_prefix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    Strings stringsWithHashCodeComparisonStrategy = new Strings(new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator()));
+    // WHEN/THEN
+    stringsWithHashCodeComparisonStrategy.assertDoesNotStartWithIgnoringCase(someInfo(), "Yoda", "Luke");
+  }
+
+  @Test
+  void should_fail_if_actual_starts_with_prefix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    ComparisonStrategy hashCodeComparisonStrategy = new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> new Strings(hashCodeComparisonStrategy).assertDoesNotStartWithIgnoringCase(someInfo(), "Yoda", "yODA"));
+    // THEN
+    then(assertionError).hasMessageContainingAll(shouldNotStartWithIgnoringCase("Yoda", "yODA", hashCodeComparisonStrategy).create());
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertEndsWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertEndsWithIgnoringCase_Test.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldEndWithIgnoringCase.shouldEndWithIgnoringCase;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.assertj.core.util.StringHashCodeTestComparator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Strings#assertEndsWithIgnoringCase(AssertionInfo, CharSequence, CharSequence)}</code>.
+ */
+class Strings_assertEndsWithIgnoringCase_Test extends StringsBaseTest {
+
+  @Test
+  void should_pass_if_actual_ends_with_suffix() {
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "YODA");
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "ODA");
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "oda");
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "Oda");
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "DA");
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "A");
+    strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "a");
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_end_with_suffix() {
+    // GIVEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", "Luke"));
+    // THEN
+    then(assertionError).hasMessage(shouldEndWithIgnoringCase("Yoda", "Luke", StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_throw_error_if_suffix_is_null() {
+    assertThatNullPointerException().isThrownBy(() -> strings.assertEndsWithIgnoringCase(someInfo(), "Yoda", null))
+                                       .withMessage("The given suffix should not be null");
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertEndsWithIgnoringCase(someInfo(), null, "Yoda"));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_pass_if_actual_ends_with_suffix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    Strings stringsWithHashCodeComparisonStrategy = new Strings(new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator()));
+    // WHEN/THEN
+    stringsWithHashCodeComparisonStrategy.assertEndsWithIgnoringCase(someInfo(), "Yoda", "ODA");
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_end_with_suffix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    ComparisonStrategy hashCodeComparisonStrategy = new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(()  -> new Strings(hashCodeComparisonStrategy).assertEndsWithIgnoringCase(someInfo(), "Yoda", "Luke"));
+    // THEN
+    then(assertionError).hasMessage(shouldEndWithIgnoringCase("Yoda", "Luke", hashCodeComparisonStrategy).create());
+  }
+}

--- a/src/test/java/org/assertj/core/internal/strings/Strings_assertStartsWithIgnoringCase_Test.java
+++ b/src/test/java/org/assertj/core/internal/strings/Strings_assertStartsWithIgnoringCase_Test.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.internal.strings;
+
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldStartWithIgnoringCase.shouldStartWithIgnoringCase;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.assertj.core.internal.Strings;
+import org.assertj.core.internal.StringsBaseTest;
+import org.assertj.core.util.StringHashCodeTestComparator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Strings#assertStartsWithIgnoringCase(AssertionInfo, CharSequence, CharSequence)}</code>.
+ */
+class Strings_assertStartsWithIgnoringCase_Test extends StringsBaseTest {
+
+  @Test
+  void should_pass_if_actual_starts_with_prefix() {
+    strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "YODA");
+    strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "YO");
+    strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "Yo");
+    strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "yo");
+    strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "Y");
+    strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "y");
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_start_with_prefix() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", "Luke"));
+    // THEN
+    then(assertionError).hasMessage(shouldStartWithIgnoringCase("Yoda", "Luke", StandardComparisonStrategy.instance()).create());
+  }
+
+  @Test
+  void should_throw_error_if_prefix_is_null() {
+    assertThatNullPointerException().isThrownBy(() -> strings.assertStartsWithIgnoringCase(someInfo(), "Yoda", null))
+                                    .withMessage("The given prefix should not be null");
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> strings.assertStartsWithIgnoringCase(someInfo(), null, "Yoda"));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_pass_if_actual_starts_with_prefix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    Strings stringsWithHashCodeComparisonStrategy = new Strings(new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator()));
+    // WHEN/THEN
+    stringsWithHashCodeComparisonStrategy.assertStartsWithIgnoringCase(someInfo(), "Yoda", "yod");
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_start_with_prefix_according_to_custom_comparison_strategy() {
+    // GIVEN
+    ComparisonStrategy hashCodeComparisonStrategy = new ComparatorBasedComparisonStrategy(new StringHashCodeTestComparator());
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> new Strings(hashCodeComparisonStrategy).assertStartsWithIgnoringCase(someInfo(), "Yoda", "Luke"));
+    // THEN
+    then(assertionError).hasMessage(shouldStartWithIgnoringCase("Yoda", "Luke", hashCodeComparisonStrategy).create());
+  }
+}

--- a/src/test/java/org/assertj/core/util/StringHashCodeTestComparator.java
+++ b/src/test/java/org/assertj/core/util/StringHashCodeTestComparator.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2021 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import java.util.Comparator;
+
+public final class StringHashCodeTestComparator implements Comparator<String> {
+  
+  @Override
+  public int compare(String s1, String s2) {
+    return s1.hashCode() - s2.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "StringHashCodeTestComparator";
+  }
+}
+


### PR DESCRIPTION
Add startsWithIgnoringCase, endsWithIgnoringCase, doesNotStartWithIgnoringCase, and doesNotEndWithIgnoringCase on AbstractCharSequenceAssert (#2449)

#### Check List:
* Fixes #2449 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)
