### PR TITLE
[ISSUE 2629] Improve readability of containsExactly

### DIFF
--- a/src/main/java/org/assertj/core/configuration/Configuration.java
+++ b/src/main/java/org/assertj/core/configuration/Configuration.java
@@ -39,6 +39,7 @@ public class Configuration {
   // default values
   public static final int MAX_LENGTH_FOR_SINGLE_LINE_DESCRIPTION = 80;
   public static final int MAX_ELEMENTS_FOR_PRINTING = 1000;
+  public static final int MAX_INDICES_FOR_PRINTING = 50;
   public static final boolean REMOVE_ASSERTJ_RELATED_ELEMENTS_FROM_STACK_TRACE = true;
   public static final boolean ALLOW_COMPARING_PRIVATE_FIELDS = true;
   public static final boolean ALLOW_EXTRACTING_PRIVATE_FIELDS = true;

--- a/src/main/java/org/assertj/core/error/ShouldContainExactly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainExactly.java
@@ -40,6 +40,9 @@ public class ShouldContainExactly extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldContainExactly(Object actual, Iterable<?> expected,
                                                          Iterable<?> notFound, Iterable<?> notExpected,
                                                          ComparisonStrategy comparisonStrategy) {
+    if (isNullOrEmpty(notExpected) && isNullOrEmpty(notFound)) {
+      return new ShouldContainExactly(actual, expected, comparisonStrategy);
+    }
     if (isNullOrEmpty(notExpected)) {
       return new ShouldContainExactly(actual, expected, notFound, comparisonStrategy);
     }
@@ -61,6 +64,15 @@ public class ShouldContainExactly extends BasicErrorMessageFactory {
   public static ErrorMessageFactory shouldContainExactly(Object actual, Iterable<?> expected,
                                                          Iterable<?> notFound, Iterable<?> notExpected) {
     return shouldContainExactly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
+  }
+
+  private ShouldContainExactly(Object actual, Object expected, ComparisonStrategy comparisonStrategy) {
+    super("%n" +
+          "Expecting actual:%n" +
+          "  %s%n" +
+          "to contain exactly (and in same order):%n" +
+          "  %s%n",
+          actual, expected, comparisonStrategy);
   }
 
   private ShouldContainExactly(Object actual, Object expected, Object notFound, Object notExpected,

--- a/src/main/java/org/assertj/core/error/ShouldContainExactly.java
+++ b/src/main/java/org/assertj/core/error/ShouldContainExactly.java
@@ -14,8 +14,12 @@ package org.assertj.core.error;
 
 import static org.assertj.core.util.IterableUtil.isNullOrEmpty;
 
+import org.assertj.core.configuration.Configuration;
 import org.assertj.core.internal.ComparisonStrategy;
+import org.assertj.core.internal.IndexedDiff;
 import org.assertj.core.internal.StandardComparisonStrategy;
+
+import java.util.List;
 
 /**
  * Creates an error message indicating that an assertion that verifies a group of elements contains exactly a given set
@@ -66,6 +70,36 @@ public class ShouldContainExactly extends BasicErrorMessageFactory {
     return shouldContainExactly(actual, expected, notFound, notExpected, StandardComparisonStrategy.instance());
   }
 
+  /**
+   * Creates a new {@link ShouldContainExactly}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param indexDifferences the {@link IndexedDiff} the actual and expected differ at.
+   * @param comparisonStrategy the {@link ComparisonStrategy} used to evaluate assertion.
+   * @return the created {@code ErrorMessageFactory}.
+   *
+   */
+  public static ErrorMessageFactory shouldContainExactlyWithIndexes(Object actual, Iterable<?> expected,
+                                                                    List<IndexedDiff> indexDifferences,
+                                                                    ComparisonStrategy comparisonStrategy) {
+    return new ShouldContainExactly(actual, expected, indexDifferences, comparisonStrategy);
+  }
+
+  /**
+   * Creates a new {@link ShouldContainExactly}.
+   *
+   * @param actual the actual value in the failed assertion.
+   * @param expected values expected to be contained in {@code actual}.
+   * @param indexDifferences the {@link IndexedDiff} the actual and expected differ at.
+   * @return the created {@code ErrorMessageFactory}.
+   *
+   */
+  public static ErrorMessageFactory shouldContainExactlyWithIndexes(Object actual, Iterable<?> expected,
+                                                                    List<IndexedDiff> indexDifferences) {
+    return new ShouldContainExactly(actual, expected, indexDifferences, StandardComparisonStrategy.instance());
+  }
+
   private ShouldContainExactly(Object actual, Object expected, ComparisonStrategy comparisonStrategy) {
     super("%n" +
           "Expecting actual:%n" +
@@ -110,6 +144,29 @@ public class ShouldContainExactly extends BasicErrorMessageFactory {
           "but some elements were not expected:%n" +
           "  %s%n%s",
           actual, expected, unexpected, comparisonStrategy);
+  }
+
+  private ShouldContainExactly(Object actual, Object expected, List<IndexedDiff> indexDiffs,
+                               ComparisonStrategy comparisonStrategy) {
+    super("%n"
+          + "Expecting actual:%n"
+          + "  %s%n"
+          + "to contain exactly (and in same order):%n"
+          + "  %s%n"
+          + formatIndexDifferences(indexDiffs), actual, expected, comparisonStrategy);
+  }
+
+  private static String formatIndexDifferences(List<IndexedDiff> indexedDiffs) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("but there were differences at these indexes");
+    if (indexedDiffs.size() >= Configuration.MAX_INDICES_FOR_PRINTING) {
+      sb.append(String.format(" (only showing the first %d mismatches)", Configuration.MAX_INDICES_FOR_PRINTING));
+    }
+    sb.append(":%n");
+    for (IndexedDiff diff : indexedDiffs) {
+      sb.append(String.format("  element at index %d: expected \"%s\" but was \"%s\"%n", diff.getIndex(), diff.getExpected(), diff.getActual()));
+    }
+    return sb.toString();
   }
 
   /**

--- a/src/main/java/org/assertj/core/internal/IndexedDiff.java
+++ b/src/main/java/org/assertj/core/internal/IndexedDiff.java
@@ -1,0 +1,46 @@
+package org.assertj.core.internal;
+
+/**
+ * The actual and expected elements at a given index.
+ * */
+public class IndexedDiff {
+  private final Object actual;
+  private final Object expected;
+  private final int index;
+
+  /**
+   * Create a {@link IndexedDiff}.
+   * @param actual the actual value of the diff.
+   * @param expected the expected value of the diff.
+   * @param index the index the diff occurred at.
+   */
+  public IndexedDiff(Object actual, Object expected, int index) {
+    this.actual = actual;
+    this.expected = expected;
+    this.index = index;
+  }
+
+  /**
+   * Get the actual value of the diff.
+   * @return {@link Object} containing the actual value of the diff.
+   */
+  public Object getActual() {
+    return actual;
+  }
+
+  /**
+   * Get the expected value of the diff.
+   * @return {@link Object} containing the expected value of the diff.
+   */
+  public Object getExpected() {
+    return expected;
+  }
+
+  /**
+   * Get the index the diff occurred at.
+   * @return {@code int} containing the index the diff occurred at.
+   */
+  public int getIndex() {
+    return index;
+  }
+}

--- a/src/main/java/org/assertj/core/internal/IndexedDiff.java
+++ b/src/main/java/org/assertj/core/internal/IndexedDiff.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
 package org.assertj.core.internal;
 
 /**

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1138,10 +1138,7 @@ public class Iterables {
       // if the objects are not equal, begin the error handling process
       if (!areEqual(actualAsList.get(i), values[i])) {
         IterableDiff<Object> diff = diff(actualAsList, asList(values), comparisonStrategy);
-        if (diff.differencesFound()) {
-          throw shouldContainExactlyWithDiffAssertionError(diff, actual, values, info);
-        }
-        throw failures.failure(info, elementsDifferAtIndex(actualAsList.get(i), values[i], i, comparisonStrategy));
+        throw shouldContainExactlyWithDiffAssertionError(diff, actual, values, info);
       }
     }
   }

--- a/src/test/java/org/assertj/core/error/ShouldContainExactly_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainExactly_create_Test.java
@@ -14,7 +14,9 @@ package org.assertj.core.error;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.error.ShouldContainExactly.*;
+import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
+import static org.assertj.core.error.ShouldContainExactly.shouldContainExactlyWithIndexes;
+import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.util.Lists.list;
 import static org.assertj.core.util.Sets.newLinkedHashSet;
 

--- a/src/test/java/org/assertj/core/error/ShouldContainExactly_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldContainExactly_create_Test.java
@@ -31,6 +31,44 @@ class ShouldContainExactly_create_Test {
   private static final ComparatorBasedComparisonStrategy CASE_INSENSITIVE_COMPARISON_STRATEGY = new ComparatorBasedComparisonStrategy(CaseInsensitiveStringComparator.INSTANCE);
 
   @Test
+  void should_display_full_expected_and_actual_sets_when_order_does_not_match() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainExactly(list("Yoda", "Han", "Luke", "Anakin"), list("Yoda", "Luke", "Han", "Anakin"),
+                                                       Collections.emptyList(), Collections.emptyList());
+
+    // WHEN
+    final String message = factory.create(new TextDescription("Test"));
+
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting actual:%n"
+                                   + "  [\"Yoda\", \"Han\", \"Luke\", \"Anakin\"]%n"
+                                   + "to contain exactly (and in same order):%n"
+                                   + "  [\"Yoda\", \"Luke\", \"Han\", \"Anakin\"]%n"));
+  }
+
+  @Test
+  void should_display_full_expected_and_actual_sets_with_missing_and_unexpected_elements() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldContainExactly(list("Yoda", "Han", "Luke", "Anakin"), list("Yoda", "Han", "Anakin", "Anakin"),
+                                                       list("Anakin"), list("Luke"));
+
+    // WHEN
+    final String message = factory.create(new TextDescription("Test"));
+
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting actual:%n"
+                                   + "  [\"Yoda\", \"Han\", \"Luke\", \"Anakin\"]%n"
+                                   + "to contain exactly (and in same order):%n"
+                                   + "  [\"Yoda\", \"Han\", \"Anakin\", \"Anakin\"]%n"
+                                   + "but some elements were not found:%n"
+                                   + "  [\"Anakin\"]%n"
+                                   + "and others were not expected:%n"
+                                   + "  [\"Luke\"]%n"));
+  }
+
+  @Test
   void should_display_missing_and_unexpected_elements() {
     // GIVEN
     ErrorMessageFactory factory = shouldContainExactly(list("Yoda", "Han"), list("Luke", "Yoda"),

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -13,7 +13,7 @@
 package org.assertj.core.internal.iterables;
 
 import static java.util.Collections.emptyList;
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -28,7 +28,7 @@ import static org.assertj.core.util.Arrays.array;
 import static org.assertj.core.util.Arrays.asList;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertContainsExactly_Test.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static org.assertj.core.error.ShouldContainExactly.elementsDifferAtIndex;
 import static org.assertj.core.error.ShouldContainExactly.shouldContainExactly;
 import static org.assertj.core.internal.ErrorMessages.valuesToLookForIsNull;
 import static org.assertj.core.internal.iterables.SinglyIterableFactory.createSinglyIterable;
@@ -106,7 +105,7 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
     Throwable error = catchThrowable(() -> iterables.assertContainsExactly(info, actual, expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1));
+    verify(failures).failure(info, shouldContainExactly(actual, newArrayList(expected), emptyList(), emptyList()));
   }
 
   @Test
@@ -155,7 +154,8 @@ class Iterables_assertContainsExactly_Test extends IterablesBaseTest {
                                                                                                                 expected));
 
     assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info, elementsDifferAtIndex("Yoda", "Leia", 1, comparisonStrategy));
+    verify(failures).failure(info, shouldContainExactly(actual, newArrayList(expected), emptyList(), emptyList(),
+                                                        comparisonStrategy));
   }
 
   @Test


### PR DESCRIPTION
Removes `elementsDifferAtIndex()` from `assertContainsExactly()` and re-use
`shouldContainExactlyWithDiffAssertionError()` in order to show the actual
and expected sets entirely. Making the `differencesFound()` check unnecessary.

It also introduces a new s`houldContainExactly()` and checks for both
the missing and unexpected diffs to be empty. Otherwise cases where the
actual and expected only differ in order, result into logging of missing
elements - which there are none.

#### Check List:
* Fixes #2629 
* Unit tests : YES
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
