### PR TITLE
Feature/improve ci output

### DIFF
--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -3,10 +3,8 @@ name: Binary Compatibility
 on: [push, pull_request]
 
 jobs:
-
   verify-with-base:
-
-    name: Verify with `${{ github.base_ref }}`
+    name: Verify with base ref
     runs-on: ubuntu-latest
     if: github.base_ref != null
 

--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -24,13 +24,20 @@ jobs:
           ref: ${{ github.base_ref }}
           path: ${{ github.run_id }}.${{ github.base_ref }}
       - name: Build `${{ github.base_ref }}`
-        run: ./mvnw -V --no-transfer-progress -e -f ${{ github.run_id }}.${{ github.base_ref }}/pom.xml package -DskipTests
+        run: >
+          ./mvnw -B -V --no-transfer-progress -e 
+          -f ${{ github.run_id }}.${{ github.base_ref }}/pom.xml package 
+          -DskipTests
+          -Djansi.passthrough=true
+          -Dstyle.color=always
       - name: Compare `${{ github.head_ref }}` with `${{ github.base_ref }}`
         run: >
           ./mvnw -B -V --no-transfer-progress -e -Pjapicmp-branch package japicmp:cmp
           -DskipTests
           -Djapicmp.breakBuildOnBinaryIncompatibleModifications=true
           -Djapicmp.oldVersion.basedir=${{ github.run_id }}.${{ github.base_ref }}
+          -Djansi.passthrough=true
+          -Dstyle.color=always
 
       - name: Add label
         if: failure()
@@ -91,6 +98,8 @@ jobs:
           ./mvnw -B -V --no-transfer-progress -e package japicmp:cmp
           -DskipTests
           -Djapicmp.breakBuildOnBinaryIncompatibleModifications=true
+          -Djansi.passthrough=true
+          -Dstyle.color=always
 
       - name: Add label
         if: failure()

--- a/.github/workflows/binary-compatibility.yml
+++ b/.github/workflows/binary-compatibility.yml
@@ -27,7 +27,7 @@ jobs:
         run: ./mvnw -V --no-transfer-progress -e -f ${{ github.run_id }}.${{ github.base_ref }}/pom.xml package -DskipTests
       - name: Compare `${{ github.head_ref }}` with `${{ github.base_ref }}`
         run: >
-          ./mvnw -V --no-transfer-progress -e -Pjapicmp-branch package japicmp:cmp
+          ./mvnw -B -V --no-transfer-progress -e -Pjapicmp-branch package japicmp:cmp
           -DskipTests
           -Djapicmp.breakBuildOnBinaryIncompatibleModifications=true
           -Djapicmp.oldVersion.basedir=${{ github.run_id }}.${{ github.base_ref }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Compare with the latest release
         run: >
-          ./mvnw -V --no-transfer-progress -e package japicmp:cmp
+          ./mvnw -B -V --no-transfer-progress -e package japicmp:cmp
           -DskipTests
           -Djapicmp.breakBuildOnBinaryIncompatibleModifications=true
 

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -20,4 +20,4 @@ jobs:
           release: ${{ matrix.java }}
           version: latest
       - name: Test
-        run: ./mvnw -V --no-transfer-progress -e verify javadoc:javadoc
+        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -20,4 +20,7 @@ jobs:
           release: ${{ matrix.java }}
           version: latest
       - name: Test
-        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'
+        run: >
+          ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'
+          -Djansi.passthrough=true
+          -Dstyle.color=always

--- a/.github/workflows/cross-version.yml
+++ b/.github/workflows/cross-version.yml
@@ -20,4 +20,4 @@ jobs:
           release: ${{ matrix.java }}
           version: latest
       - name: Test
-        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc
+        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,20 @@ jobs:
 
   test_os:
     name: OS ${{ matrix.os }}
+    permissions:
+      # Needed for test reporting
+      checks: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+            comment-test-results: true
+          - os: macOS-latest
+            comment-test-results: false
+          - os: windows-latest
+            comment-test-results: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -22,10 +32,20 @@ jobs:
       - name: Test
         run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'
 
+      # Add test results to the PR.
+      - name: Publish unit test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: ${{ matrix.comment-test-results }}
+        continue-on-error: true
+        with:
+          check_name: "JUnit test results"
+          files: "target/surefire-reports/TEST-*.xml"
+
   sonar:
     name: Sonar code analysis
     runs-on: ubuntu-latest
     if: github.repository == 'assertj/assertj-core' && github.event_name == 'push'
+
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,12 @@ jobs:
           java-version: 17
 #          cache: 'maven'
       - name: Test
-        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'
+        # Note: arguments with a period or bang in them have to be single quoted to prevent
+        # confusing the PowerShell instance on Windows runners.
+        run: >
+          ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'
+          '-Djansi.passthrough=true'
+          '-Dstyle.color=always'
 
       # Add test results to the PR.
       - name: Publish unit test results
@@ -62,6 +67,8 @@ jobs:
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=assertj
           -Dsonar.projectKey=joel-costigliola_assertj-core
+          -Djansi.passthrough=true
+          -Dstyle.color=always
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 17
 #          cache: 'maven'
       - name: Test
-        run: ./mvnw -V --no-transfer-progress -e verify javadoc:javadoc
+        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc
 
   sonar:
     name: Sonar code analysis
@@ -38,7 +38,7 @@ jobs:
 #          cache: 'maven'
       - name: Test with Sonar
         run: >
-          ./mvnw -V --no-transfer-progress -e -Pcoverage verify javadoc:javadoc sonar:sonar
+          ./mvnw -B -V --no-transfer-progress -e -Pcoverage verify javadoc:javadoc sonar:sonar
           -Dsonar.host.url=https://sonarcloud.io
           -Dsonar.organization=assertj
           -Dsonar.projectKey=joel-costigliola_assertj-core

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: 17
 #          cache: 'maven'
       - name: Test
-        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc
+        run: ./mvnw -B -V --no-transfer-progress -e verify javadoc:javadoc '-P!coverage'
 
   sonar:
     name: Sonar code analysis

--- a/.github/workflows/pitest-receive-pr.yml
+++ b/.github/workflows/pitest-receive-pr.yml
@@ -38,9 +38,15 @@ jobs:
         # pitest has been bound to a profile called pitest for normal running
         # we add config to analyse only changes made within a PR and treat surviving mutants as check errors
         # failWhenNoMutations is unset in the pom, as otherwise PRs that do not affect java code would fail
-        run: mvn -e -B -Ppitest -Dfeatures="+GIT(from[HEAD~1]), +gitci" test
+        run: >
+          mvn -e -B -Ppitest -Dfeatures="+GIT(from[HEAD~1]), +gitci" test
+          -Djansi.passthrough=true
+          -Dstyle.color=always
       - name: aggregate files
-        run: mvn -e -B -Ppitest pitest-git:aggregate
+        run: >
+          mvn -e -B -Ppitest pitest-git:aggregate
+          -Djansi.passthrough=true
+          -Dstyle.color=always
       - name: upload results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/pitest-updated-pr.yml
+++ b/.github/workflows/pitest-updated-pr.yml
@@ -42,4 +42,7 @@ jobs:
         # The updatePR maven goal is used here with an explicit version. This allows us to upload without checking out
         # the code, but does mean the version here must be maintained. An alternative would be to checkout the code and use 
         # the github goal. This will work as long as the artifact is extracted to the maven target directory
-        run: mvn -B -DrepoToken=${{ secrets.GITHUB_TOKEN }} com.groupcdg:pitest-github-maven-plugin:0.2.0:updatePR
+        run: >
+          mvn -B -DrepoToken=${{ secrets.GITHUB_TOKEN }} com.groupcdg:pitest-github-maven-plugin:0.2.0:updatePR
+          -Djansi.passthrough=true
+          -Dstyle.color=always

--- a/.github/workflows/pitest-updated-pr.yml
+++ b/.github/workflows/pitest-updated-pr.yml
@@ -42,4 +42,4 @@ jobs:
         # The updatePR maven goal is used here with an explicit version. This allows us to upload without checking out
         # the code, but does mean the version here must be maintained. An alternative would be to checkout the code and use 
         # the github goal. This will work as long as the artifact is extracted to the maven target directory
-        run: mvn -DrepoToken=${{ secrets.GITHUB_TOKEN }} com.groupcdg:pitest-github-maven-plugin:0.2.0:updatePR
+        run: mvn -B -DrepoToken=${{ secrets.GITHUB_TOKEN }} com.groupcdg:pitest-github-maven-plugin:0.2.0:updatePR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
         run: |
           git config user.name '${{ github.actor }}'
           git config user.email '${{ github.actor }}@users.noreply.github.com'
-          ./mvnw -B release:prepare release:perform -Dpassword=${{ secrets.GITHUB_TOKEN }}
+          ./mvnw -B release:prepare release:perform -Dpassword=${{ secrets.GITHUB_TOKEN }} \
+              -Djansi.passthrough=true \
+              -Dstyle.color=always
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M7</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
           <excludes>
@@ -373,6 +374,33 @@
             <exclude>org/assertj/core/internal/objects/Objects_assertHasOnlyFields_Test*</exclude>
           </excludes>
           <runOrder>random</runOrder>
+
+          <!--
+            These blocks are needed to show @DisplayName and @ParameterizedTest
+            in reports with the provided names, as well as with console output.
+          -->
+          <consoleOutputReporter
+            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5ConsoleOutputReporter">
+            <!-- Set to true to suppress log output being included in Surefire output -->
+            <disable>false</disable>
+          </consoleOutputReporter>
+
+          <statelessTestsetInfoReporter
+            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoReporter">
+            <disable>false</disable>
+            <usePhrasedFileName>false</usePhrasedFileName>
+            <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+            <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+          </statelessTestsetInfoReporter>
+
+          <statelessTestsetReporter
+            implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+            <disable>false</disable>
+            <usePhrasedFileName>false</usePhrasedFileName>
+            <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+            <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+            <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+          </statelessTestsetReporter>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -622,6 +622,9 @@
     </profile>
     <profile>
       <id>coverage</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>
@@ -637,6 +640,12 @@
             <!-- jacoco is executed in the prepare-package phase instead of the verify phase, it can not determine code coverage
               of the unpacked shaded classes -->
             <executions>
+              <execution>
+                <goals>
+                  <goal>prepare-agent</goal>
+                </goals>
+              </execution>
+
               <execution>
                 <id>jacoco-report</id>
                 <phase>prepare-package</phase>


### PR DESCRIPTION
This contains several tweaks to the CI that make it a little easier to read, as well as adding functionality to add test result details as a comment to each PR. It also tweaks Jacoco so that local builds of forks/clones will opt into enabling Jacoco by default rather than having to explicitly run it.

- **Run mvnw in CI with batch flag** - this prevents some more noisy output from Maven that would otherwise make the logs more spammy.
- **Enable Jacoco on local builds by default** - CI then explicitly opts out of enabling this where important. This helps contributors be aware of the coverage as they make changes without having to remember to explicitly turn Jacoco on first.
- **Use Surefire v3, use JUnit5 reporters**:
    - Bump Surefire plugin to 3.0.0-M7, as this is stable despite being a prerelease, but contains numerous fixes and improvements compared to v2.22.x. These include fixes to potential crashes on some systems due to console log corruption, improved JUnit5 support, etc
    - Override default reporters for Surefire to use JUnit5 ones. This improves the format of the output logs in builds.
    - Prefer use of `@DisplayName` and `@ParameterizedTest` name for over the method name in Surefire reports, as this becomes easier to read and is prettier.
- <details>
    <summary>
      <strong>Report test results on PRs as a comment</strong> - this also adds some text to the Workflow page with the same details on it, and will automatically edit existing comments if results change or reruns occur. This requires two permissions to be set to <code>write</code> which I have added to that commit.
    </summary>
    <img src="https://user-images.githubusercontent.com/73482956/174478067-a7713050-e3d2-4b13-853a-dfd305bafb3d.png"/>
    <img src="https://user-images.githubusercontent.com/73482956/174478068-fdbe3fb1-3078-41d7-aba4-ba14e77f9599.png"/>
  </details>

- <details>
    <summary>
      <strong>Enable showing colour in GitHub action logs</strong> - this makes errors and warnings easier to spot, and makes the entire output a bit easier to read.
    </summary>
    <img src="https://user-images.githubusercontent.com/73482956/174477939-5408b8db-f501-4f85-93cc-074024159871.png"/>
  </details>
  
- <details>
    <summary>
      <strong>Replace uninterpolated job name outside PRs</strong> - outside PRs, one of the job names was explicitly showing up with a mangled name due to a context variable being missing. This just fixes that:
    </summary>
    <img src="https://user-images.githubusercontent.com/73482956/174477877-546681fe-8e61-46d8-aef9-e8890ac4c189.png"/>
  </details>
