### PR TITLE
Fix pom url to match the actual url to the doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
   <artifactId>assertj-core</artifactId>
   <version>3.23.0-SNAPSHOT</version>
+  <url>${project.parent.url}#${project.artifactId}</url>
 
   <name>AssertJ fluent assertions</name>
   <description>Rich and fluent assertions for testing for Java</description>


### PR DESCRIPTION
This url is placed in the jar manifest as the Bundle-DocURL.

By default the project URL is `${project.parent.url}${project.artifactId}` but the actual website requires the `#`.
