### PR TITLE
Reset global state more aggressively in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,7 @@
             <exclude>org/assertj/core/osgi/**</exclude>
             <exclude>org/assertj/core/internal/objects/Objects_assertHasOnlyFields_Test*</exclude>
           </excludes>
+          <runOrder>random</runOrder>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/java/org/assertj/core/api/AssumptionExceptionFactory.java
+++ b/src/main/java/org/assertj/core/api/AssumptionExceptionFactory.java
@@ -20,7 +20,7 @@ import org.assertj.core.configuration.PreferredAssumptionException;
 import org.assertj.core.util.VisibleForTesting;
 
 /**
- * Responsible of building the exception to throw for failing assumptions.
+ * Responsible for building the exception to throw for failing assumptions.
  * @since 3.21.0
  */
 public class AssumptionExceptionFactory {

--- a/src/main/java/org/assertj/core/configuration/Configuration.java
+++ b/src/main/java/org/assertj/core/configuration/Configuration.java
@@ -65,6 +65,13 @@ public class Configuration {
   private PreferredAssumptionException preferredAssumptionException;
   
   public Configuration() {
+    setDefaults();
+  }
+
+  /**
+   * Set all configuration settings to their default values again.
+   */
+  public void setDefaults() {
     comparingPrivateFields = ALLOW_COMPARING_PRIVATE_FIELDS;
     extractingPrivateFields = ALLOW_EXTRACTING_PRIVATE_FIELDS;
     bareNamePropertyExtraction = BARE_NAME_PROPERTY_EXTRACTION_ENABLED;

--- a/src/test/java/org/assertj/core/api/EntryPointAssertions_useDefaultRepresentation_Test.java
+++ b/src/test/java/org/assertj/core/api/EntryPointAssertions_useDefaultRepresentation_Test.java
@@ -21,12 +21,14 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.assertj.core.presentation.Representation;
+import org.assertj.core.test.MutatesGlobalConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 @DisplayName("EntryPoint assertions useDefaultRepresentation method")
+@MutatesGlobalConfiguration
 class EntryPointAssertions_useDefaultRepresentation_Test extends EntryPointAssertionsBaseTest {
 
   private static final Representation DEFAULT_CUSTOM_REPRESENTATION = AbstractAssert.customRepresentation;

--- a/src/test/java/org/assertj/core/api/EntryPoint_Assumptions_setPreferredAssumptionException_Test.java
+++ b/src/test/java/org/assertj/core/api/EntryPoint_Assumptions_setPreferredAssumptionException_Test.java
@@ -28,12 +28,14 @@ import java.util.function.Consumer;
 import java.util.stream.Stream;
 
 import org.assertj.core.configuration.PreferredAssumptionException;
+import org.assertj.core.test.MutatesGlobalConfiguration;
 import org.junit.AssumptionViolatedException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentest4j.TestAbortedException;
 
+@MutatesGlobalConfiguration
 class EntryPoint_Assumptions_setPreferredAssumptionException_Test {
 
   protected static final WithAssumptions withAssumptions = mock(WithAssumptions.class, CALLS_REAL_METHODS);

--- a/src/test/java/org/assertj/core/configuration/Configuration_apply_Test.java
+++ b/src/test/java/org/assertj/core/configuration/Configuration_apply_Test.java
@@ -21,11 +21,13 @@ import java.util.Date;
 import org.assertj.core.api.AssumptionExceptionFactory;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.presentation.StandardRepresentation;
+import org.assertj.core.test.MutatesGlobalConfiguration;
 import org.assertj.core.util.introspection.FieldSupport;
 import org.assertj.core.util.introspection.Introspection;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+@MutatesGlobalConfiguration
 class Configuration_apply_Test {
 
   @Test

--- a/src/test/java/org/assertj/core/configuration/Configuration_describe_Test.java
+++ b/src/test/java/org/assertj/core/configuration/Configuration_describe_Test.java
@@ -18,9 +18,11 @@ import static org.assertj.core.api.BDDAssertions.then;
 import java.util.function.Consumer;
 
 import org.assertj.core.description.Description;
+import org.assertj.core.test.MutatesGlobalConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+@MutatesGlobalConfiguration
 class Configuration_describe_Test {
 
   @Test

--- a/src/test/java/org/assertj/core/extension/SoftlyExtensionInstanceTest.java
+++ b/src/test/java/org/assertj/core/extension/SoftlyExtensionInstanceTest.java
@@ -10,7 +10,7 @@
  *
  * Copyright 2012-2022 the original author or authors.
  */
-package org.assertj.core.extention;
+package org.assertj.core.extension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.util.AssertionsUtil.assertThatAssertionErrorIsThrownBy;

--- a/src/test/java/org/assertj/core/osgi/AssumptionsTest.java
+++ b/src/test/java/org/assertj/core/osgi/AssumptionsTest.java
@@ -20,11 +20,11 @@ import static org.assertj.core.presentation.UnicodeRepresentation.UNICODE_REPRES
 
 import org.assertj.core.api.Assumptions;
 import org.assertj.core.configuration.PreferredAssumptionException;
+import org.assertj.core.test.MutatesGlobalConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Isolated;
 import org.opentest4j.TestAbortedException;
 
-@Isolated  // Isolated as the preferred assumption class is mutated globally here.
+@MutatesGlobalConfiguration
 class AssumptionsTest {
 
   @Test

--- a/src/test/java/org/assertj/core/presentation/StandardRepresentation_throwable_format_Test.java
+++ b/src/test/java/org/assertj/core/presentation/StandardRepresentation_throwable_format_Test.java
@@ -20,7 +20,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.assertj.core.configuration.Configuration;
-import org.junit.jupiter.api.AfterEach;
+import org.assertj.core.test.MutatesGlobalConfiguration;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
  *
  *  @author XiaoMingZHM Eveneko
  */
+@MutatesGlobalConfiguration
 class StandardRepresentation_throwable_format_Test {
 
   private static final Representation REPRESENTATION = new StandardRepresentation();
@@ -44,12 +45,6 @@ class StandardRepresentation_throwable_format_Test {
     static void boom() {
       Test2.boom2();
     }
-  }
-
-  @AfterEach
-  void afterEach() {
-    // Restore default configuration after each test
-    DEFAULT_CONFIGURATION.apply();
   }
 
   @Test

--- a/src/test/java/org/assertj/core/test/MutatesGlobalConfiguration.java
+++ b/src/test/java/org/assertj/core/test/MutatesGlobalConfiguration.java
@@ -1,0 +1,43 @@
+package org.assertj.core.test;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import org.assertj.core.configuration.ConfigurationProvider;
+import org.assertj.core.test.MutatesGlobalConfiguration.AssumptionMutatingExtension;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * An annotation for any test class that mutates the global configuration.
+ *
+ * <p>By using this annotation, any tests that mutate this configuration will have the configuration
+ * reset to the default values after each test case runs.
+ *
+ * @author Ashley Scopes
+ */
+@ExtendWith(AssumptionMutatingExtension.class)
+@Isolated("Mutates global state")
+@Target(ElementType.TYPE)
+public @interface MutatesGlobalConfiguration {
+
+  final class AssumptionMutatingExtension implements AfterEachCallback, AfterAllCallback {
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+      resetAll();
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+      resetAll();
+    }
+
+    private void resetAll() {
+      ConfigurationProvider.CONFIGURATION_PROVIDER.configuration().setDefaults();
+    }
+  }
+}
+

--- a/src/test/java/org/assertj/core/test/MutatesGlobalConfiguration.java
+++ b/src/test/java/org/assertj/core/test/MutatesGlobalConfiguration.java
@@ -1,3 +1,15 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
 package org.assertj.core.test;
 
 import java.lang.annotation.ElementType;
@@ -40,4 +52,3 @@ public @interface MutatesGlobalConfiguration {
     }
   }
 }
-


### PR DESCRIPTION
Noticed when I run the tests in my IDE, sometimes there are cases where loads of tests are failing.

![image](https://user-images.githubusercontent.com/73482956/174485702-a80194ea-003c-4c0d-bcda-fdd4c1925959.png)

Seems to be related to the global state being changed, so I have added an annotation that can be placed on any test cases that manipulate the global state. This annotation will ensure the test runs in global isolation to prevent race conditions, and it will enforce resetting the global state after each test and at the end of the test execution for the class (to handle cases such as `@AfterAll` which run outside the scope of regular test cases).

I have also made Surefire now execute tests in complete random order, which should assist in identifying any other places this kind of thing is happening in