### PR TITLE
Fixes #2459: Avoid ValueNode being considered as iterable while using recursive comparison

### DIFF
--- a/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
@@ -170,8 +170,8 @@ public final class DualValue {
   }
 
   public boolean isActualFieldAnIterable() {
-    // ignore Path to be consistent with isExpectedFieldAnIterable
-    return actual instanceof Iterable && !(actual instanceof Path);
+    // ignore Path and ValueNode to be consistent with isExpectedFieldAnIterable
+    return actual instanceof Iterable && !(actual instanceof Path || isActualFieldAJsonValueNode());
   }
 
   public boolean isExpectedFieldAnIterable() {
@@ -179,7 +179,26 @@ public final class DualValue {
     // Iterable are compared element by element recursively
     // Ex: /tmp/foo.txt path has /tmp as its first element
     // so /tmp is going to be compared recursively but /tmp first element is itself leading to an infinite recursion
-    return expected instanceof Iterable && !(expected instanceof Path);
+    // Don't consider ValueNode as an Iterable as they only contain one value and iterating them does not make sense.
+    return expected instanceof Iterable && !(expected instanceof Path || isExpectedFieldAJsonValueNode());
+  }
+
+  private boolean isActualFieldAJsonValueNode() {
+    return isAJsonValueNode(actual);
+  }
+
+  private boolean isExpectedFieldAJsonValueNode() {
+    return isAJsonValueNode(expected);
+  }
+
+  private static boolean isAJsonValueNode(Object value) {
+    try {
+      Class<?> valueNodeClass = Class.forName("com.fasterxml.jackson.databind.node.ValueNode");
+      return valueNodeClass.isInstance(value);
+    } catch (ClassNotFoundException e) {
+      // value cannot be a ValueNode because the class couldn't be located
+      return false;
+    }
   }
 
   private static boolean isAnOrderedCollection(Object value) {

--- a/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
@@ -180,7 +180,7 @@ public final class DualValue {
     // Ex: /tmp/foo.txt path has /tmp as its first element
     // so /tmp is going to be compared recursively but /tmp first element is itself leading to an infinite recursion
     // Don't consider ValueNode as an Iterable as they only contain one value and iterating them does not make sense.
-    return expected instanceof Iterable && !(expected instanceof Path || isExpectedFieldAJsonValueNode());
+    return expected instanceof Iterable && !(expected instanceof Path || isAJsonValueNode(expected));
   }
 
   private boolean isActualFieldAJsonValueNode() {

--- a/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/DualValue.java
@@ -171,7 +171,7 @@ public final class DualValue {
 
   public boolean isActualFieldAnIterable() {
     // ignore Path and ValueNode to be consistent with isExpectedFieldAnIterable
-    return actual instanceof Iterable && !(actual instanceof Path || isActualFieldAJsonValueNode());
+    return actual instanceof Iterable && !(actual instanceof Path || isAJsonValueNode(actual)());
   }
 
   public boolean isExpectedFieldAnIterable() {

--- a/src/test/java/org/assertj/core/api/recursive/comparison/DualValue_iterableValues_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/DualValue_iterableValues_Test.java
@@ -26,6 +26,16 @@ import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.BinaryNode;
+import com.fasterxml.jackson.databind.node.BooleanNode;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.POJONode;
+import com.fasterxml.jackson.databind.node.TextNode;
+
 class DualValue_iterableValues_Test {
 
   private static final List<String> PATH = list("foo", "bar");
@@ -105,7 +115,8 @@ class DualValue_iterableValues_Test {
   }
 
   static Stream<Iterable<?>> iterables() {
-    return Stream.of(list("a", "b"), newTreeSet("a", "b"), newLinkedHashSet("a", "b"), newHashSet("a", "b"));
+    return Stream.of(list("a", "b"), newTreeSet("a", "b"), newLinkedHashSet("a", "b"), newHashSet("a", "b"), new ObjectNode(null),
+                     new ArrayNode(null));
   }
 
   @ParameterizedTest
@@ -131,8 +142,9 @@ class DualValue_iterableValues_Test {
   }
 
   static Stream<Object> nonIterables() {
-    // even though Path is an iterable, it must not be considered as such
-    return Stream.of(123, "abc", array("a", "b"), Paths.get("/tmp"));
+    // even though Path and ValueNode are iterables, they must not be considered as such
+    return Stream.of(123, "abc", array("a", "b"), Paths.get("/tmp"), new TextNode("foo"), new IntNode(42), BooleanNode.TRUE,
+                     new POJONode(new Object()), MissingNode.getInstance(), NullNode.getInstance(), new BinaryNode(new byte[0]));
   }
 
 }


### PR DESCRIPTION

#### Check List:
* Fixes #2459
* Unit tests : YES
* Javadoc with a code example (on API only) : YES / NO / NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)
