### PR TITLE
Improved runtime of containsExactly

### DIFF
--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1130,28 +1130,29 @@ public class Iterables {
     // length check
     if (actualAsList.size() != values.length) {
       IterableDiff<Object> diff = diff(actualAsList, asList(values), comparisonStrategy);
-      throw failures.failure(info,
-        shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
-          comparisonStrategy));
+      throw buildShouldContainExactlyWithDiffAssertionError(diff, actual, values, info);
     }
 
     // actual and values have the same number elements but are they equivalent and in the same order?
-    int i = 0;
-    for (Object elementFromActual : actualAsList) {
+    for (int i = 0; i < actualAsList.size(); i++) {
       // if the objects are not equal, begin the error handling process
-      if (!areEqual(elementFromActual, values[i])) {
+      if (!areEqual(actualAsList.get(i), values[i])) {
         IterableDiff<Object> diff = diff(actualAsList, asList(values), comparisonStrategy);
         if (diff.differencesFound()) {
-          throw failures.failure(info,
-            shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
-              comparisonStrategy));
+          throw buildShouldContainExactlyWithDiffAssertionError(diff, actual, values, info);
         } else {
-          throw failures.failure(info, elementsDifferAtIndex(elementFromActual, values[i], i, comparisonStrategy));
+          throw failures.failure(info, elementsDifferAtIndex(actualAsList.get(i), values[i], i, comparisonStrategy));
         }
       }
-      i++;
     }
   }
+
+  private AssertionError buildShouldContainExactlyWithDiffAssertionError(IterableDiff<Object> diff, Iterable<?> actual,
+                                                                         Object[] values, AssertionInfo info) {
+    return failures.failure(info,
+      shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected, comparisonStrategy));
+  }
+
 
   public <E> void assertAllSatisfy(AssertionInfo info, Iterable<? extends E> actual, Consumer<? super E> requirements) {
     assertNotNull(info, actual);

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1124,7 +1124,7 @@ public class Iterables {
   public void assertContainsExactly(AssertionInfo info, Iterable<?> actual, Object[] values) {
     checkIsNotNull(values);
     assertNotNull(info, actual);
-
+    // use actualAsList instead of actual in case actual is a singly-passable iterable
     List<Object> actualAsList = newArrayList(actual);
 
     // length check
@@ -1137,7 +1137,6 @@ public class Iterables {
 
     // actual and values have the same number elements but are they equivalent and in the same order?
     int i = 0;
-    // use actualAsList instead of actual in case actual is a singly-passable iterable
     for (Object elementFromActual : actualAsList) {
       // if the objects are not equal, begin the error handling process
       if (!areEqual(elementFromActual, values[i])) {
@@ -1152,9 +1151,7 @@ public class Iterables {
       }
       i++;
     }
-    // If here, then done!
   }
-
 
   public <E> void assertAllSatisfy(AssertionInfo info, Iterable<? extends E> actual, Consumer<? super E> requirements) {
     assertNotNull(info, actual);

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1126,23 +1126,35 @@ public class Iterables {
     assertNotNull(info, actual);
 
     List<Object> actualAsList = newArrayList(actual);
-    IterableDiff<Object> diff = diff(actualAsList, asList(values), comparisonStrategy);
-    if (!diff.differencesFound()) {
-      // actual and values have the same elements but are they in the same order ?
-      int i = 0;
-      // use actualAsList instead of actual in case actual is a singly-passable iterable
-      for (Object elementFromActual : actualAsList) {
-        if (!areEqual(elementFromActual, values[i])) {
+
+    // length check
+    if (actualAsList.size() != values.length) {
+      IterableDiff<Object> diff = diff(actualAsList, asList(values), comparisonStrategy);
+      throw failures.failure(info,
+        shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
+          comparisonStrategy));
+    }
+
+    // actual and values have the same number elements but are they equivalent and in the same order?
+    int i = 0;
+    // use actualAsList instead of actual in case actual is a singly-passable iterable
+    for (Object elementFromActual : actualAsList) {
+      // if the objects are not equal, begin the error handling process
+      if (!areEqual(elementFromActual, values[i])) {
+        IterableDiff<Object> diff = diff(actualAsList, asList(values), comparisonStrategy);
+        if (diff.differencesFound()) {
+          throw failures.failure(info,
+            shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
+              comparisonStrategy));
+        } else {
           throw failures.failure(info, elementsDifferAtIndex(elementFromActual, values[i], i, comparisonStrategy));
         }
-        i++;
       }
-      return;
+      i++;
     }
-    throw failures.failure(info,
-                           shouldContainExactly(actual, asList(values), diff.missing, diff.unexpected,
-                                                comparisonStrategy));
+    // If here, then done!
   }
+
 
   public <E> void assertAllSatisfy(AssertionInfo info, Iterable<? extends E> actual, Consumer<? super E> requirements) {
     assertNotNull(info, actual);


### PR DESCRIPTION
Check List:
* Fixes [Improve the performance of containsExactly from quadratic to linear complexity #2548](https://github.com/assertj/assertj-core/issues/2548)
* Unit tests : NO
* Javadoc with a code example (on API only) : NO
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

With these edits, the the assertContainsExactly() function will run in O(n) time if the `actual` and `expected` iterable are equivalent. However, if they are not equivalent, the code will run in O(n^2) time.

Also, I was told to rebase my changes or something, so I tried doing some research to figure that out but wasn't sure if I did it right. Hope I did it correctly, but if not, I could use a tutorial or a walkthrough on that!