### PR TITLE
add hasHour in LocalTime

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractLocalTimeAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLocalTimeAssert.java
@@ -19,6 +19,9 @@ import static org.assertj.core.error.ShouldBeBeforeOrEqualTo.shouldBeBeforeOrEqu
 import static org.assertj.core.error.ShouldBeEqualIgnoringNanos.shouldBeEqualIgnoringNanos;
 import static org.assertj.core.error.ShouldBeEqualIgnoringSeconds.shouldBeEqualIgnoringSeconds;
 import static org.assertj.core.error.ShouldHaveSameHourAs.shouldHaveSameHourAs;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
+
+
 import static org.assertj.core.util.Preconditions.checkArgument;
 
 import java.time.LocalTime;
@@ -579,6 +582,31 @@ public abstract class AbstractLocalTimeAssert<SELF extends AbstractLocalTimeAsse
   }
 
   /**
+   * Verifies that actual {@code LocalTime} is in the given hour.
+   * <p>
+   * Example:
+   * <pre><code class='java'> // Assertion succeeds:
+   * assertThat(LocalTime.of(23, 59, 59)).hasHour(23);
+   *
+   * // Assertion fails:
+   * assertThat(LocalTime.of(23, 59, 59)).hasHour(22);</code></pre>
+   *
+   * @param hour the given hour.
+   * @return this assertion object.
+   * @throws AssertionError if the actual {@code LocalTime} is {@code null}.
+   * @throws AssertionError if the actual {@code LocalTime} is not in the given hour.
+   *
+   * @since 3.23.0
+   */
+  public SELF hasHour(int hour) {
+    Objects.instance().assertNotNull(info, actual);
+    if (actual.getHour() != hour) {
+      throw Failures.instance().failure(info, shouldHaveDateField(actual,"hour", hour));
+    }
+    return myself;
+  }
+
+  /**
    * {@inheritDoc}
    */
   @Override
@@ -613,5 +641,7 @@ public abstract class AbstractLocalTimeAssert<SELF extends AbstractLocalTimeAsse
   private static boolean haveSameHourField(LocalTime actual, LocalTime other) {
     return actual.getHour() == other.getHour();
   }
+
+
 
 }

--- a/src/main/java/org/assertj/core/error/ShouldHaveDateField.java
+++ b/src/main/java/org/assertj/core/error/ShouldHaveDateField.java
@@ -13,6 +13,8 @@
 package org.assertj.core.error;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.Temporal;
 import java.util.Date;
 
 /**
@@ -38,11 +40,19 @@ public class ShouldHaveDateField extends BasicErrorMessageFactory {
     return new ShouldHaveDateField(actual, fieldDescription, fieldValue);
   }
 
+  public static ErrorMessageFactory shouldHaveDateField(Temporal actual, String fieldDescription, int fieldValue) {
+    return new ShouldHaveDateField(actual, fieldDescription, fieldValue);
+  }
+
   private ShouldHaveDateField(Date actual, String fieldDescription, int fieldValue) {
     super("%nExpecting actual:%n  %s%nto be on %s %s", actual, fieldDescription, fieldValue);
   }
 
   private ShouldHaveDateField(LocalDate actual, String fieldDescription, int fieldValue) {
+    super("%nExpecting actual:%n  %s%nto be on %s %s", actual, fieldDescription, fieldValue);
+  }
+
+  private ShouldHaveDateField(Temporal actual, String fieldDescription, int fieldValue) {
     super("%nExpecting actual:%n  %s%nto be on %s %s", actual, fieldDescription, fieldValue);
   }
 

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_hasHour_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_hasHour_Test.java
@@ -1,0 +1,45 @@
+package org.assertj.core.api.localtime;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldHaveDateField.shouldHaveDateField;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
+
+public class LocalTimeAssert_hasHour_Test {
+  @Test
+  void should_pass_if_actual_is_in_given_hour(){
+    //GIVEN
+    LocalTime actual = LocalTime.of(23,59,59);
+    //WHEN/THEN
+    then(actual).hasHour(23);
+
+  }
+
+  @Test
+  void should_fail_if_actual_is_not_in_given_hour(){
+    //GIVEN
+    LocalTime actual = LocalTime.of(23,59,59);
+    int expectedHour = 22;
+    //WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasHour(expectedHour));
+    //THEN
+    then(assertionError).hasMessage(shouldHaveDateField(actual, "hour", expectedHour).create());
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    LocalTime actual = null;
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).hasHour(LocalTime.now().getHour()));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+
+}

--- a/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_hasHour_Test.java
+++ b/src/test/java/org/assertj/core/api/localtime/LocalTimeAssert_hasHour_Test.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
 package org.assertj.core.api.localtime;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
#### Check List:
* Fixes part of  #2541 
* Unit tests : YES 
* Javadoc with a code example (on API only) : YES 
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. 
I found that both LocalTime and LocalDate implement Temporal, is it suitable to combine the ShouldHaveDateField method of the two into one method by set the first argument as type Temporal?
