### PR TITLE
Fix MapEntry.hashCode() to conform to Map.Entry.hashCode() javadoc

### DIFF
--- a/src/main/java/org/assertj/core/data/MapEntry.java
+++ b/src/main/java/org/assertj/core/data/MapEntry.java
@@ -58,7 +58,7 @@ public final class MapEntry<K, V> implements Map.Entry<K, V> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(key, value);
+    return Objects.hashCode(key) ^ Objects.hashCode(value);
   }
 
   @Override

--- a/src/test/java/org/assertj/core/data/MapEntry_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_Test.java
@@ -16,6 +16,9 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.data.MapEntry.entry;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -62,6 +65,50 @@ class MapEntry_Test {
     String result = underTest.toString();
     // THEN
     then(result).isEqualTo("\"name\"=[\"Yoda\"]");
+  }
+
+  @Test
+  void hashCode_non_null_key_and_value() {
+    // GIVEN
+    MapEntry<String, String> underTest = entry("name", "Yoda");
+    Map.Entry<String, String> spec = new SimpleImmutableEntry<>("name", "Yoda");
+    // WHEN
+    int result = underTest.hashCode();
+    // THEN
+    then(result).isEqualTo(spec.hashCode());
+  }
+
+  @Test
+  void hashCode_null_key() {
+    // GIVEN
+    MapEntry<String, String> underTest = entry(null, "Yoda");
+    Map.Entry<String, String> spec = new SimpleImmutableEntry<>(null, "Yoda");
+    // WHEN
+    int result = underTest.hashCode();
+    // THEN
+    then(result).isEqualTo(spec.hashCode());
+  }
+
+  @Test
+  void hashCode_null_value() {
+    // GIVEN
+    MapEntry<String, String> underTest = entry("name", null);
+    Map.Entry<String, String> spec = new SimpleImmutableEntry<>("name", null);
+    // WHEN
+    int result = underTest.hashCode();
+    // THEN
+    then(result).isEqualTo(spec.hashCode());
+  }
+
+  @Test
+  void hashCode_null_key_and_value() {
+    // GIVEN
+    MapEntry<String, String> underTest = entry(null, null);
+    Map.Entry<String, String> spec = new SimpleImmutableEntry<>(null, null);
+    // WHEN
+    int result = underTest.hashCode();
+    // THEN
+    then(result).isEqualTo(spec.hashCode());
   }
 
 }

--- a/src/test/java/org/assertj/core/data/MapEntry_Test.java
+++ b/src/test/java/org/assertj/core/data/MapEntry_Test.java
@@ -16,16 +16,15 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.data.MapEntry.entry;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
-import java.util.Map;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
- * Tests for {@link MapEntry}.
- *
  * @author Alex Ruiz
  */
 class MapEntry_Test {
@@ -35,6 +34,23 @@ class MapEntry_Test {
     // WHEN/THEN
     EqualsVerifier.forClass(MapEntry.class)
                   .verify();
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "name, Yoda",
+    " , Yoda",
+    "name, ",
+    " , ",
+  })
+  void should_honor_Entry_hashCode_contract(String key, String value) {
+    // GIVEN
+    MapEntry<String, String> underTest = entry(key, value);
+    int expected = Objects.hashCode(key) ^ Objects.hashCode(value);
+    // WHEN
+    int result = underTest.hashCode();
+    // THEN
+    then(result).isEqualTo(expected);
   }
 
   @Test
@@ -65,50 +81,6 @@ class MapEntry_Test {
     String result = underTest.toString();
     // THEN
     then(result).isEqualTo("\"name\"=[\"Yoda\"]");
-  }
-
-  @Test
-  void hashCode_non_null_key_and_value() {
-    // GIVEN
-    MapEntry<String, String> underTest = entry("name", "Yoda");
-    Map.Entry<String, String> spec = new SimpleImmutableEntry<>("name", "Yoda");
-    // WHEN
-    int result = underTest.hashCode();
-    // THEN
-    then(result).isEqualTo(spec.hashCode());
-  }
-
-  @Test
-  void hashCode_null_key() {
-    // GIVEN
-    MapEntry<String, String> underTest = entry(null, "Yoda");
-    Map.Entry<String, String> spec = new SimpleImmutableEntry<>(null, "Yoda");
-    // WHEN
-    int result = underTest.hashCode();
-    // THEN
-    then(result).isEqualTo(spec.hashCode());
-  }
-
-  @Test
-  void hashCode_null_value() {
-    // GIVEN
-    MapEntry<String, String> underTest = entry("name", null);
-    Map.Entry<String, String> spec = new SimpleImmutableEntry<>("name", null);
-    // WHEN
-    int result = underTest.hashCode();
-    // THEN
-    then(result).isEqualTo(spec.hashCode());
-  }
-
-  @Test
-  void hashCode_null_key_and_value() {
-    // GIVEN
-    MapEntry<String, String> underTest = entry(null, null);
-    Map.Entry<String, String> spec = new SimpleImmutableEntry<>(null, null);
-    // WHEN
-    int result = underTest.hashCode();
-    // THEN
-    then(result).isEqualTo(spec.hashCode());
   }
 
 }


### PR DESCRIPTION
The javadoc for Map.Entry.hashCode() specifies how to compute the
hashcode value for a Map Entry. This fix conforms to that
specification.
