### PR TITLE
Only compare comparingOnlyFields if it is set (#2610)

### DIFF
--- a/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
+++ b/src/main/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration.java
@@ -674,7 +674,7 @@ public class RecursiveComparisonConfiguration {
                             .filter(fieldName -> !shouldIgnoreFieldBasedOnFieldLocation(dualValue.fieldLocation.field(fieldName)))
                             .map(fieldName -> dualValueForField(dualValue, fieldName))
                             // evaluate field value ignoring criteria
-                            .filter(fieldDualValue -> !shouldIgnoreFieldBasedOnFieldValue(fieldDualValue))
+                            .filter(fieldDualValue -> !shouldIgnore(fieldDualValue))
                             // back to field name
                             .map(DualValue::getFieldName)
                             .filter(fieldName -> !fieldName.isEmpty())

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test.java
@@ -117,6 +117,19 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
   }
 
   @Test
+  public void should_fail_when_actual_differs_from_expected_on_compared_fields_independent_of_object_order() {
+    Staff staff = new Staff();
+    StaffWithLessFields staffWithLessFields = new StaffWithLessFields();
+    staff.setDeleted(Boolean.TRUE);
+    staffWithLessFields.setDeleted(Boolean.FALSE);
+
+    recursiveComparisonConfiguration.compareOnlyFields("deleted");
+
+    compareRecursivelyFailsAsExpected(staffWithLessFields, staff);
+    compareRecursivelyFailsAsExpected(staff, staffWithLessFields);
+  }
+
+  @Test
   void can_be_combined_with_ignoringFields() {
     // GIVEN
     Person actual = new Person("John");
@@ -152,6 +165,13 @@ class RecursiveComparisonAssert_isEqualTo_comparingOnlyFields_Test extends Recur
     return list.toArray(new String[0]);
   }
 
+  static class StaffWithLessFields {
+    private Boolean deleted;
+
+    public void setDeleted(Boolean deleted) {
+      this.deleted = deleted;
+    }
+  }
   @SuppressWarnings("unused")
   static class Staff {
 

--- a/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_getActualNonIgnoreFields_Test.java
+++ b/src/test/java/org/assertj/core/api/recursive/comparison/RecursiveComparisonConfiguration_getActualNonIgnoreFields_Test.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.Set;
 
 import org.assertj.core.internal.objects.data.Person;
+import org.assertj.core.internal.objects.data.PersonDtoWithPersonNeighbour;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,6 +55,19 @@ class RecursiveComparisonConfiguration_getActualNonIgnoreFields_Test {
     Set<String> fields = recursiveComparisonConfiguration.getNonIgnoredActualFieldNames(dualValue);
     // THEN
     assertThat(fields).doesNotContain("number", "dateOfBirth", "name");
+  }
+
+  @Test
+  void should_only_return_fields_from_compareOnlyFields_list() {
+    // GIVEN
+    recursiveComparisonConfiguration.compareOnlyFields("people.name");
+    Person person1 = new Person("John");
+    PersonDtoWithPersonNeighbour person2 = new PersonDtoWithPersonNeighbour("John");
+    DualValue dualValue = new DualValue(list("people"), person2, person1);
+    // WHEN
+    Set<String> fields = recursiveComparisonConfiguration.getNonIgnoredActualFieldNames(dualValue);
+    // THEN
+    assertThat(fields).containsExactly("name");
   }
 
 }


### PR DESCRIPTION
It looks like the comparedFields list was ignored when putting together the list of "non-ignored-actual-field-names".
I added a test to ensure that the order of objects is irrelevant when comparing unequal objects by field name only.

#### Check List:
* Fixes #2610
* Unit tests : YES
* Javadoc with a code example (on API only) :NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
