### PR TITLE
Work around/suppress around 95 warnings produced on JDK-17 with -Xlint:all

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractMapAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractMapAssert.java
@@ -685,6 +685,7 @@ public abstract class AbstractMapAssert<SELF extends AbstractMapAssert<SELF, ACT
     return containsOnly(toEntries(map));
   }
 
+  @SuppressWarnings("unchecked")
   private Map.Entry<? extends K, ? extends V>[] toEntries(Map<? extends K, ? extends V> map) {
     return map.entrySet().toArray(new Map.Entry[0]);
   }

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -90,7 +90,8 @@ import org.assertj.core.util.introspection.IntrospectionError;
  * @author Lovro Pandzic
  */
 // suppression of deprecation works in Eclipse to hide warning for the deprecated classes in the imports
-@SuppressWarnings("deprecation")
+// IntelliJ thinks this is redundant when it is not.
+@SuppressWarnings({"deprecation", "RedundantSuppression"})
 public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArrayAssert<SELF, ELEMENT>, ELEMENT> extends
     AbstractAssert<SELF, ELEMENT[]>
     implements IndexedObjectEnumerableAssert<AbstractObjectArrayAssert<SELF, ELEMENT>, ELEMENT>,

--- a/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractOptionalAssert.java
@@ -44,7 +44,8 @@ import org.assertj.core.util.CheckReturnValue;
  * @author Nicolai Parlog
  * @author Grzegorz Piwowarek
  */
-@SuppressWarnings("deprecation")
+// Deprecation is raised by JDK-17. IntelliJ thinks this is redundant when it is not.
+@SuppressWarnings({"deprecation", "RedundantSuppression"})
 public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert<SELF, VALUE>, VALUE> extends
     AbstractAssert<SELF, Optional<VALUE>> {
 
@@ -278,6 +279,7 @@ public abstract class AbstractOptionalAssert<SELF extends AbstractOptionalAssert
    */
   @Deprecated
   @CheckReturnValue
+  @SuppressWarnings({"DeprecatedIsStillUsed", "deprecation"})
   public SELF usingFieldByFieldValueComparator() {
     return usingValueComparator(new FieldByFieldComparator());
   }

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -70,20 +70,21 @@ import org.assertj.core.util.VisibleForTesting;
 import org.assertj.core.util.introspection.IntrospectionError;
 
 // suppression of deprecation works in Eclipse to hide warning for the deprecated classes in the imports
-@SuppressWarnings("deprecation")
+// Deprecation is raised by JDK-17. IntelliJ thinks this is redundant when it is not.
+@SuppressWarnings({"deprecation", "RedundantSuppression"})
 public class AtomicReferenceArrayAssert<T>
     extends AbstractAssert<AtomicReferenceArrayAssert<T>, AtomicReferenceArray<T>>
     implements IndexedObjectEnumerableAssert<AtomicReferenceArrayAssert<T>, T>,
     ArraySortedAssert<AtomicReferenceArrayAssert<T>, T> {
 
-  private T[] array;
+  private final T[] array;
   @VisibleForTesting
   ObjectArrays arrays = ObjectArrays.instance();
   @VisibleForTesting
   Iterables iterables = Iterables.instance();
 
   private TypeComparators comparatorsByType;
-  private Map<String, Comparator<?>> comparatorsForElementPropertyOrFieldNames = new TreeMap<>();
+  private final Map<String, Comparator<?>> comparatorsForElementPropertyOrFieldNames = new TreeMap<>();
   private TypeComparators comparatorsForElementPropertyOrFieldTypes;
 
   public AtomicReferenceArrayAssert(AtomicReferenceArray<T> actual) {

--- a/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
+++ b/src/main/java/org/assertj/core/api/InstanceOfAssertFactories.java
@@ -89,7 +89,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #PREDICATE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <T> InstanceOfAssertFactory<Predicate, PredicateAssert<T>> predicate(Class<T> type) {
     return new InstanceOfAssertFactory<>(Predicate.class, Assertions::<T> assertThat);
   }
@@ -129,7 +131,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #COMPLETABLE_FUTURE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <RESULT> InstanceOfAssertFactory<CompletableFuture, CompletableFutureAssert<RESULT>> completableFuture(Class<RESULT> resultType) {
     return new InstanceOfAssertFactory<>(CompletableFuture.class, Assertions::<RESULT> assertThat);
   }
@@ -151,7 +155,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #COMPLETION_STAGE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <RESULT> InstanceOfAssertFactory<CompletionStage, CompletableFutureAssert<RESULT>> completionStage(Class<RESULT> resultType) {
     return new InstanceOfAssertFactory<>(CompletionStage.class, Assertions::<RESULT> assertThat);
   }
@@ -173,7 +179,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #OPTIONAL
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <VALUE> InstanceOfAssertFactory<Optional, OptionalAssert<VALUE>> optional(Class<VALUE> resultType) {
     return new InstanceOfAssertFactory<>(Optional.class, Assertions::<VALUE> assertThat);
   }
@@ -338,7 +346,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #FUTURE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <RESULT> InstanceOfAssertFactory<Future, FutureAssert<RESULT>> future(Class<RESULT> resultType) {
     return new InstanceOfAssertFactory<>(Future.class, Assertions::<RESULT> assertThat);
   }
@@ -574,7 +584,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_INTEGER_FIELD_UPDATER
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <OBJECT> InstanceOfAssertFactory<AtomicIntegerFieldUpdater, AtomicIntegerFieldUpdaterAssert<OBJECT>> atomicIntegerFieldUpdater(Class<OBJECT> objectType) {
     return new InstanceOfAssertFactory<>(AtomicIntegerFieldUpdater.class, Assertions::<OBJECT> assertThat);
   }
@@ -614,7 +626,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_LONG_FIELD_UPDATER
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <OBJECT> InstanceOfAssertFactory<AtomicLongFieldUpdater, AtomicLongFieldUpdaterAssert<OBJECT>> atomicLongFieldUpdater(Class<OBJECT> objectType) {
     return new InstanceOfAssertFactory<>(AtomicLongFieldUpdater.class, Assertions::<OBJECT> assertThat);
   }
@@ -636,7 +650,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_REFERENCE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <VALUE> InstanceOfAssertFactory<AtomicReference, AtomicReferenceAssert<VALUE>> atomicReference(Class<VALUE> valueType) {
     return new InstanceOfAssertFactory<>(AtomicReference.class, Assertions::<VALUE> assertThat);
   }
@@ -658,7 +674,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_REFERENCE_ARRAY
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <ELEMENT> InstanceOfAssertFactory<AtomicReferenceArray, AtomicReferenceArrayAssert<ELEMENT>> atomicReferenceArray(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(AtomicReferenceArray.class, Assertions::<ELEMENT> assertThat);
   }
@@ -683,7 +701,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_REFERENCE_FIELD_UPDATER
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <FIELD, OBJECT> InstanceOfAssertFactory<AtomicReferenceFieldUpdater, AtomicReferenceFieldUpdaterAssert<FIELD, OBJECT>> atomicReferenceFieldUpdater(Class<FIELD> fieldType,
                                                                                                                                                             Class<OBJECT> objectType) {
     return new InstanceOfAssertFactory<>(AtomicReferenceFieldUpdater.class, Assertions::<FIELD, OBJECT> assertThat);
@@ -706,7 +726,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_MARKABLE_REFERENCE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <VALUE> InstanceOfAssertFactory<AtomicMarkableReference, AtomicMarkableReferenceAssert<VALUE>> atomicMarkableReference(Class<VALUE> valueType) {
     return new InstanceOfAssertFactory<>(AtomicMarkableReference.class, Assertions::<VALUE> assertThat);
   }
@@ -728,7 +750,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ATOMIC_STAMPED_REFERENCE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <VALUE> InstanceOfAssertFactory<AtomicStampedReference, AtomicStampedReferenceAssert<VALUE>> atomicStampedReference(Class<VALUE> valueType) {
     return new InstanceOfAssertFactory<>(AtomicStampedReference.class, Assertions::<VALUE> assertThat);
   }
@@ -794,7 +818,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ITERABLE
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <ELEMENT> InstanceOfAssertFactory<Iterable, IterableAssert<ELEMENT>> iterable(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(Iterable.class, Assertions::<ELEMENT> assertThat);
   }
@@ -816,7 +842,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #ITERATOR
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <ELEMENT> InstanceOfAssertFactory<Iterator, IteratorAssert<ELEMENT>> iterator(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(Iterator.class, Assertions::<ELEMENT> assertThat);
   }
@@ -840,7 +868,9 @@ public interface InstanceOfAssertFactories {
    * @see #COLLECTION
    * @since 3.21.0
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <E> InstanceOfAssertFactory<Collection, AbstractCollectionAssert<?, Collection<? extends E>, E, ObjectAssert<E>>> collection(Class<E> elementType) {
     return new InstanceOfAssertFactory<>(Collection.class, Assertions::<E> assertThat);
   }
@@ -862,7 +892,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #LIST
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <ELEMENT> InstanceOfAssertFactory<List, ListAssert<ELEMENT>> list(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(List.class, Assertions::<ELEMENT> assertThat);
   }
@@ -884,7 +916,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #STREAM
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <ELEMENT> InstanceOfAssertFactory<Stream, ListAssert<ELEMENT>> stream(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(Stream.class, Assertions::<ELEMENT> assertThat);
   }
@@ -930,7 +964,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #SPLITERATOR
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <ELEMENT> InstanceOfAssertFactory<Spliterator, SpliteratorAssert<ELEMENT>> spliterator(Class<ELEMENT> elementType) {
     return new InstanceOfAssertFactory<>(Spliterator.class, Assertions::<ELEMENT> assertThat);
   }
@@ -954,7 +990,9 @@ public interface InstanceOfAssertFactories {
    *
    * @see #MAP
    */
-  @SuppressWarnings({ "rawtypes", "unused" }) // rawtypes: using Class instance, unused: parameter needed for type inference
+  @SuppressWarnings({"rawtypes", "unused", "unchecked", "RedundantSuppression"})
+  // rawtypes+unchecked: using Class instance, unused: parameter needed for type inference.
+  // IntelliJ can warn that this is redundant when it is not.
   static <K, V> InstanceOfAssertFactory<Map, MapAssert<K, V>> map(Class<K> keyType, Class<V> valueType) {
     return new InstanceOfAssertFactory<>(Map.class, Assertions::<K, V> assertThat);
   }

--- a/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
+++ b/src/main/java/org/assertj/core/api/Java6BDDAssertions.java
@@ -55,6 +55,8 @@ import org.assertj.core.util.CheckReturnValue;
  */
 @Deprecated
 @CheckReturnValue
+// Deprecation is raised by JDK-17. IntelliJ thinks this is redundant when it is not.
+@SuppressWarnings({"DeprecatedIsStillUsed", "deprecation", "RedundantSuppression"})
 public class Java6BDDAssertions {
 
   /**

--- a/src/main/java/org/assertj/core/api/ListAssert.java
+++ b/src/main/java/org/assertj/core/api/ListAssert.java
@@ -220,9 +220,9 @@ public class ListAssert<ELEMENT> extends
                    .failure(info, shouldStartWith("Stream under test", sequence, iterables.getComparisonStrategy()));
   }
 
-  @SuppressWarnings("rawtypes")
-  private ListFromStream asListFromStream() {
-    return (ListFromStream) actual;
+  @SuppressWarnings("unchecked")
+  private ListFromStream<ELEMENT, Stream<ELEMENT>> asListFromStream() {
+    return (ListFromStream<ELEMENT, Stream<ELEMENT>>) actual;
   }
 
   @VisibleForTesting

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -57,6 +57,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not contain the given values.
    */
+  @SuppressWarnings("unchecked")
   SELF contains(ELEMENT... values);
 
   /**
@@ -96,6 +97,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group contains some
    *           or none of the given values, or the actual group contains more values than the given ones.
    */
+  @SuppressWarnings("unchecked")
   SELF containsOnly(ELEMENT... values);
 
   /**
@@ -144,6 +146,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group contains some
    *           or none of the given values, or the actual group contains more than once these values.
    */
+  @SuppressWarnings("unchecked")
   SELF containsOnlyOnce(ELEMENT... values);
 
   /**
@@ -171,6 +174,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    *           contains some or none of the given values, or the actual group contains more values than the given ones
    *           or values are the same but the order is not.
    */
+  @SuppressWarnings("unchecked")
   SELF containsExactly(ELEMENT... values);
 
   /**
@@ -196,6 +200,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group does not contain the given values, i.e. the actual group
    *           contains some or none of the given values, or the actual group contains more values than the given ones.
    */
+  @SuppressWarnings("unchecked")
   SELF containsExactlyInAnyOrder(ELEMENT... values);
 
   /**
@@ -250,6 +255,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the given array is {@code null}.
    * @throws AssertionError if the actual group does not contain the given sequence.
    */
+  @SuppressWarnings("unchecked")
   SELF containsSequence(ELEMENT... sequence);
 
   /**
@@ -304,6 +310,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the given array is {@code null}.
    * @throws AssertionError if the actual group contains the given sequence.
    */
+  @SuppressWarnings("unchecked")
   SELF doesNotContainSequence(ELEMENT... sequence);
 
   /**
@@ -356,6 +363,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the given array is {@code null}.
    * @throws AssertionError if the actual group does not contain the given subsequence.
    */
+  @SuppressWarnings("unchecked")
   SELF containsSubsequence(ELEMENT... sequence);
 
   /**
@@ -405,6 +413,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the given array is {@code null}.
    * @throws AssertionError if the actual group contains the given subsequence.
    */
+  @SuppressWarnings("unchecked")
   SELF doesNotContainSubsequence(ELEMENT... sequence);
 
   /**
@@ -457,6 +466,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group contains any of the given values.
    */
+  @SuppressWarnings("unchecked")
   SELF doesNotContain(ELEMENT... values);
 
   /**
@@ -502,6 +512,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not start with the given sequence of objects.
    */
+  @SuppressWarnings("unchecked")
   SELF startsWith(ELEMENT... sequence);
 
   /**
@@ -529,6 +540,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual group is {@code null}.
    * @throws AssertionError if the actual group does not end with the given sequence of objects.
    */
+  @SuppressWarnings("unchecked")
   SELF endsWith(ELEMENT first, ELEMENT... sequence);
 
   /**
@@ -1223,6 +1235,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the actual {@code Iterable} is {@code null}.
    * @throws AssertionError if the actual {@code Iterable} is not subset of the given values.
    */
+  @SuppressWarnings("unchecked")
   SELF isSubsetOf(ELEMENT... values);
 
   /**
@@ -1376,6 +1389,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if there are not as many requirements as there are iterable elements.
    * @since 3.19.0
    */
+  @SuppressWarnings("unchecked")
   SELF satisfiesExactly(Consumer<? super ELEMENT>... allRequirements);
   
   /**
@@ -1424,6 +1438,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if there are not as many requirements as there are iterable elements.
    * @since 3.21.0
    */
+  @SuppressWarnings("unchecked")
   SELF satisfiesExactly(ThrowingConsumer<? super ELEMENT>... allRequirements);
 
   /**
@@ -1477,6 +1492,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    *
    * @since 3.19.0
    */
+  @SuppressWarnings("unchecked")
   SELF satisfiesExactlyInAnyOrder(Consumer<? super ELEMENT>... allRequirements);
   
   /**
@@ -1530,6 +1546,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if there are not as many requirements as there are iterable elements.
    * @since 3.21.0
    */
+  @SuppressWarnings("unchecked")
   SELF satisfiesExactlyInAnyOrder(ThrowingConsumer<? super ELEMENT>... allRequirements);
 
   /**
@@ -1696,6 +1713,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws AssertionError if the {@code Iterable} under test does not contain any of the given {@code values}.
    * @since 2.9.0 / 3.9.0
    */
+  @SuppressWarnings("unchecked")
   SELF containsAnyOf(ELEMENT... values);
 
   /**

--- a/src/main/java/org/assertj/core/api/WithAssertions.java
+++ b/src/main/java/org/assertj/core/api/WithAssertions.java
@@ -233,7 +233,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @throws NullPointerException if the given array is {@code null}.
    * @throws NullPointerException if any of the elements in the given array is {@code null}.
    */
-  default <T> Condition<T> allOf(@SuppressWarnings("unchecked") final Condition<? super T>... conditions) {
+  @SuppressWarnings("unchecked") // Heap pollution risk. We accept that as we cannot use @SafeVarargs here.
+  default <T> Condition<T> allOf(final Condition<? super T>... conditions) {
     return Assertions.allOf(conditions);
   }
 
@@ -1960,7 +1961,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @param conditions the conditions to evaluate.
    * @return the created {@code AnyOf}.
    */
-  default <T> Condition<T> anyOf(@SuppressWarnings("unchecked") final Condition<? super T>... conditions) {
+  @SuppressWarnings("unchecked")  // Heap pollution risk. We accept that as we cannot use @SafeVarargs here.
+  default <T> Condition<T> anyOf(final Condition<? super T>... conditions) {
     return Assertions.anyOf(conditions);
   }
 
@@ -2793,7 +2795,8 @@ public interface WithAssertions extends InstanceOfAssertFactories {
    * @since 3.20.0
    */
   @CanIgnoreReturnValue
-  default <T> ObjectAssert<T> assertWith(T actual, @SuppressWarnings("unchecked") Consumer<T>... requirements) {
+  @SuppressWarnings("unchecked")  // Heap pollution risk. We accept that as we cannot use @SafeVarargs here.
+  default <T> ObjectAssert<T> assertWith(T actual, Consumer<T>... requirements) {
     return assertThat(actual).satisfies(requirements);
   }
 

--- a/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
+++ b/src/main/java/org/assertj/core/api/junit/jupiter/SoftAssertionsExtension.java
@@ -370,6 +370,7 @@ public class SoftAssertionsExtension
                                                   AssertionErrorCollector.class);
   }
 
+  @SuppressWarnings("unchecked")
   private static Collection<SoftAssertionsProvider> getSoftAssertionsProviders(ExtensionContext context) {
     return getStore(context).getOrComputeIfAbsent(Collection.class, unused -> new ConcurrentLinkedQueue<>(), Collection.class);
   }

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertLessThanOrEqualTo_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertLessThanOrEqualTo_Test.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 
 /**
- * Tests for <code>{@link Floats#assertLessThanOrEqualTo(AssertionInfo, Float, float)}</code>.
+ * Tests for <code>{@link Floats#assertLessThanOrEqualTo(AssertionInfo, Comparable, Object)}</code>.
  * 
  * @author Alex Ruiz
  * @author Joel Costigliola

--- a/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
+++ b/src/test/java/org/assertj/core/test/jdk11/ImmutableCollections.java
@@ -707,7 +707,7 @@ class ImmutableCollections {
 
     @Override
     public Iterator<E> iterator() {
-      return new SetN.SetNIterator();
+      return new SetN<E>.SetNIterator();
     }
 
     @Override


### PR DESCRIPTION
- Work around/suppress around 95 warnings produced on JDK-17 with -Xlint:all flag enabled.
- Fix a couple of warnings dotted around in tests to do with unchecked operations
- Fix incorrect javadoc reference in Floats_AssertLessThanOrEqualTo_test

Some suppressions are being marked as being redundant by IntelliJ when they are not. For these, I have added an IntelliJ-specific suppression about redundant suppressions to prevent a risk of the original suppression being accidentally removed in the future due to the false positive.

Xlint:all was run by adding 

```xml
<compilerArgs>
  <arg>-Xlint:all</arg>
</compilerArgs>
```

...to the `<configuration />` block for maven-compiler-plugin in the POM.