### PR TITLE
Fix javadoc error of `hasMonthValue` in `LocalDate` assertions

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractLocalDateAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractLocalDateAssert.java
@@ -513,10 +513,10 @@ public abstract class AbstractLocalDateAssert<SELF extends AbstractLocalDateAsse
    * <p>
    * Example:
    * <pre><code class='java'> // Assertion succeeds:
-   * assertThat(LocalDate.of(2000, 12, 31)).hasMonth(12);
+   * assertThat(LocalDate.of(2000, 12, 31)).hasMonthValue(12);
    *
    * // Assertion fails:
-   * assertThat(LocalDate.of(2000, 12, 31)).hasMonth(11);</code></pre>
+   * assertThat(LocalDate.of(2000, 12, 31)).hasMonthValue(11);</code></pre>
    *
    * @param month the given month's value between 1 and 12 inclusive.
    * @return this assertion object.


### PR DESCRIPTION
#### Check List:
* See #2566 the last comment
* Unit tests :  NA
* Javadoc with a code example (on API only) : NA