### PR TITLE
Fix typo in docs for assertIsEqualToNormalizingNewlines

### DIFF
--- a/src/main/java/org/assertj/core/internal/Strings.java
+++ b/src/main/java/org/assertj/core/internal/Strings.java
@@ -662,7 +662,7 @@ public class Strings {
   }
 
   /**
-   * Verifies that two {@code CharSequence}s are not equal, normalizing newlines.
+   * Verifies that two {@code CharSequence}s are equal, normalizing newlines.
    *
    * @param info contains information about the assertion.
    * @param actual the actual {@code CharSequence} (newlines will be normalized).


### PR DESCRIPTION
#### Check List:
* Fixes #??? (ignore if not applicable)
* Unit tests : NA
* Javadoc with a code example (on API only) : NA
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

Following the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR.
