### PR TITLE
Expose `ComparisonStrategy::areEqual` in `AbstractAssert`

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractAssert.java
@@ -42,6 +42,7 @@ import org.assertj.core.error.BasicErrorMessageFactory;
 import org.assertj.core.error.ErrorMessageFactory;
 import org.assertj.core.error.MessageFormatter;
 import org.assertj.core.internal.ComparatorBasedComparisonStrategy;
+import org.assertj.core.internal.ComparisonStrategy;
 import org.assertj.core.internal.Conditions;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.internal.Objects;
@@ -1116,6 +1117,22 @@ public abstract class AbstractAssert<SELF extends AbstractAssert<SELF, ACTUAL>, 
     isNotNull();
     T extractedValue = extractor.apply(actual);
     return (ASSERT) assertFactory.createAssert(extractedValue).withAssertionState(myself);
+  }
+
+  /**
+   * Returns true if actual and other are equal according to the current comparison strategy.
+   *
+   * @param actual the object to compare to other
+   * @param other the object to compare to actual
+   * @return true if actual and other are equal according to the underlying comparison strategy.
+   * @since 3.23.0
+   *
+   * @deprecated {@link ComparisonStrategy} will become part of the public API in the next major release and this method
+   * will be removed.
+   */
+  @Deprecated
+  protected boolean areEqual(Object actual, Object other) {
+    return objects.getComparisonStrategy().areEqual(actual, other);
   }
 
 }

--- a/src/test/java/org/assertj/core/api/AbstractAssert_areEqual_Test.java
+++ b/src/test/java/org/assertj/core/api/AbstractAssert_areEqual_Test.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.Objects;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractAssert_areEqual_Test {
+
+  @Mock(answer = CALLS_REAL_METHODS)
+  private AbstractAssert<?, Object> underTest;
+
+  @Mock
+  private ComparisonStrategy comparisonStrategy;
+
+  @Test
+  @SuppressWarnings("deprecation")
+  void should_delegate_to_ComparableAssert() {
+    // GIVEN
+    underTest.objects = new Objects(comparisonStrategy);
+    // WHEN
+    underTest.areEqual(42, 43);
+    // THEN
+    verify(comparisonStrategy).areEqual(42, 43);
+  }
+
+  @Test
+  void should_be_protected() throws NoSuchMethodException {
+    // GIVEN
+    Method areEqual = underTest.getClass().getDeclaredMethod("areEqual", Object.class, Object.class);
+    // WHEN
+    boolean isProtected = Modifier.isProtected(areEqual.getModifiers());
+    // THEN
+    then(isProtected).isTrue();
+  }
+
+}


### PR DESCRIPTION
Prerequisite for fixing [assertj/assertj-guava#70](https://github.com/assertj/assertj-guava/issues/70#issuecomment-1057532277).

Related to #2631, supersedes #2632.