### PR TITLE
Add `linesOf` variants for a `Path` content

### DIFF
--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -2844,12 +2844,12 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+   * Loads the text content of a file at a given path into a list of strings with the default charset, each string corresponding to a
    * line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */
@@ -2858,12 +2858,12 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a path into a list of strings, each string corresponding to a line.
+   * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
    * @param charset the character set to use.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */
@@ -2872,12 +2872,12 @@ public class Assertions implements InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line. The line endings are
    * either \n, \r or \r\n.
    *
    * @param path the path.
    * @param charsetName the name of the character set to use.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -2852,6 +2852,8 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
    */
   public static List<String> linesOf(Path path) {
     return Paths.linesOf(path, Charset.defaultCharset());
@@ -2866,6 +2868,8 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
    */
   public static List<String> linesOf(Path path, Charset charset) {
     return Paths.linesOf(path, charset);
@@ -2880,6 +2884,8 @@ public class Assertions implements InstanceOfAssertFactories {
    * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
    */
   public static List<String> linesOf(Path path, String charsetName) {
     return Paths.linesOf(path, charsetName);

--- a/src/main/java/org/assertj/core/api/Assertions.java
+++ b/src/main/java/org/assertj/core/api/Assertions.java
@@ -104,6 +104,7 @@ import org.assertj.core.presentation.UnicodeRepresentation;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
+import org.assertj.core.util.Paths;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
 import org.assertj.core.util.introspection.Introspection;
@@ -169,7 +170,7 @@ public class Assertions implements InstanceOfAssertFactories {
     return AssertionsForInterfaceTypes.assertThat(actual);
   }
 
-  
+
   /**
    * Create assertion for {@link Predicate}.
    * <p>
@@ -2840,6 +2841,48 @@ public class Assertions implements InstanceOfAssertFactories {
    */
   public static List<String> linesOf(File file, String charsetName) {
     return Files.linesOf(file, charsetName);
+  }
+
+  /**
+   * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+   * line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(Path path) {
+    return Paths.linesOf(path, Charset.defaultCharset());
+  }
+
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(Path path, Charset charset) {
+    return Paths.linesOf(path, charset);
+  }
+
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(Path path, String charsetName) {
+    return Paths.linesOf(path, charsetName);
   }
 
   // --------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -39,8 +39,8 @@ import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
-
 import java.util.regex.Matcher;
+
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.filter.FilterOperator;
 import org.assertj.core.api.filter.Filters;
@@ -1654,47 +1654,53 @@ public class AssertionsForClassTypes {
     return Files.linesOf(file, charsetName);
   }
 
-	/**
-	 * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
-	 * line.
-	 * The line endings are either \n, \r or \r\n.
-	 *
-	 * @param path the path.
-	 * @return the content of the file.
-	 * @throws NullPointerException if the given charset is {@code null}.
-	 * @throws UncheckedIOException if an I/O exception occurs.
-	 */
-	public static List<String> linesOf(Path path) {
-		return Paths.linesOf(path, Charset.defaultCharset());
-	}
+  /**
+   * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+   * line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
+   */
+  public static List<String> linesOf(Path path) {
+    return Paths.linesOf(path, Charset.defaultCharset());
+  }
 
-	/**
-	 * Loads the text content of a path into a list of strings, each string corresponding to a line.
-	 * The line endings are either \n, \r or \r\n.
-	 *
-	 * @param path the path.
-	 * @param charset the character set to use.
-	 * @return the content of the file.
-	 * @throws NullPointerException if the given charset is {@code null}.
-	 * @throws UncheckedIOException if an I/O exception occurs.
-	 */
-	public static List<String> linesOf(Path path, Charset charset) {
-		return Paths.linesOf(path, charset);
-	}
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
+   */
+  public static List<String> linesOf(Path path, Charset charset) {
+    return Paths.linesOf(path, charset);
+  }
 
-	/**
-	 * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
-	 * either \n, \r or \r\n.
-	 *
-	 * @param path the path.
-	 * @param charsetName the name of the character set to use.
-	 * @return the content of the file.
-	 * @throws NullPointerException if the given charset is {@code null}.
-	 * @throws UncheckedIOException if an I/O exception occurs.
-	 */
-	public static List<String> linesOf(Path path, String charsetName) {
-		return Paths.linesOf(path, charsetName);
-	}
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
+   */
+  public static List<String> linesOf(Path path, String charsetName) {
+    return Paths.linesOf(path, charsetName);
+  }
 
   // --------------------------------------------------------------------------------------------------
   // URL/Resource methods : not assertions but here to have a single entry point to all AssertJ features.

--- a/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
+++ b/src/main/java/org/assertj/core/api/AssertionsForClassTypes.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -60,6 +61,7 @@ import org.assertj.core.presentation.StandardRepresentation;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.assertj.core.util.CheckReturnValue;
 import org.assertj.core.util.Files;
+import org.assertj.core.util.Paths;
 import org.assertj.core.util.URLs;
 import org.assertj.core.util.introspection.FieldSupport;
 
@@ -1651,6 +1653,48 @@ public class AssertionsForClassTypes {
   public static List<String> linesOf(File file, String charsetName) {
     return Files.linesOf(file, charsetName);
   }
+
+	/**
+	 * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+	 * line.
+	 * The line endings are either \n, \r or \r\n.
+	 *
+	 * @param path the path.
+	 * @return the content of the file.
+	 * @throws NullPointerException if the given charset is {@code null}.
+	 * @throws UncheckedIOException if an I/O exception occurs.
+	 */
+	public static List<String> linesOf(Path path) {
+		return Paths.linesOf(path, Charset.defaultCharset());
+	}
+
+	/**
+	 * Loads the text content of a path into a list of strings, each string corresponding to a line.
+	 * The line endings are either \n, \r or \r\n.
+	 *
+	 * @param path the path.
+	 * @param charset the character set to use.
+	 * @return the content of the file.
+	 * @throws NullPointerException if the given charset is {@code null}.
+	 * @throws UncheckedIOException if an I/O exception occurs.
+	 */
+	public static List<String> linesOf(Path path, Charset charset) {
+		return Paths.linesOf(path, charset);
+	}
+
+	/**
+	 * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+	 * either \n, \r or \r\n.
+	 *
+	 * @param path the path.
+	 * @param charsetName the name of the character set to use.
+	 * @return the content of the file.
+	 * @throws NullPointerException if the given charset is {@code null}.
+	 * @throws UncheckedIOException if an I/O exception occurs.
+	 */
+	public static List<String> linesOf(Path path, String charsetName) {
+		return Paths.linesOf(path, charsetName);
+	}
 
   // --------------------------------------------------------------------------------------------------
   // URL/Resource methods : not assertions but here to have a single entry point to all AssertJ features.

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -3348,6 +3348,7 @@ public class BDDAssertions extends Assertions {
 	 * @throws NullPointerException if the given charset is {@code null}.
 	 * @throws UncheckedIOException if an I/O exception occurs.
 	 *
+	 * @since 3.23.0
 	 */
 	public static List<String> linesOf(Path path) {
 		return Assertions.linesOf(path, Charset.defaultCharset());
@@ -3363,6 +3364,7 @@ public class BDDAssertions extends Assertions {
 	 * @throws NullPointerException if the given charset is {@code null}.
 	 * @throws UncheckedIOException if an I/O exception occurs.
 	 *
+	 * @since 3.23.0
 	 */
 	public static List<String> linesOf(Path path, Charset charset) {
 		return Assertions.linesOf(path, charset);
@@ -3378,6 +3380,7 @@ public class BDDAssertions extends Assertions {
 	 * @throws NullPointerException if the given charset is {@code null}.
 	 * @throws UncheckedIOException if an I/O exception occurs.
 	 *
+	 * @since 3.23.0
 	 */
 	public static List<String> linesOf(Path path, String charsetName) {
 		return Assertions.linesOf(path, charsetName);

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -3338,6 +3338,51 @@ public class BDDAssertions extends Assertions {
     return Assertions.linesOf(file, charsetName);
   }
 
+	/**
+	 * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+	 * line.
+	 * The line endings are either \n, \r or \r\n.
+	 *
+	 * @param path the path.
+	 * @return the content of the file.
+	 * @throws NullPointerException if the given charset is {@code null}.
+	 * @throws UncheckedIOException if an I/O exception occurs.
+	 *
+	 */
+	public static List<String> linesOf(Path path) {
+		return Assertions.linesOf(path, Charset.defaultCharset());
+	}
+
+	/**
+	 * Loads the text content of a path into a list of strings, each string corresponding to a line.
+	 * The line endings are either \n, \r or \r\n.
+	 *
+	 * @param path the path.
+	 * @param charset the character set to use.
+	 * @return the content of the file.
+	 * @throws NullPointerException if the given charset is {@code null}.
+	 * @throws UncheckedIOException if an I/O exception occurs.
+	 *
+	 */
+	public static List<String> linesOf(Path path, Charset charset) {
+		return Assertions.linesOf(path, charset);
+	}
+
+	/**
+	 * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+	 * either \n, \r or \r\n.
+	 *
+	 * @param path the path.
+	 * @param charsetName the name of the character set to use.
+	 * @return the content of the file.
+	 * @throws NullPointerException if the given charset is {@code null}.
+	 * @throws UncheckedIOException if an I/O exception occurs.
+	 *
+	 */
+	public static List<String> linesOf(Path path, String charsetName) {
+		return Assertions.linesOf(path, charsetName);
+	}
+
   // --------------------------------------------------------------------------------------------------
   // URL/Resource methods : not assertions but here to have a single entry point to all AssertJ features.
   // --------------------------------------------------------------------------------------------------

--- a/src/main/java/org/assertj/core/api/BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/BDDAssertions.java
@@ -3339,12 +3339,12 @@ public class BDDAssertions extends Assertions {
   }
 
 	/**
-	 * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+	 * Loads the text content of a file at a given path into a list of strings with the default charset, each string corresponding to a
 	 * line.
 	 * The line endings are either \n, \r or \r\n.
 	 *
 	 * @param path the path.
-	 * @return the content of the file.
+	 * @return the content of the file at the given path.
 	 * @throws NullPointerException if the given charset is {@code null}.
 	 * @throws UncheckedIOException if an I/O exception occurs.
 	 *
@@ -3354,12 +3354,12 @@ public class BDDAssertions extends Assertions {
 	}
 
 	/**
-	 * Loads the text content of a path into a list of strings, each string corresponding to a line.
+	 * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line.
 	 * The line endings are either \n, \r or \r\n.
 	 *
 	 * @param path the path.
 	 * @param charset the character set to use.
-	 * @return the content of the file.
+	 * @return the content of the file at the given path.
 	 * @throws NullPointerException if the given charset is {@code null}.
 	 * @throws UncheckedIOException if an I/O exception occurs.
 	 *
@@ -3369,12 +3369,12 @@ public class BDDAssertions extends Assertions {
 	}
 
 	/**
-	 * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+	 * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line. The line endings are
 	 * either \n, \r or \r\n.
 	 *
 	 * @param path the path.
 	 * @param charsetName the name of the character set to use.
-	 * @return the content of the file.
+	 * @return the content of the file at the given path.
 	 * @throws NullPointerException if the given charset is {@code null}.
 	 * @throws UncheckedIOException if an I/O exception occurs.
 	 *

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -2068,6 +2068,48 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
+   * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+   * line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  default List<String> linesOf(final Path path) {
+    return Assertions.linesOf(path);
+  }
+
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
+   * @param path the file.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  default List<String> linesOf(final Path path, final String charsetName) {
+    return Assertions.linesOf(path, charsetName);
+  }
+
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line.
+   * The line endings are either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  default List<String> linesOf(final Path path, final Charset charset) {
+    return Assertions.linesOf(path, charset);
+  }
+
+  /**
    * Sets whether we remove elements related to AssertJ from assertion error stack trace.
    *
    * @param removeAssertJRelatedElementsFromStackTrace flag.

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -2068,12 +2068,12 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a path into a list of strings with the default charset, each string corresponding to a
+   * Loads the text content of a file at a given path into a list of strings with the default charset, each string corresponding to a
    * line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */
@@ -2082,12 +2082,12 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line. The line endings are
    * either \n, \r or \r\n.
    *
    * @param path the file.
    * @param charsetName the name of the character set to use.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */
@@ -2096,12 +2096,12 @@ public interface WithAssertions extends InstanceOfAssertFactories {
   }
 
   /**
-   * Loads the text content of a path into a list of strings, each string corresponding to a line.
+   * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line.
    * The line endings are either \n, \r or \r\n.
    *
    * @param path the path.
    * @param charset the character set to use.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -2076,6 +2076,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
    */
   default List<String> linesOf(final Path path) {
     return Assertions.linesOf(path);
@@ -2090,6 +2092,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
    */
   default List<String> linesOf(final Path path, final String charsetName) {
     return Assertions.linesOf(path, charsetName);
@@ -2104,6 +2108,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
+   *
+   * @since 3.23.0
    */
   default List<String> linesOf(final Path path, final Charset charset) {
     return Assertions.linesOf(path, charset);

--- a/src/main/java/org/assertj/core/util/Files.java
+++ b/src/main/java/org/assertj/core/util/Files.java
@@ -288,12 +288,7 @@ public class Files {
    * @throws UncheckedIOException if an I/O exception occurs.
    */
   public static List<String> linesOf(File file, Charset charset) {
-    requireNonNull(charset, "The charset should not be null");
-    try {
-      return java.nio.file.Files.readAllLines(file.toPath(), charset);
-    } catch (IOException e) {
-      throw new UncheckedIOException("Unable to read " + file.getAbsolutePath(), e);
-    }
+    return Paths.linesOf(file.toPath(), charset);
   }
 
   /**
@@ -307,8 +302,7 @@ public class Files {
    * @throws UncheckedIOException if an I/O exception occurs.
    */
   public static List<String> linesOf(File file, String charsetName) {
-    checkArgumentCharsetIsSupported(charsetName);
-    return linesOf(file, Charset.forName(charsetName));
+    return Paths.linesOf(file.toPath(), charsetName);
   }
 
   private static void checkArgumentCharsetIsSupported(String charsetName) {

--- a/src/main/java/org/assertj/core/util/Paths.java
+++ b/src/main/java/org/assertj/core/util/Paths.java
@@ -26,6 +26,8 @@ import java.util.List;
  * Utility methods related to {@link Path}s.
  *
  * @author Stefan Bratanov
+ *
+ * @since 3.23.0
  */
 public class Paths {
 

--- a/src/main/java/org/assertj/core/util/Paths.java
+++ b/src/main/java/org/assertj/core/util/Paths.java
@@ -32,12 +32,12 @@ public class Paths {
   private Paths() {}
 
   /**
-   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line. The line endings are
    * either \n, \r or \r\n.
    *
    * @param path the path.
    * @param charset the character set to use.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */
@@ -51,12 +51,12 @@ public class Paths {
   }
 
   /**
-   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * Loads the text content of a file at a given path into a list of strings, each string corresponding to a line. The line endings are
    * either \n, \r or \r\n.
    *
    * @param path the path.
    * @param charsetName the name of the character set to use.
-   * @return the content of the file.
+   * @return the content of the file at the given path.
    * @throws NullPointerException if the given charset is {@code null}.
    * @throws UncheckedIOException if an I/O exception occurs.
    */

--- a/src/main/java/org/assertj/core/util/Paths.java
+++ b/src/main/java/org/assertj/core/util/Paths.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
 package org.assertj.core.util;
 
 import static java.util.Objects.requireNonNull;

--- a/src/main/java/org/assertj/core/util/Paths.java
+++ b/src/main/java/org/assertj/core/util/Paths.java
@@ -1,0 +1,59 @@
+package org.assertj.core.util;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.util.Preconditions.checkArgument;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Utility methods related to {@link Path}s.
+ *
+ * @author Stefan Bratanov
+ */
+public class Paths {
+
+  private Paths() {}
+
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charset the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(Path path, Charset charset) {
+    requireNonNull(charset, "The charset should not be null");
+    try {
+      return Files.readAllLines(path, charset);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Unable to read " + path, e);
+    }
+  }
+
+  /**
+   * Loads the text content of a path into a list of strings, each string corresponding to a line. The line endings are
+   * either \n, \r or \r\n.
+   *
+   * @param path the path.
+   * @param charsetName the name of the character set to use.
+   * @return the content of the file.
+   * @throws NullPointerException if the given charset is {@code null}.
+   * @throws UncheckedIOException if an I/O exception occurs.
+   */
+  public static List<String> linesOf(Path path, String charsetName) {
+    checkArgumentCharsetIsSupported(charsetName);
+    return linesOf(path, Charset.forName(charsetName));
+  }
+
+  private static void checkArgumentCharsetIsSupported(String charsetName) {
+    checkArgument(Charset.isSupported(charsetName), "Charset:<'%s'> is not supported on this system", charsetName);
+  }
+}

--- a/src/test/java/org/assertj/core/api/Assertions_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/Assertions_linesOf_Test.java
@@ -18,6 +18,8 @@ import static org.assertj.core.util.Lists.newArrayList;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -31,6 +33,13 @@ class Assertions_linesOf_Test {
     File file = new File("src/test/resources/utf8.txt");
     assertThat(linesOf(file, "UTF-8")).isEqualTo(EXPECTED_CONTENT);
     assertThat(linesOf(file, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  void should_read_lines_of_path_with_UTF8_charset() {
+    Path path = Paths.get("src", "test", "resources", "utf8.txt");
+    assertThat(linesOf(path, "UTF-8")).isEqualTo(EXPECTED_CONTENT);
+    assertThat(linesOf(path, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/EntryPointAssertions_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/api/EntryPointAssertions_linesOf_Test.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.BDDAssertions.then;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -72,6 +74,51 @@ class EntryPointAssertions_linesOf_Test extends EntryPointAssertionsBaseTest {
   }
 
   private static Stream<Function<File, List<String>>> fileLinesOfWithDefaultCharsetFunctions() {
+    return Stream.of(Assertions::linesOf, BDDAssertions::linesOf, withAssertions::linesOf);
+  }
+
+  @ParameterizedTest
+  @MethodSource("pathLinesOfWithCharsetFunctions")
+  void should_read_path_lines_with_charset(BiFunction<Path, Charset, List<String>> linesOfWithCharsetFunction) {
+    // GIVEN
+    Path sampleFile = Paths.get("src", "test", "resources", "utf8.txt");
+    // WHEN
+    List<String> lines = linesOfWithCharsetFunction.apply(sampleFile, UTF_8);
+    // THEN
+    then(lines).containsExactly("A text file encoded in UTF-8, with diacritics:", "é à");
+  }
+
+  private static Stream<BiFunction<Path, Charset, List<String>>> pathLinesOfWithCharsetFunctions() {
+    return Stream.of(Assertions::linesOf, BDDAssertions::linesOf, withAssertions::linesOf);
+  }
+
+  @ParameterizedTest
+  @MethodSource("pathLinesOfWithCharsetAsStringFunctions")
+  void should_read_path_lines_with_charset_as_string(BiFunction<Path, String, List<String>> linesOfWithCharsetFunction) {
+    // GIVEN
+    Path sampleFile = Paths.get("src", "test", "resources", "utf8.txt");
+    // WHEN
+    List<String> lines = linesOfWithCharsetFunction.apply(sampleFile, "UTF8");
+    // THEN
+    then(lines).containsExactly("A text file encoded in UTF-8, with diacritics:", "é à");
+  }
+
+  private static Stream<BiFunction<Path, String, List<String>>> pathLinesOfWithCharsetAsStringFunctions() {
+    return Stream.of(Assertions::linesOf, BDDAssertions::linesOf, withAssertions::linesOf);
+  }
+
+  @ParameterizedTest
+  @MethodSource("pathLinesOfWithDefaultCharsetFunctions")
+  void should_read_path_lines_with_default_charset(Function<Path, List<String>> linesOfWithDefaultCharsetFunction) {
+    // GIVEN
+    Path sampleFile = Paths.get("src", "test", "resources", "ascii.txt");
+    // WHEN
+    List<String> lines = linesOfWithDefaultCharsetFunction.apply(sampleFile);
+    // THEN
+    then(lines).containsExactly("abc");
+  }
+
+  private static Stream<Function<Path, List<String>>> pathLinesOfWithDefaultCharsetFunctions() {
     return Stream.of(Assertions::linesOf, BDDAssertions::linesOf, withAssertions::linesOf);
   }
 

--- a/src/test/java/org/assertj/core/util/Paths_linesOf_Test.java
+++ b/src/test/java/org/assertj/core/util/Paths_linesOf_Test.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.util.Lists.newArrayList;
+import static org.assertj.core.util.Paths.linesOf;
+
+import java.io.UncheckedIOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Paths#linesOf(Path, Charset)} and {@link Paths#linesOf(Path, String)}.
+ * 
+ * @author Stefan Bratanov
+ * @author Mateusz Haligowski
+ */
+class Paths_linesOf_Test {
+
+  private static final Path RESOURCES_DIRECTORY = java.nio.file.Paths.get("src", "test", "resources");
+
+  private static final Path SAMPLE_UNIX_FILE = RESOURCES_DIRECTORY.resolve("utf8.txt");
+  private static final Path SAMPLE_WIN_FILE = RESOURCES_DIRECTORY.resolve("utf8_win.txt");
+  private static final Path SAMPLE_MAC_FILE = RESOURCES_DIRECTORY.resolve("utf8_mac.txt");
+
+  private static final List<String> EXPECTED_CONTENT = newArrayList("A text file encoded in UTF-8, with diacritics:", "é à");
+  public static final String UTF_8 = "UTF-8";
+
+  @Test
+  void should_throw_exception_when_charset_is_null() {
+    Charset charset = null;
+    assertThatNullPointerException().isThrownBy(() -> linesOf(SAMPLE_UNIX_FILE, charset));
+  }
+
+  @Test
+  void should_throw_exception_if_charset_name_does_not_exist() {
+    assertThatIllegalArgumentException().isThrownBy(() -> linesOf(java.nio.file.Paths.get("test"), "Klingon"));
+  }
+
+  @Test
+  void should_throw_exception_if_path_not_found() {
+    Path missingFile = java.nio.file.Paths.get("missing.txt");
+    assertThat(missingFile).doesNotExist();
+
+    assertThatExceptionOfType(UncheckedIOException.class).isThrownBy(() -> linesOf(missingFile,
+                                                                                   Charset.defaultCharset()));
+  }
+
+  @Test
+  void should_pass_if_unix_path_is_split_into_lines() {
+    assertThat(linesOf(SAMPLE_UNIX_FILE, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  void should_pass_if_unix_path_is_split_into_lines_using_charset() {
+    assertThat(linesOf(SAMPLE_UNIX_FILE, UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  void should_pass_if_windows_path_is_split_into_lines() {
+    assertThat(linesOf(SAMPLE_WIN_FILE, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  void should_pass_if_windows_path_is_split_into_lines_using_charset() {
+    assertThat(linesOf(SAMPLE_WIN_FILE, UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  void should_pass_if_mac_path_is_split_into_lines() {
+    assertThat(linesOf(SAMPLE_MAC_FILE, StandardCharsets.UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+
+  @Test
+  void should_pass_if_mac_path_is_split_into_lines_using_charset() {
+    assertThat(linesOf(SAMPLE_MAC_FILE, UTF_8)).isEqualTo(EXPECTED_CONTENT);
+  }
+}


### PR DESCRIPTION
#### Check List:
* Fixes #2617 
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

`BDDAssertions` uses `@since` in the javadoc, but wasn't sure which version to add