### PR TITLE
Fix spurious Future tests failure on Windows runners

### DIFF
--- a/src/test/java/org/assertj/core/api/future/AbstractFutureTest.java
+++ b/src/test/java/org/assertj/core/api/future/AbstractFutureTest.java
@@ -12,23 +12,63 @@
  */
 package org.assertj.core.api.future;
 
+import static java.lang.String.format;
+
+import java.lang.Thread.UncaughtExceptionHandler;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.platform.commons.logging.Logger;
+import org.junit.platform.commons.logging.LoggerFactory;
 
 abstract class AbstractFutureTest {
-
   protected ExecutorService executorService;
+  private final ThreadFactory factory;
+
+  AbstractFutureTest() {
+    factory = new FutureTestThreadFactory();
+  }
 
   @BeforeEach
   void beforeEach() {
-    executorService = Executors.newSingleThreadExecutor();
+    executorService = Executors.newSingleThreadExecutor(factory);
   }
 
   @AfterEach
   void afterEach() {
     executorService.shutdownNow();
+  }
+
+  private class FutureTestThreadFactory implements ThreadFactory, UncaughtExceptionHandler {
+    private final Logger logger;
+    private final AtomicInteger count;
+
+    private FutureTestThreadFactory() {
+      logger = LoggerFactory.getLogger(AbstractFutureTest.this.getClass());
+      count = new AtomicInteger(0);
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+      Thread thread = new Thread(runnable);
+      thread.setName(AbstractFutureTest.this.getClass().getName() + "." + count.incrementAndGet());
+      thread.setDaemon(true);
+      thread.setPriority(Thread.MAX_PRIORITY);
+      thread.setUncaughtExceptionHandler(this);
+      thread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+      return thread;
+    }
+
+    @Override
+    public void uncaughtException(Thread thread, Throwable ex) {
+      logger.info(
+        ex,
+        () -> format("Thread %s [%s] threw an exception", thread.getName(), thread.getId())
+      );
+    }
   }
 }

--- a/src/test/java/org/assertj/core/api/future/FutureAssert_succeedsWithin_duration_Test.java
+++ b/src/test/java/org/assertj/core/api/future/FutureAssert_succeedsWithin_duration_Test.java
@@ -46,12 +46,14 @@ class FutureAssert_succeedsWithin_duration_Test extends AbstractFutureTest {
   void should_allow_assertion_on_future_result_when_completed_normally_within_timeout() {
     // GIVEN
     String value = "done";
-    int sleepDuration = 10;
+    int sleepDuration = 100;
     Future<String> future = futureAfter(value, sleepDuration, executorService);
+
     // WHEN/THEN
     // using the same duration would fail depending on when the thread executing the future is started
-    assertThat(future).succeedsWithin(Duration.ofMillis(sleepDuration + 100))
-                      .isEqualTo(value);
+    assertThat(future)
+      .succeedsWithin(Duration.ofMillis(sleepDuration + 1_000))
+      .isEqualTo(value);
   }
 
   @Test


### PR DESCRIPTION
Addresses an issue where FutureAssert tests in CI would sometimes fail on the Windows runner due to kernel thread sleep calls.

I have increased the timeout for that call, and also implemented a custom ThreadFactory for the abstract base class which will ensure that:

1. the threads in the executor are daemon threads
2. the threads in the executor are named appropriately to assist in debugging in the future (e.g. through Java Mission Control, JMX, JConsole, or similar)
3. all uncaught exceptions get reported to the logs
4. the threads emulate PrivilegedThreadFactory in that they hold a reference to the parent thread context class loader (no need to run this in an access control block for tests).
5. the threads run with the highest priority where possible.
