### PR TITLE
Swap out deprecated-for-removal methods in BDDAssertions_then_Test.java

### DIFF
--- a/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
+++ b/src/test/java/org/assertj/core/api/BDDAssertions_then_Test.java
@@ -72,7 +72,7 @@ class BDDAssertions_then_Test {
 
   @Test
   void then_Character() {
-    then(new Character('A')).isEqualTo(new Character('A'));
+    then(Character.valueOf('A')).isEqualTo(Character.valueOf('A'));
   }
 
   @Test


### PR DESCRIPTION
The Character::new constructor has been deprecated for removal since Java 9.
All usages are directed to use Character#valueOf instead, which holds the same API
signature. This will prevent future compilation issues on newer JDKs when the
method is totally removed from OpenJDK.

