### PR TITLE
Fix file names to prevent MacOS casing issues

### DIFF
--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isCloseToPercentage_double_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isCloseToPercentage_double_primitive_Test.java
@@ -10,32 +10,32 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.short_;
+package org.assertj.core.api.double_;
 
-import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.ShortAssert;
-import org.assertj.core.api.ShortAssertBaseTest;
-import org.assertj.core.data.Offset;
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.assertj.core.data.Percentage;
 
 /**
- * Tests for <code>{@link ShortAssert#isCloseTo(short, Offset)}</code>.
+ * Tests for <code>{@link DoubleAssert#isCloseTo(double, Percentage)}</code>.
  *
  * @author Sára Juhošová
  */
-class ShortAssert_isCloseTo_short_Test extends ShortAssertBaseTest {
+class DoubleAssert_isCloseToPercentage_double_primitive_Test extends DoubleAssertBaseTest {
 
-  private final Offset<Short> offset = offset((short) 1);
-  private final short value = 16;
+  private final Percentage percentage = withPercentage(6.0);
+  private final double value = 22.6;
 
   @Override
-  protected ShortAssert invoke_api_method() {
-    return assertions.isCloseTo(value, offset);
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isCloseTo(value, percentage);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(shorts).assertIsCloseTo(getInfo(assertions), getActual(assertions), value, offset);
+    verify(doubles).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
   }
 }

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotCloseToPercentage_double_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotCloseToPercentage_double_primitive_Test.java
@@ -10,32 +10,32 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.short_;
+package org.assertj.core.api.double_;
 
-import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.ShortAssert;
-import org.assertj.core.api.ShortAssertBaseTest;
-import org.assertj.core.data.Offset;
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
+import org.assertj.core.data.Percentage;
 
 /**
- * Tests for <code>{@link ShortAssert#isNotCloseTo(short, Offset)}</code>.
+ * Tests for <code>{@link DoubleAssert#isNotCloseTo(double, Percentage)}</code>.
  *
  * @author Sára Juhošová
  */
-class ShortAssert_isNotCloseTo_short_Test extends ShortAssertBaseTest {
+class DoubleAssert_isNotCloseToPercentage_double_primitive_Test extends DoubleAssertBaseTest {
 
-  private final Offset<Short> offset = offset((short) 1);
-  private final short value = 16;
+  private final Percentage percentage = withPercentage(5.4);
+  private final double value = 62.7;
 
   @Override
-  protected ShortAssert invoke_api_method() {
-    return assertions.isNotCloseTo(value, offset);
+  protected DoubleAssert invoke_api_method() {
+    return assertions.isNotCloseTo(value, percentage);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(shorts).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), value, offset);
+    verify(doubles).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
   }
 }

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotCloseTo_double_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotCloseTo_double_primitive_Test.java
@@ -24,7 +24,7 @@ import org.assertj.core.data.Offset;
  *
  * @author Sára Juhošová
  */
-class DoubleAssert_isNotCloseTo_double_Test extends DoubleAssertBaseTest {
+class DoubleAssert_isNotCloseTo_double_primitive_Test extends DoubleAssertBaseTest {
 
   private final Offset<Double> offset = offset(13.2);
   private final double value = 55.1;

--- a/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotEqualTo_double_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/double_/DoubleAssert_isNotEqualTo_double_primitive_Test.java
@@ -10,11 +10,12 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.float_;
+package org.assertj.core.api.double_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.AlwaysDifferentComparator.ALWAY_DIFFERENT;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.BDDMockito.given;
@@ -23,60 +24,71 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.Comparator;
 
-import org.assertj.core.api.FloatAssert;
-import org.assertj.core.api.FloatAssertBaseTest;
+import org.assertj.core.api.DoubleAssert;
+import org.assertj.core.api.DoubleAssertBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Tests for <code>{@link FloatAssert#isNotEqualTo(float)}</code>.
+ * Tests for <code>{@link DoubleAssert#isNotEqualTo(double)}</code>.
  *
  * @author Alex Ruiz
  */
-class FloatAssert_isNotEqualTo_float_Test extends FloatAssertBaseTest {
+class DoubleAssert_isNotEqualTo_double_primitive_Test extends DoubleAssertBaseTest {
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
-  protected FloatAssert invoke_api_method() {
+  protected DoubleAssert invoke_api_method() {
     // trick to simulate a custom comparator
-    given(floats.getComparator()).willReturn((Comparator) ALWAY_EQUAL_FLOAT);
-    return assertions.isNotEqualTo(8f);
+    given(doubles.getComparator()).willReturn((Comparator) ALWAY_EQUAL_DOUBLE);
+    return assertions.isNotEqualTo(8d);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(floats).getComparator();
-    verify(floats).assertNotEqual(getInfo(assertions), getActual(assertions), 8f);
-    verifyNoMoreInteractions(floats);
+    verify(doubles).getComparator();
+    verify(doubles).assertNotEqual(getInfo(assertions), getActual(assertions), 8d);
+    verifyNoMoreInteractions(doubles);
   }
 
   @ParameterizedTest
-  @CsvSource({ "1.0f, -1.0f", "NaN, NaN" })
-  void should_pass_using_primitive_comparison(float actual, float expected) {
+  @CsvSource({ "1.0, -1.0", "NaN, NaN" })
+  void should_pass_using_primitive_comparison(double actual, double expected) {
     assertThat(actual).isNotEqualTo(expected);
   }
 
   @Test
   void should_honor_user_specified_comparator() {
     // GIVEN
-    final float one = 1.0f;
+    final double one = 1.0d;
     // THEN
     assertThat(one).usingComparator(ALWAY_DIFFERENT)
                    .isNotEqualTo(one);
   }
 
   @Test
-  void should_fail_if_floats_are_equal() {
+  void should_fail_if_doubles_are_equal() {
     // GIVEN
-    float actual = 0.0f;
-    float expected = -0.0f;
+    double actual = 0.0;
+    double expected = -0.0;
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotEqualTo(expected));
     // THEN
     then(assertionError).hasMessage(format("%nExpecting actual:%n" +
-                                           "  0.0f%n" +
+                                           "  0.0%n" +
                                            "not to be equal to:%n" +
-                                           "  -0.0f%n"));
+                                           "  -0.0%n"));
+  }
+
+  @Test
+  void should_fail_when_actual_null_expected_primitive() {
+    // GIVEN
+    Double actual = null;
+    double expected = 1.0d;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotEqualTo(expected));
+    // THEN
+    then(assertionError).hasMessageContaining(shouldNotBeNull().create());
   }
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isCloseToPercentage_float_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isCloseToPercentage_float_primitive_Test.java
@@ -24,7 +24,7 @@ import org.assertj.core.data.Percentage;
  *
  * @author Sára Juhošová
  */
-class FloatAssert_isCloseToPercentage_float_Test extends FloatAssertBaseTest {
+class FloatAssert_isCloseToPercentage_float_primitive_Test extends FloatAssertBaseTest {
 
   private final Percentage percentage = withPercentage(2.4f);
   private final float value = 16.3f;

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotCloseToPercentage_float_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotCloseToPercentage_float_primitive_Test.java
@@ -10,32 +10,32 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.double_;
+package org.assertj.core.api.float_;
 
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.DoubleAssert;
-import org.assertj.core.api.DoubleAssertBaseTest;
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
 import org.assertj.core.data.Percentage;
 
 /**
- * Tests for <code>{@link DoubleAssert#isNotCloseTo(double, Percentage)}</code>.
+ * Tests for <code>{@link FloatAssert#isNotCloseTo(float, Percentage)}</code>.
  *
  * @author Sára Juhošová
  */
-class DoubleAssert_isNotCloseToPercentage_double_Test extends DoubleAssertBaseTest {
+class FloatAssert_isNotCloseToPercentage_float_primitive_Test extends FloatAssertBaseTest {
 
-  private final Percentage percentage = withPercentage(5.4);
-  private final double value = 62.7;
+  private final Percentage percentage = withPercentage(2.4f);
+  private final float value = 16.3f;
 
   @Override
-  protected DoubleAssert invoke_api_method() {
+  protected FloatAssert invoke_api_method() {
     return assertions.isNotCloseTo(value, percentage);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(doubles).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    verify(floats).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
   }
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotCloseTo_float_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotCloseTo_float_primitive_Test.java
@@ -10,32 +10,31 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.short_;
+package org.assertj.core.api.float_;
 
-import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.ShortAssert;
-import org.assertj.core.api.ShortAssertBaseTest;
-import org.assertj.core.data.Percentage;
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
+import org.assertj.core.data.Offset;
 
 /**
- * Tests for <code>{@link ShortAssert#isNotCloseTo(short, Percentage)}</code>.
+ * Tests for <code>{@link FloatAssert#isNotCloseTo(float, Offset)}</code>.
  *
- * @author Sára Juhošová
+ * @author Chris Arnott
  */
-class ShortAssert_isNotCloseToPercentage_short_Test extends ShortAssertBaseTest {
+class FloatAssert_isNotCloseTo_float_primitive_Test extends FloatAssertBaseTest {
 
-  private final Percentage percentage = withPercentage((short) 13);
-  private final short value = (short) 42;
+  private final Offset<Float> offset = offset(5f);
 
   @Override
-  protected ShortAssert invoke_api_method() {
-    return assertions.isNotCloseTo(value, percentage);
+  protected FloatAssert invoke_api_method() {
+    return assertions.isNotCloseTo(8f, offset);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(shorts).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    verify(floats).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), 8f, offset);
   }
 }

--- a/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotEqualTo_float_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/float_/FloatAssert_isNotEqualTo_float_primitive_Test.java
@@ -10,12 +10,11 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.double_;
+package org.assertj.core.api.float_;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldNotBeNull.shouldNotBeNull;
 import static org.assertj.core.test.AlwaysDifferentComparator.ALWAY_DIFFERENT;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.mockito.BDDMockito.given;
@@ -24,71 +23,60 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.Comparator;
 
-import org.assertj.core.api.DoubleAssert;
-import org.assertj.core.api.DoubleAssertBaseTest;
+import org.assertj.core.api.FloatAssert;
+import org.assertj.core.api.FloatAssertBaseTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 /**
- * Tests for <code>{@link DoubleAssert#isNotEqualTo(double)}</code>.
+ * Tests for <code>{@link FloatAssert#isNotEqualTo(float)}</code>.
  *
  * @author Alex Ruiz
  */
-class DoubleAssert_isNotEqualTo_double_Test extends DoubleAssertBaseTest {
+class FloatAssert_isNotEqualTo_float_primitive_Test extends FloatAssertBaseTest {
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   @Override
-  protected DoubleAssert invoke_api_method() {
+  protected FloatAssert invoke_api_method() {
     // trick to simulate a custom comparator
-    given(doubles.getComparator()).willReturn((Comparator) ALWAY_EQUAL_DOUBLE);
-    return assertions.isNotEqualTo(8d);
+    given(floats.getComparator()).willReturn((Comparator) ALWAY_EQUAL_FLOAT);
+    return assertions.isNotEqualTo(8f);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(doubles).getComparator();
-    verify(doubles).assertNotEqual(getInfo(assertions), getActual(assertions), 8d);
-    verifyNoMoreInteractions(doubles);
+    verify(floats).getComparator();
+    verify(floats).assertNotEqual(getInfo(assertions), getActual(assertions), 8f);
+    verifyNoMoreInteractions(floats);
   }
 
   @ParameterizedTest
-  @CsvSource({ "1.0, -1.0", "NaN, NaN" })
-  void should_pass_using_primitive_comparison(double actual, double expected) {
+  @CsvSource({ "1.0f, -1.0f", "NaN, NaN" })
+  void should_pass_using_primitive_comparison(float actual, float expected) {
     assertThat(actual).isNotEqualTo(expected);
   }
 
   @Test
   void should_honor_user_specified_comparator() {
     // GIVEN
-    final double one = 1.0d;
+    final float one = 1.0f;
     // THEN
     assertThat(one).usingComparator(ALWAY_DIFFERENT)
                    .isNotEqualTo(one);
   }
 
   @Test
-  void should_fail_if_doubles_are_equal() {
+  void should_fail_if_floats_are_equal() {
     // GIVEN
-    double actual = 0.0;
-    double expected = -0.0;
+    float actual = 0.0f;
+    float expected = -0.0f;
     // WHEN
     AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotEqualTo(expected));
     // THEN
     then(assertionError).hasMessage(format("%nExpecting actual:%n" +
-                                           "  0.0%n" +
+                                           "  0.0f%n" +
                                            "not to be equal to:%n" +
-                                           "  -0.0%n"));
-  }
-
-  @Test
-  void should_fail_when_actual_null_expected_primitive() {
-    // GIVEN
-    Double actual = null;
-    double expected = 1.0d;
-    // WHEN
-    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).isNotEqualTo(expected));
-    // THEN
-    then(assertionError).hasMessageContaining(shouldNotBeNull().create());
+                                           "  -0.0f%n"));
   }
 }

--- a/src/test/java/org/assertj/core/api/short_/ShortAssert_isCloseToPercentage_short_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/short_/ShortAssert_isCloseToPercentage_short_primitive_Test.java
@@ -10,32 +10,32 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.float_;
+package org.assertj.core.api.short_;
 
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.FloatAssert;
-import org.assertj.core.api.FloatAssertBaseTest;
+import org.assertj.core.api.ShortAssert;
+import org.assertj.core.api.ShortAssertBaseTest;
 import org.assertj.core.data.Percentage;
 
 /**
- * Tests for <code>{@link FloatAssert#isNotCloseTo(float, Percentage)}</code>.
+ * Tests for <code>{@link ShortAssert#isCloseTo(short, Percentage)}</code>.
  *
  * @author Sára Juhošová
  */
-class FloatAssert_isNotCloseToPercentage_float_Test extends FloatAssertBaseTest {
+class ShortAssert_isCloseToPercentage_short_primitive_Test extends ShortAssertBaseTest {
 
-  private final Percentage percentage = withPercentage(2.4f);
-  private final float value = 16.3f;
+  private final Percentage percentage = withPercentage((short) 13);
+  private final short value = (short) 42;
 
   @Override
-  protected FloatAssert invoke_api_method() {
-    return assertions.isNotCloseTo(value, percentage);
+  protected ShortAssert invoke_api_method() {
+    return assertions.isCloseTo(value, percentage);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(floats).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    verify(shorts).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
   }
 }

--- a/src/test/java/org/assertj/core/api/short_/ShortAssert_isCloseTo_short_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/short_/ShortAssert_isCloseTo_short_primitive_Test.java
@@ -10,31 +10,32 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.float_;
+package org.assertj.core.api.short_;
 
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.FloatAssert;
-import org.assertj.core.api.FloatAssertBaseTest;
+import org.assertj.core.api.ShortAssert;
+import org.assertj.core.api.ShortAssertBaseTest;
 import org.assertj.core.data.Offset;
 
 /**
- * Tests for <code>{@link FloatAssert#isNotCloseTo(float, Offset)}</code>.
+ * Tests for <code>{@link ShortAssert#isCloseTo(short, Offset)}</code>.
  *
- * @author Chris Arnott
+ * @author Sára Juhošová
  */
-class FloatAssert_isNotCloseTo_float_Test extends FloatAssertBaseTest {
+class ShortAssert_isCloseTo_short_primitive_Test extends ShortAssertBaseTest {
 
-  private final Offset<Float> offset = offset(5f);
+  private final Offset<Short> offset = offset((short) 1);
+  private final short value = 16;
 
   @Override
-  protected FloatAssert invoke_api_method() {
-    return assertions.isNotCloseTo(8f, offset);
+  protected ShortAssert invoke_api_method() {
+    return assertions.isCloseTo(value, offset);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(floats).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), 8f, offset);
+    verify(shorts).assertIsCloseTo(getInfo(assertions), getActual(assertions), value, offset);
   }
 }

--- a/src/test/java/org/assertj/core/api/short_/ShortAssert_isNotCloseToPercentage_short_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/short_/ShortAssert_isNotCloseToPercentage_short_primitive_Test.java
@@ -10,32 +10,32 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.api.double_;
+package org.assertj.core.api.short_;
 
 import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.Mockito.verify;
 
-import org.assertj.core.api.DoubleAssert;
-import org.assertj.core.api.DoubleAssertBaseTest;
+import org.assertj.core.api.ShortAssert;
+import org.assertj.core.api.ShortAssertBaseTest;
 import org.assertj.core.data.Percentage;
 
 /**
- * Tests for <code>{@link DoubleAssert#isCloseTo(double, Percentage)}</code>.
+ * Tests for <code>{@link ShortAssert#isNotCloseTo(short, Percentage)}</code>.
  *
  * @author Sára Juhošová
  */
-class DoubleAssert_isCloseToPercentage_double_Test extends DoubleAssertBaseTest {
+class ShortAssert_isNotCloseToPercentage_short_primitive_Test extends ShortAssertBaseTest {
 
-  private final Percentage percentage = withPercentage(6.0);
-  private final double value = 22.6;
+  private final Percentage percentage = withPercentage((short) 13);
+  private final short value = (short) 42;
 
   @Override
-  protected DoubleAssert invoke_api_method() {
-    return assertions.isCloseTo(value, percentage);
+  protected ShortAssert invoke_api_method() {
+    return assertions.isNotCloseTo(value, percentage);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(doubles).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    verify(shorts).assertIsNotCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
   }
 }

--- a/src/test/java/org/assertj/core/api/short_/ShortAssert_isNotCloseTo_short_primitive_Test.java
+++ b/src/test/java/org/assertj/core/api/short_/ShortAssert_isNotCloseTo_short_primitive_Test.java
@@ -12,30 +12,30 @@
  */
 package org.assertj.core.api.short_;
 
-import static org.assertj.core.data.Percentage.withPercentage;
+import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.verify;
 
 import org.assertj.core.api.ShortAssert;
 import org.assertj.core.api.ShortAssertBaseTest;
-import org.assertj.core.data.Percentage;
+import org.assertj.core.data.Offset;
 
 /**
- * Tests for <code>{@link ShortAssert#isCloseTo(short, Percentage)}</code>.
+ * Tests for <code>{@link ShortAssert#isNotCloseTo(short, Offset)}</code>.
  *
  * @author Sára Juhošová
  */
-class ShortAssert_isCloseToPercentage_short_Test extends ShortAssertBaseTest {
+class ShortAssert_isNotCloseTo_short_primitive_Test extends ShortAssertBaseTest {
 
-  private final Percentage percentage = withPercentage((short) 13);
-  private final short value = (short) 42;
+  private final Offset<Short> offset = offset((short) 1);
+  private final short value = 16;
 
   @Override
   protected ShortAssert invoke_api_method() {
-    return assertions.isCloseTo(value, percentage);
+    return assertions.isNotCloseTo(value, offset);
   }
 
   @Override
   protected void verify_internal_effects() {
-    verify(shorts).assertIsCloseToPercentage(getInfo(assertions), getActual(assertions), value, percentage);
+    verify(shorts).assertIsNotCloseTo(getInfo(assertions), getActual(assertions), value, offset);
   }
 }


### PR DESCRIPTION
Fixes the issue of MacOS not accepting files with the same name but different casing.

#### Check List:
* Fixes: NA
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md): NA

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
