### PR TITLE
Run cross-version CI on JRE 8 and 11 to verify compatibility

### DIFF
--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -4,7 +4,24 @@ on: [push, pull_request]
 
 jobs:
 
-  test_java:
+  test_java_old:
+    name: Java ${{ matrix.java }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [8, 11]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+      - name: Test
+        run: ./mvnw -V --no-transfer-progress -e verify javadoc:javadoc -Denforcer.skip
+
+  test_java_new:
     name: Java ${{ matrix.java }}
     strategy:
       fail-fast: false
@@ -20,4 +37,4 @@ jobs:
           release: ${{ matrix.java }}
           version: latest
       - name: Test
-        run: ./mvnw -V --no-transfer-progress -e verify javadoc:javadoc
+        run: ./mvnw -V --no-transfer-progress -e verify javadoc:javadoc -Denforcer.skip


### PR DESCRIPTION
Just a suggestion that I thought might be beneficial for CI builds:
considering running CI builds on JRE 8 and JRE 11 explicitly.

This reduces the risk of missing differences between older JREs and
JRE 17 which CI currently runs on. The main risk by avoiding this
is coming across bugs that were fixed in newer JRE versions.

One of the things this can impact is the differences in default
classloaders in newer versions.

