### PR TITLE
Fix some additional compilation warnings and deprecated JDK API usages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <showDeprecation>true</showDeprecation>
+          <showWarnings>true</showWarnings>
           <release>8</release>
         </configuration>
         <executions>

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_extracting_with_SortedSet_Test.java
@@ -52,7 +52,7 @@ import org.assertj.core.util.introspection.IntrospectionError;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class IterableAssert_extracting_with_SortedSet_Test {
+class qIterableAssert_extracting_with_SortedSet_Test {
 
   private Employee yoda;
   private Employee luke;

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_satisfiesExactlyInAnyOrder_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_satisfiesExactlyInAnyOrder_Test.java
@@ -29,7 +29,8 @@ import org.assertj.core.api.IterableAssertBaseTest;
  */
 class IterableAssert_satisfiesExactlyInAnyOrder_Test extends IterableAssertBaseTest {
 
-  private Consumer<Object> consumer = mock(Consumer.class);
+  @SuppressWarnings("unchecked")
+  private final Consumer<Object> consumer = mock(Consumer.class);
 
   @Override
   protected ConcreteIterableAssert<Object> create_assertions() {

--- a/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/doublearrays/DoubleArrays_assertIsSortedAccordingToComparator_Test.java
@@ -44,8 +44,7 @@ class DoubleArrays_assertIsSortedAccordingToComparator_Test extends DoubleArrays
     super.setUp();
     actual = new double[] { 4.0, 3.0, 2.0, 2.0, 1.0 };
     doubleDescendingOrderComparator = (double1, double2) -> -double1.compareTo(double2);
-    doubleSquareComparator = (double1,
-                              double2) -> new Double(double1 * double1).compareTo(new Double(double2 * double2));
+    doubleSquareComparator = Comparator.comparing(aDouble -> aDouble * aDouble);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/doubles/Doubles_assertIsZero_Test.java
@@ -35,7 +35,7 @@ class Doubles_assertIsZero_Test extends DoublesBaseTest {
 
   @Test
   void should_fail_since_actual_is_negative_zero_and_not_primitive() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsZero(someInfo(), new Double(-0.0d)))
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> doubles.assertIsZero(someInfo(), -0.0d))
                                                    .withMessage(shouldBeEqualMessage("-0.0", "0.0"));
   }
 

--- a/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/floatarrays/FloatArrays_assertIsSortedAccordingToComparator_Test.java
@@ -46,7 +46,7 @@ class FloatArrays_assertIsSortedAccordingToComparator_Test extends FloatArraysBa
     super.setUp();
     actual = new float[] { 4.0f, 3.0f, 2.0f, 2.0f, 1.0f };
     floatDescendingOrderComparator = (float1, float2) -> -float1.compareTo(float2);
-    floatSquareComparator = (float1, float2) -> new Float(float1 * float1).compareTo(new Float(float2 * float2));
+    floatSquareComparator = Comparator.comparing(aFloat -> aFloat * aFloat);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/floats/Floats_assertIsZero_Test.java
+++ b/src/test/java/org/assertj/core/internal/floats/Floats_assertIsZero_Test.java
@@ -42,7 +42,7 @@ class Floats_assertIsZero_Test extends FloatsBaseTest {
 
   @Test
   void should_fail_since_actual_is_negative_zero_and_not_primitive() {
-    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsZero(someInfo(), new Float(-0.0)))
+    assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> floats.assertIsZero(someInfo(), -0.0f))
                                                    .withMessage(shouldBeEqualMessage("-0.0f", "0.0f"));
   }
 

--- a/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSortedAccordingToComparator_Test.java
+++ b/src/test/java/org/assertj/core/internal/intarrays/IntArrays_assertIsSortedAccordingToComparator_Test.java
@@ -47,7 +47,7 @@ class IntArrays_assertIsSortedAccordingToComparator_Test extends IntArraysBaseTe
     super.setUp();
     actual = new int[] { 4, 3, 2, 2, 1 };
     intDescendingOrderComparator = (int1, int2) -> -int1.compareTo(int2);
-    intSquareComparator = (int1, int2) -> new Integer(int1 * int1).compareTo(new Integer(int2 * int2));
+    intSquareComparator = Comparator.comparingInt(anInt -> anInt * anInt);
   }
 
   @Test

--- a/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSorted_Test.java
+++ b/src/test/java/org/assertj/core/internal/objectarrays/ObjectArrays_assertIsSorted_Test.java
@@ -106,7 +106,7 @@ class ObjectArrays_assertIsSorted_Test extends ObjectArraysBaseTest {
   @Test
   void should_fail_if_actual_has_some_not_mutually_comparable_elements() {
     AssertionInfo info = someInfo();
-    Object[] actual = new Object[] { "bar", new Integer(5), "foo" };
+    Object[] actual = new Object[] { "bar", 5, "foo" };
 
     Throwable error = catchThrowable(() -> arrays.assertIsSorted(info, actual));
 
@@ -178,10 +178,11 @@ class ObjectArrays_assertIsSorted_Test extends ObjectArraysBaseTest {
         shouldHaveComparableElementsAccordingToGivenComparator(actual, comparatorForCustomComparisonStrategy()));
   }
 
+  @SuppressWarnings("UnnecessaryBoxing")
   @Test
   void should_fail_if_actual_has_some_not_mutually_comparable_elements_according_to_custom_comparison_strategy() {
     AssertionInfo info = someInfo();
-    Object[] actual = new Object[] { "bar", new Integer(5), "foo" };
+    Object[] actual = new Object[] { "bar", Integer.valueOf(5), "foo" };
 
     Throwable error = catchThrowable(() -> arraysWithCustomComparisonStrategy.assertIsSorted(info, actual));
 


### PR DESCRIPTION
Fixes some additional warnings I missed yesterday afternoon in #2648.

I have enabled deprecation warnings and compilation warnings. Is there an issue that needs to be made to consider eventually removing those deprecated APIs? (I see a bunch of Java 6 stuff dotted around but the release target is set to 8 in the POM).
