### PR TITLE
Runtime require opentest4j in JPMS

### DIFF
--- a/src/main/java9/module-info.java
+++ b/src/main/java9/module-info.java
@@ -43,7 +43,7 @@ module org.assertj.core {
   requires static net.bytebuddy;
   requires static org.hamcrest;
   requires static org.junit.jupiter.api;
-  requires static org.opentest4j; // to throw AssertionFailedError which is IDE friendly
+  requires org.opentest4j; // to throw AssertionFailedError which is IDE friendly
 
   // Services loaded by org.assertj.core.configuration.ConfigurationProvider
   uses org.assertj.core.configuration.Configuration;


### PR DESCRIPTION
Change Opentest4J dependency to be non-static in module-info.java.

Since we rely on OpenTest4J for any assertion error, we should
include it as a runtime dependency to prevent the user needing
to also explicitly include that dependency.

This also ensures `requires transitive` propagates this dependency
automatically.

#### Check List
* Unit tests : N/A.
* Javadoc with a code example (on API only) : N/A.
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) - simple change - should be covered.