### PR TITLE
Breaking change: Extracting within SoftAssertions now throws an assertion error if actual is null

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -1110,8 +1110,9 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
                                                                        AssertFactory<T, ASSERT> assertFactory) {
     requireNonNull(extractor, shouldNotBeNull("extractor")::create);
     requireNonNull(assertFactory, shouldNotBeNull("assertFactory")::create);
+    T extractedValue = null;
     if (actual == null) throwAssertionError(shouldNotBeNull());
-    T extractedValue = extractor.apply(actual);
+    else extractedValue = extractor.apply(actual);
     return (ASSERT) assertFactory.createAssert(extractedValue).withAssertionState(myself);
   }
 

--- a/src/test/java/org/assertj/core/api/SoftAssertions_extracting_Test.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertions_extracting_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.test.Name.name;
+
+import org.assertj.core.test.Name;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SoftAssertions_extracting_Test extends BaseAssertionsTest {
+
+  private SoftAssertions softly;
+
+  @BeforeEach
+  void beforeEachTest() {
+    softly = new SoftAssertions();
+  }
+
+  @Test
+  void should_throw_assertion_error_when_extracting_from_null() {
+    // GIVEN
+    Name nameObject = name("John", "Doe");
+    Name nameNull = null;
+    // WHEN
+    softly.assertThat(nameObject).extracting(Name::getFirst).isEqualTo("John");
+    softly.assertThat(nameNull).extracting(Name::getFirst);
+    // THEN
+    assertThat(softly.errorsCollected()).hasSize(1);
+  }
+
+}


### PR DESCRIPTION
#### Check List:
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) : Should be, but feel free to notify me if not!

#2401 introduced `extracting` to throw an assertion error if `actual` is `null`, but it's not effective when using `SoftAssertions`. So I've fixed it.

Actually, I think I should see related #2411 and #2412. Will take a look if my approach is right.