### PR TITLE
Replaced `for` loop with enhanced `for` loop.

### DIFF
--- a/src/main/java/org/assertj/core/api/ClassBasedNavigableIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/ClassBasedNavigableIterableAssert.java
@@ -49,8 +49,7 @@ public class ClassBasedNavigableIterableAssert<SELF extends ClassBasedNavigableI
     try {
       Constructor<?>[] declaredConstructors = assertClass.getDeclaredConstructors();
       // find a matching Assert constructor for E or one of its subclass.
-      for (int i = 0; i < declaredConstructors.length; i++) {
-        Constructor<?> constructor = declaredConstructors[i];
+      for (Constructor<?> constructor : declaredConstructors) {
         if (constructor.getParameterTypes().length == 1 && constructor.getParameterTypes()[0].isAssignableFrom(clazz)) {
           @SuppressWarnings("unchecked")
           ELEMENT_ASSERT newAssert = (ELEMENT_ASSERT) constructor.newInstance(value);

--- a/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
+++ b/src/main/java/org/assertj/core/presentation/StandardRepresentation.java
@@ -323,8 +323,8 @@ public class StandardRepresentation implements Representation {
    */
   // not static so that it can be overridden
   protected boolean hasAlreadyAnUnambiguousToStringOf(Object obj) {
-    for (int i = 0; i < TYPE_WITH_UNAMBIGUOUS_REPRESENTATION.length; i++) {
-      if (TYPE_WITH_UNAMBIGUOUS_REPRESENTATION[i].isInstance(obj)) return true;
+    for (Class<?> aClass : TYPE_WITH_UNAMBIGUOUS_REPRESENTATION) {
+      if (aClass.isInstance(obj)) return true;
     }
     return false;
   }

--- a/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
+++ b/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
@@ -637,8 +637,7 @@ class ImmutableCollections {
       size = input.length; // implicit nullcheck of input
 
       elements = (E[]) new Object[EXPAND_FACTOR * input.length];
-      for (int i = 0; i < input.length; i++) {
-        E e = input[i];
+      for (E e : input) {
         int idx = probe(e); // implicit nullcheck of e
         if (idx >= 0) {
           throw new IllegalArgumentException("duplicate element: " + e);
@@ -1173,8 +1172,8 @@ final class CollSer implements Serializable {
   private void writeObject(ObjectOutputStream oos) throws IOException {
     oos.defaultWriteObject();
     oos.writeInt(array.length);
-    for (int i = 0; i < array.length; i++) {
-      oos.writeObject(array[i]);
+    for (Object o : array) {
+      oos.writeObject(o);
     }
   }
 

--- a/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
+++ b/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
@@ -637,7 +637,8 @@ class ImmutableCollections {
       size = input.length; // implicit nullcheck of input
 
       elements = (E[]) new Object[EXPAND_FACTOR * input.length];
-      for (E e : input) {
+      for (int i = 0; i < input.length; i++) {
+        E e = input[i];
         int idx = probe(e); // implicit nullcheck of e
         if (idx >= 0) {
           throw new IllegalArgumentException("duplicate element: " + e);
@@ -1172,8 +1173,8 @@ final class CollSer implements Serializable {
   private void writeObject(ObjectOutputStream oos) throws IOException {
     oos.defaultWriteObject();
     oos.writeInt(array.length);
-    for (Object o : array) {
-      oos.writeObject(o);
+    for (int i = 0; i < array.length; i++) {
+      oos.writeObject(array[i]);
     }
   }
 


### PR DESCRIPTION
In few cases the simple `for` loop can be replaced with a enhanced `for` loop to improve readability and make the code cleaner.