### PR TITLE
[CI fix] Allow add-label to fail in binary-compatibility.yml

### DIFF
--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Add label
         if: failure()
         uses: actions/github-script@v6
+        # This will occur when the user running the CI job lacks permission to manipulate
+        # the resource with this integration.
+        continue-on-error: true
         with:
           script: |
             github.rest.issues.addLabels({
@@ -43,6 +46,7 @@ jobs:
               issue_number: context.issue.number,
               labels: ['binary incompatible with: base']
             })
+
       - name: Remove label
         if: success()
         uses: actions/github-script@v6


### PR DESCRIPTION
Binary-compatibility is currently failing when attempting to add a label to 
the resource behind this integration when the person running the CI does not have
permission to manipulate that resource.

This allows that error to be ignored.
