### PR TITLE
refactor: change visibility of constructor in final util class to private

### DIFF
--- a/src/main/java/org/assertj/core/api/Fail.java
+++ b/src/main/java/org/assertj/core/api/Fail.java
@@ -109,8 +109,7 @@ public final class Fail {
   }
 
   /**
-   * This constructor is protected to make it possible to subclass this class. Since all its methods are static, there is no point
-   * on creating a new instance of it.
+   * Since all its methods are static and the class is final, there is no point on creating a new instance of it.
    */
-  protected Fail() {}
+  private Fail() {}
 }


### PR DESCRIPTION
#### Check List:
* Fixes: no issue
* Unit tests : No
* Javadoc with a code example (on API only) : NA

The Fail class is final, but the constructor is protected. This seems like a little bad smell. Because `Fail` is pure static class, I changed the visibility to private.
