### PR TITLE
Add satisfiesOnlyOnce to ObjectEnumerableAssert

### DIFF
--- a/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractIterableAssert.java
@@ -3873,6 +3873,30 @@ public abstract class AbstractIterableAssert<SELF extends AbstractIterableAssert
     return myself;
   }
 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements) {
+    return satisfiesOnlyOnceForProxy(requirements);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF satisfiesOnlyOnce(ThrowingConsumer<? super ELEMENT> requirements) {
+    return satisfiesOnlyOnceForProxy(requirements);
+  }
+
+  // This method is protected in order to be proxied for SoftAssertions / Assumptions.
+  // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
+  // in order to avoid compiler warning in user code
+  protected SELF satisfiesOnlyOnceForProxy(Consumer<? super ELEMENT> requirements) {
+    iterables.assertSatisfiesOnlyOnce(info, actual, requirements);
+    return myself;
+  }
+
   // override methods to avoid compilation error when chaining an AbstractAssert method with a AbstractIterableAssert
   // one on raw types.
 

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -3768,7 +3768,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @return this assertion object.
    * @throws NullPointerException if the given requirements are {@code null}.
    * @throws AssertionError if the requirements are not satisfied only once
-   * @since 3.x.x
+   * @since 3.24.0
    */
   @Override
   public SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements) {
@@ -3798,7 +3798,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    * @throws NullPointerException if the given requirements are {@code null}.
    * @throws RuntimeException rethrown as is by the given {@link ThrowingConsumer} or wrapping any {@link Throwable}.    
    * @throws AssertionError if the requirements are not satisfied only once
-   * @since 3.x.x
+   * @since 3.24.0
    */
   @Override
   public SELF satisfiesOnlyOnce(ThrowingConsumer<? super ELEMENT> requirements) {

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -3747,7 +3747,28 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * {@inheritDoc}
+   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link Consumer}.
+   *
+   * Examples:
+   * <pre><code class='java'> String[] starWarsCharacterNames = {"Luke", "Leia", "Yoda"};
+   *
+   * // these assertions succeed:
+   *
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
+   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
+   *
+   * // this assertion fails because the requirements are satisfied two times
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("a")); // matches "Leia" and "Yoda"
+   *
+   * // this assertion fails because no element contains "Han"
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Han"));</code></pre>
+   *
+   * @param requirements the {@link Consumer} that is expected to be satisfied only once by the elements of the given {@code Iterable}.
+   * @return this assertion object.
+   * @throws NullPointerException if the given requirements are {@code null}.
+   * @throws AssertionError if the requirements are not satisfied only once
+   * @since 3.x.x
    */
   @Override
   public SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements) {
@@ -3755,7 +3776,29 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * {@inheritDoc}
+   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link ThrowingConsumer}.
+   *
+   * Examples:
+   * <pre><code class='java'> String[] starWarsCharacterNames = {"Luke", "Leia", "Yoda"};
+   *
+   * // these assertions succeed:
+   *
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
+   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
+   *
+   * // this assertion fails because the requirements are satisfied two times
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("a")); // matches "Leia" and "Yoda"
+   *
+   * // this assertion fails because no element contains "Han"
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Han"));</code></pre>
+   *
+   * @param requirements the {@link ThrowingConsumer} that is expected to be satisfied only once by the elements of the given {@code Iterable}.
+   * @return this assertion object.
+   * @throws NullPointerException if the given requirements are {@code null}.
+   * @throws RuntimeException rethrown as is by the given {@link ThrowingConsumer} or wrapping any {@link Throwable}.    
+   * @throws AssertionError if the requirements are not satisfied only once
+   * @since 3.x.x
    */
   @Override
   public SELF satisfiesOnlyOnce(ThrowingConsumer<? super ELEMENT> requirements) {

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -3754,7 +3754,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    *
    * // these assertions succeed:
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
-   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *								                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
    *
    * // this assertion fails because the requirements are satisfied two times
@@ -3782,7 +3782,7 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
    *
    * // these assertions succeed:
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
-   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *								                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
    *
    * // this assertion fails because the requirements are satisfied two times

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -3747,13 +3747,12 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link Consumer}.
-   *
+   * Verifies that there is exactly one element of the array under test that satisfies the {@link Consumer}.
+   * <p>
    * Examples:
    * <pre><code class='java'> String[] starWarsCharacterNames = {"Luke", "Leia", "Yoda"};
    *
    * // these assertions succeed:
-   *
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
    *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
@@ -3776,13 +3775,12 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   }
 
   /**
-   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link ThrowingConsumer}.
-   *
+   * Verifies that there is exactly one element of the array under test that satisfies the {@link ThrowingConsumer}.
+   * <p>
    * Examples:
    * <pre><code class='java'> String[] starWarsCharacterNames = {"Luke", "Leia", "Yoda"};
    *
    * // these assertions succeed:
-   *
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
    *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"

--- a/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AbstractObjectArrayAssert.java
@@ -91,7 +91,7 @@ import org.assertj.core.util.introspection.IntrospectionError;
  */
 // suppression of deprecation works in Eclipse to hide warning for the deprecated classes in the imports
 // IntelliJ thinks this is redundant when it is not.
-@SuppressWarnings({"deprecation", "RedundantSuppression"})
+@SuppressWarnings({ "deprecation", "RedundantSuppression" })
 public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArrayAssert<SELF, ELEMENT>, ELEMENT> extends
     AbstractAssert<SELF, ELEMENT[]>
     implements IndexedObjectEnumerableAssert<AbstractObjectArrayAssert<SELF, ELEMENT>, ELEMENT>,
@@ -3743,6 +3743,30 @@ public abstract class AbstractObjectArrayAssert<SELF extends AbstractObjectArray
   // in order to avoid compiler warning in user code
   protected SELF satisfiesExactlyInAnyOrderForProxy(Consumer<? super ELEMENT>[] requirements) {
     iterables.assertSatisfiesExactlyInAnyOrder(info, newArrayList(actual), requirements);
+    return myself;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements) {
+    return satisfiesOnlyOnceForProxy(requirements);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public SELF satisfiesOnlyOnce(ThrowingConsumer<? super ELEMENT> requirements) {
+    return satisfiesOnlyOnceForProxy(requirements);
+  }
+
+  // This method is protected in order to be proxied for SoftAssertions / Assumptions.
+  // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
+  // in order to avoid compiler warning in user code
+  protected SELF satisfiesOnlyOnceForProxy(Consumer<? super ELEMENT> requirements) {
+    iterables.assertSatisfiesOnlyOnce(info, newArrayList(actual), requirements);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -3822,7 +3822,28 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * {@inheritDoc}
+   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link Consumer}.
+   *
+   * Examples:
+   * <pre><code class='java'> AtomicReferenceArray&lt;String&gt; starWarsCharacterNames = new AtomicReferenceArray&lt;&gt;(new String[] {"Luke", "Leia", "Yoda"});
+   *
+   * // these assertions succeed:
+   *
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
+   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
+   *
+   * // this assertion fails because the requirements are satisfied two times
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("a")); // matches "Leia" and "Yoda"
+   *
+   * // this assertion fails because no element contains "Han"
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Han"));</code></pre>
+   *
+   * @param requirements the {@link Consumer} that is expected to be satisfied only once by the elements of the given {@code Iterable}.
+   * @return this assertion object.
+   * @throws NullPointerException if the given requirements are {@code null}.
+   * @throws AssertionError if the requirements are not satisfied only once
+   * @since 3.x.x
    */
   @Override
   public AtomicReferenceArrayAssert<T> satisfiesOnlyOnce(Consumer<? super T> requirements) {
@@ -3830,7 +3851,29 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * {@inheritDoc}
+   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link ThrowingConsumer}.
+   *
+   * Examples:
+   * <pre><code class='java'> AtomicReferenceArray&lt;String&gt; starWarsCharacterNames = new AtomicReferenceArray&lt;&gt;(new String[] {"Luke", "Leia", "Yoda"});
+   *
+   * // these assertions succeed:
+   *
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
+   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
+   *
+   * // this assertion fails because the requirements are satisfied two times
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("a")); // matches "Leia" and "Yoda"
+   *
+   * // this assertion fails because no element contains "Han"
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Han"));</code></pre>
+   *
+   * @param requirements the {@link ThrowingConsumer} that is expected to be satisfied only once by the elements of the given {@code Iterable}.
+   * @return this assertion object.
+   * @throws NullPointerException if the given requirements are {@code null}.
+   * @throws RuntimeException rethrown as is by the given {@link ThrowingConsumer} or wrapping any {@link Throwable}.    
+   * @throws AssertionError if the requirements are not satisfied only once
+   * @since 3.x.x
    */
   @Override
   public AtomicReferenceArrayAssert<T> satisfiesOnlyOnce(ThrowingConsumer<? super T> requirements) {

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -3843,7 +3843,7 @@ public class AtomicReferenceArrayAssert<T>
    * @return this assertion object.
    * @throws NullPointerException if the given requirements are {@code null}.
    * @throws AssertionError if the requirements are not satisfied only once
-   * @since 3.x.x
+   * @since 3.24.0
    */
   @Override
   public AtomicReferenceArrayAssert<T> satisfiesOnlyOnce(Consumer<? super T> requirements) {
@@ -3873,7 +3873,7 @@ public class AtomicReferenceArrayAssert<T>
    * @throws NullPointerException if the given requirements are {@code null}.
    * @throws RuntimeException rethrown as is by the given {@link ThrowingConsumer} or wrapping any {@link Throwable}.    
    * @throws AssertionError if the requirements are not satisfied only once
-   * @since 3.x.x
+   * @since 3.24.0
    */
   @Override
   public AtomicReferenceArrayAssert<T> satisfiesOnlyOnce(ThrowingConsumer<? super T> requirements) {

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -71,7 +71,7 @@ import org.assertj.core.util.introspection.IntrospectionError;
 
 // suppression of deprecation works in Eclipse to hide warning for the deprecated classes in the imports
 // Deprecation is raised by JDK-17. IntelliJ thinks this is redundant when it is not.
-@SuppressWarnings({"deprecation", "RedundantSuppression"})
+@SuppressWarnings({ "deprecation", "RedundantSuppression" })
 public class AtomicReferenceArrayAssert<T>
     extends AbstractAssert<AtomicReferenceArrayAssert<T>, AtomicReferenceArray<T>>
     implements IndexedObjectEnumerableAssert<AtomicReferenceArrayAssert<T>, T>,
@@ -1095,7 +1095,6 @@ public class AtomicReferenceArrayAssert<T>
     arrays.assertHasExactlyElementsOfTypes(info, array, expectedTypes);
     return myself;
   }
-
 
   /**
    * Verifies that the actual AtomicReferenceArray does not contain the given object at the given index.
@@ -3819,6 +3818,30 @@ public class AtomicReferenceArrayAssert<T>
   // in order to avoid compiler warning in user code
   protected AtomicReferenceArrayAssert<T> satisfiesExactlyInAnyOrderForProxy(Consumer<? super T>[] requirements) {
     iterables.assertSatisfiesExactlyInAnyOrder(info, newArrayList(array), requirements);
+    return myself;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> satisfiesOnlyOnce(Consumer<? super T> requirements) {
+    return satisfiesOnlyOnceForProxy(requirements);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public AtomicReferenceArrayAssert<T> satisfiesOnlyOnce(ThrowingConsumer<? super T> requirements) {
+    return satisfiesOnlyOnceForProxy(requirements);
+  }
+
+  // This method is protected in order to be proxied for SoftAssertions / Assumptions.
+  // The public method for it (the one not ending with "ForProxy") is marked as final and annotated with @SafeVarargs
+  // in order to avoid compiler warning in user code
+  protected AtomicReferenceArrayAssert<T> satisfiesOnlyOnceForProxy(Consumer<? super T> requirements) {
+    iterables.assertSatisfiesOnlyOnce(info, newArrayList(array), requirements);
     return myself;
   }
 

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -3822,13 +3822,12 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link Consumer}.
-   *
+   * Verifies that there is exactly one element of the {@link AtomicReferenceArray} under test that satisfies the {@link Consumer}.
+   * <p>
    * Examples:
    * <pre><code class='java'> AtomicReferenceArray&lt;String&gt; starWarsCharacterNames = new AtomicReferenceArray&lt;&gt;(new String[] {"Luke", "Leia", "Yoda"});
    *
    * // these assertions succeed:
-   *
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
    *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
@@ -3851,13 +3850,12 @@ public class AtomicReferenceArrayAssert<T>
   }
 
   /**
-   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link ThrowingConsumer}.
-   *
+   * Verifies that there is exactly one element of the {@link AtomicReferenceArray} under test that satisfies the {@link ThrowingConsumer}.
+   * <p>
    * Examples:
    * <pre><code class='java'> AtomicReferenceArray&lt;String&gt; starWarsCharacterNames = new AtomicReferenceArray&lt;&gt;(new String[] {"Luke", "Leia", "Yoda"});
    *
    * // these assertions succeed:
-   *
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
    *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"

--- a/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
+++ b/src/main/java/org/assertj/core/api/AtomicReferenceArrayAssert.java
@@ -3829,7 +3829,7 @@ public class AtomicReferenceArrayAssert<T>
    *
    * // these assertions succeed:
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
-   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *								                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
    *
    * // this assertion fails because the requirements are satisfied two times
@@ -3857,7 +3857,7 @@ public class AtomicReferenceArrayAssert<T>
    *
    * // these assertions succeed:
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
-   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *								                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
    *
    * // this assertion fails because the requirements are satisfied two times

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -1557,7 +1557,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    *
    * // these assertions succeed:
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
-   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *								                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
    *
    * // this assertion fails because the requirements are satisfied two times
@@ -1583,7 +1583,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    *
    * // these assertions succeed:
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
-   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *								                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
    *
    * // this assertion fails because the requirements are satisfied two times

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -1571,7 +1571,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @return this assertion object.
    * @throws NullPointerException if the given requirements are {@code null}.
    * @throws AssertionError if the requirements are not satisfied only once
-   * @since 3.x.x
+   * @since 3.24.0
    */
   @SuppressWarnings("unchecked")
   SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements);
@@ -1599,7 +1599,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @throws NullPointerException if the given requirements are {@code null}.
    * @throws RuntimeException rethrown as is by the given {@link ThrowingConsumer} or wrapping any {@link Throwable}.    
    * @throws AssertionError if the requirements are not satisfied only once
-   * @since 3.x.x
+   * @since 3.24.0
    */
   @SuppressWarnings("unchecked")
   SELF satisfiesOnlyOnce(ThrowingConsumer<? super ELEMENT> requirements);

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -1550,20 +1550,55 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
   SELF satisfiesExactlyInAnyOrder(ThrowingConsumer<? super ELEMENT>... allRequirements);
 
   /**
+   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link Consumer}.
    *
-   * @param requirements
-   * @return {@code this} object.
-   * 
+   * Examples:
+   * <pre><code class='java'> List&lt;String&gt; starWarsCharacterNames = list("Luke", "Leia", "Yoda");
+   *
+   * // these assertions succeed:
+   *
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
+   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
+   *
+   * // this assertion fails because the requirements are satisfied two times
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("a")); // matches "Leia" and "Yoda"
+   *
+   * // this assertion fails because no element contains "Han"
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Han"));</code></pre>
+   *
+   * @param requirements the {@link Consumer} that is expected to be satisfied only once by the elements of the given {@code Iterable}.
+   * @return this assertion object.
+   * @throws NullPointerException if the given requirements are {@code null}.
+   * @throws AssertionError if the requirements are not satisfied only once
    * @since 3.x.x
    */
   @SuppressWarnings("unchecked")
   SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements);
 
   /**
+   * Verifies that there is exactly one element of the iterable elements that satisfies the {@link ThrowingConsumer}.
    *
-   * @param requirements
-   * @return {@code this} object.
-   * 
+   * Examples:
+   * <pre><code class='java'> List&lt;String&gt; starWarsCharacterNames = list("Luke", "Leia", "Yoda");
+   *
+   * // these assertions succeed:
+   *
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
+   *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
+   *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
+   *
+   * // this assertion fails because the requirements are satisfied two times
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("a")); // matches "Leia" and "Yoda"
+   *
+   * // this assertion fails because no element contains "Han"
+   * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Han"));</code></pre>
+   *
+   * @param requirements the {@link ThrowingConsumer} that is expected to be satisfied only once by the elements of the given {@code Iterable}.
+   * @return this assertion object.
+   * @throws NullPointerException if the given requirements are {@code null}.
+   * @throws RuntimeException rethrown as is by the given {@link ThrowingConsumer} or wrapping any {@link Throwable}.    
+   * @throws AssertionError if the requirements are not satisfied only once
    * @since 3.x.x
    */
   @SuppressWarnings("unchecked")

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -949,7 +949,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @since 3.5.0
    */
   SELF hasOnlyOneElementSatisfying(Consumer<? super ELEMENT> elementAssertions);
-  
+
   /**
    * Verifies that all elements of the actual group are instances of the given types.
    * <p>
@@ -1348,7 +1348,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @since 3.21.0
    */
   SELF allSatisfy(ThrowingConsumer<? super ELEMENT> requirements);
-  
+
   /**
    * Verifies that each element satisfies the requirements corresponding to its index, so the first element must satisfy the
    * first requirements, the second element the second requirements etc...
@@ -1391,7 +1391,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    */
   @SuppressWarnings("unchecked")
   SELF satisfiesExactly(Consumer<? super ELEMENT>... allRequirements);
-  
+
   /**
    * Verifies that each element satisfies the requirements corresponding to its index, so the first element must satisfy the
    * first requirements, the second element the second requirements etc...
@@ -1494,7 +1494,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    */
   @SuppressWarnings("unchecked")
   SELF satisfiesExactlyInAnyOrder(Consumer<? super ELEMENT>... allRequirements);
-  
+
   /**
    * Verifies that at least one combination of iterable elements exists that satisfies the {@link ThrowingConsumer}s in order (there must be as
    * many consumers as iterable elements and once a consumer is matched it cannot be reused to match other elements).
@@ -1548,6 +1548,26 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    */
   @SuppressWarnings("unchecked")
   SELF satisfiesExactlyInAnyOrder(ThrowingConsumer<? super ELEMENT>... allRequirements);
+
+  /**
+   *
+   * @param requirements
+   * @return {@code this} object.
+   * 
+   * @since 3.x.x
+   */
+  @SuppressWarnings("unchecked")
+  SELF satisfiesOnlyOnce(Consumer<? super ELEMENT> requirements);
+
+  /**
+   *
+   * @param requirements
+   * @return {@code this} object.
+   * 
+   * @since 3.x.x
+   */
+  @SuppressWarnings("unchecked")
+  SELF satisfiesOnlyOnce(ThrowingConsumer<? super ELEMENT> requirements);
 
   /**
    * Verifies whether any elements match the provided {@link Predicate}.
@@ -1631,7 +1651,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @since 3.21.0
    */
   SELF anySatisfy(ThrowingConsumer<? super ELEMENT> requirements);
-  
+
   /**
    * Verifies that no elements satisfy the given restrictions expressed as a {@link Consumer}.
    * <p>
@@ -1685,7 +1705,7 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
    * @since 3.21.0
    */
   SELF noneSatisfy(ThrowingConsumer<? super ELEMENT> restrictions);
-  
+
   /**
    * Verifies that the actual {@link Iterable} contains at least one of the given values.
    * <p>

--- a/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
+++ b/src/main/java/org/assertj/core/api/ObjectEnumerableAssert.java
@@ -1551,12 +1551,11 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
 
   /**
    * Verifies that there is exactly one element of the iterable elements that satisfies the {@link Consumer}.
-   *
+   * <p>
    * Examples:
    * <pre><code class='java'> List&lt;String&gt; starWarsCharacterNames = list("Luke", "Leia", "Yoda");
    *
    * // these assertions succeed:
-   *
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
    *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"
@@ -1578,12 +1577,11 @@ public interface ObjectEnumerableAssert<SELF extends ObjectEnumerableAssert<SELF
 
   /**
    * Verifies that there is exactly one element of the iterable elements that satisfies the {@link ThrowingConsumer}.
-   *
+   * <p>
    * Examples:
    * <pre><code class='java'> List&lt;String&gt; starWarsCharacterNames = list("Luke", "Leia", "Yoda");
    *
    * // these assertions succeed:
-   *
    * assertThat(starWarsCharacterNames).satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Y")) // matches only "Yoda"
    *								   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Lu")) // matches only "Luke"
    *                                   .satisfiesOnlyOnce(name -&gt; assertThat(name).contains("Le")); // matches only "Leia"

--- a/src/main/java/org/assertj/core/error/ShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/ShouldSatisfy.java
@@ -27,8 +27,6 @@ public class ShouldSatisfy extends BasicErrorMessageFactory {
   public static final String CONDITION_SHOULD_BE_SATISFIED = "%nExpecting actual:%n  %s%nto satisfy:%n  %s";
   @VisibleForTesting
   public static final String CONSUMERS_SHOULD_BE_SATISFIED_IN_ANY_ORDER = "%nExpecting actual:%n  %s%nto satisfy all the consumers in any order.";
-  @VisibleForTesting
-  public static final String CONSUMERS_SHOULD_NOT_BE_NULL = "The Consumer<? super E>... expressing the assertions consumers must not be null";
 
   public static <T> ErrorMessageFactory shouldSatisfy(T actual, Condition<? super T> condition) {
     return new ShouldSatisfy(actual, condition);

--- a/src/main/java/org/assertj/core/error/ShouldSatisfy.java
+++ b/src/main/java/org/assertj/core/error/ShouldSatisfy.java
@@ -27,6 +27,8 @@ public class ShouldSatisfy extends BasicErrorMessageFactory {
   public static final String CONDITION_SHOULD_BE_SATISFIED = "%nExpecting actual:%n  %s%nto satisfy:%n  %s";
   @VisibleForTesting
   public static final String CONSUMERS_SHOULD_BE_SATISFIED_IN_ANY_ORDER = "%nExpecting actual:%n  %s%nto satisfy all the consumers in any order.";
+  @VisibleForTesting
+  public static final String CONSUMERS_SHOULD_NOT_BE_NULL = "The Consumer<? super E>... expressing the assertions consumers must not be null";
 
   public static <T> ErrorMessageFactory shouldSatisfy(T actual, Condition<? super T> condition) {
     return new ShouldSatisfy(actual, condition);

--- a/src/main/java/org/assertj/core/error/ShouldSatisfyOnlyOnce.java
+++ b/src/main/java/org/assertj/core/error/ShouldSatisfyOnlyOnce.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.error;
 
+import java.util.List;
+
 import org.assertj.core.util.VisibleForTesting;
 
 /**
@@ -20,21 +22,32 @@ import org.assertj.core.util.VisibleForTesting;
 public class ShouldSatisfyOnlyOnce extends BasicErrorMessageFactory {
 
   @VisibleForTesting
-  public static final String REQUIREMENTS_SHOULD_BE_SATISFIED_ONLY_ONCE = "%nExpecting actual:%n  %s%nto satisfy the requirements only once but it did %s times";
+  public static final String NO_ELEMENT_SATISFIED_REQUIREMENTS = "%nExpecting exactly one element of actual:%n %s%nto satisfy the requirements but none did";
+
+  @VisibleForTesting
+  public static final String MORE_THAN_ONE_ELEMENT_SATISFIED_REQUIREMENTS = "%nExpecting exactly one element of actual:%n %s%nto satisfy the requirements but these %s elements did:%n %s";
 
   /**
    * Creates a new <code>{@link ShouldSatisfyOnlyOnce}</code>.
    *
    * @param <E> the iterable elements type.
    * @param actual the actual iterable in the failed assertion.
-   * @param countOfSatisfactions the count of times that the requirements were satisfied
+   * @param satisfiedElements the elements which satisfied the requirement
    * @return the created {@link ErrorMessageFactory}.
    */
-  public static <E> ErrorMessageFactory shouldSatisfyOnlyOnce(Iterable<E> actual, int countOfSatisfactions) {
-    return new ShouldSatisfyOnlyOnce(actual, countOfSatisfactions);
+  public static <E> ErrorMessageFactory shouldSatisfyOnlyOnce(Iterable<? extends E> actual,
+                                                              List<? extends E> satisfiedElements) {
+    if (satisfiedElements.isEmpty()) {
+      return new ShouldSatisfyOnlyOnce(actual);
+    }
+    return new ShouldSatisfyOnlyOnce(actual, satisfiedElements);
   }
 
-  private ShouldSatisfyOnlyOnce(Iterable<?> actual, int countOfSatisfactions) {
-    super(REQUIREMENTS_SHOULD_BE_SATISFIED_ONLY_ONCE, actual, countOfSatisfactions);
+  private ShouldSatisfyOnlyOnce(Iterable<?> actual) {
+    super(NO_ELEMENT_SATISFIED_REQUIREMENTS, actual);
+  }
+
+  private ShouldSatisfyOnlyOnce(Iterable<?> actual, List<?> satisfiedElements) {
+    super(MORE_THAN_ONE_ELEMENT_SATISFIED_REQUIREMENTS, actual, satisfiedElements.size(), satisfiedElements);
   }
 }

--- a/src/main/java/org/assertj/core/error/ShouldSatisfyOnlyOnce.java
+++ b/src/main/java/org/assertj/core/error/ShouldSatisfyOnlyOnce.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import org.assertj.core.util.VisibleForTesting;
+
+/**
+ * Creates an error message indicating that an assertion that verifies that requirements are not satisfied only once.
+ */
+public class ShouldSatisfyOnlyOnce extends BasicErrorMessageFactory {
+
+  @VisibleForTesting
+  public static final String REQUIREMENTS_SHOULD_BE_SATISFIED_ONLY_ONCE = "%nExpecting actual:%n  %s%nto satisfy the requirements only once but it did %s times";
+
+  /**
+   * Creates a new <code>{@link ShouldSatisfyOnlyOnce}</code>.
+   *
+   * @param <E> the iterable elements type.
+   * @param actual the actual iterable in the failed assertion.
+   * @param countOfSatisfactions the count of times that the requirements were satisfied
+   * @return the created {@link ErrorMessageFactory}.
+   */
+  public static <E> ErrorMessageFactory shouldSatisfyOnlyOnce(Iterable<E> actual, int countOfSatisfactions) {
+    return new ShouldSatisfyOnlyOnce(actual, countOfSatisfactions);
+  }
+
+  private ShouldSatisfyOnlyOnce(Iterable<?> actual, int countOfSatisfactions) {
+    super(REQUIREMENTS_SHOULD_BE_SATISFIED_ONLY_ONCE, actual, countOfSatisfactions);
+  }
+}

--- a/src/main/java/org/assertj/core/internal/Iterables.java
+++ b/src/main/java/org/assertj/core/internal/Iterables.java
@@ -1211,12 +1211,12 @@ public class Iterables {
     assertNotNull(info, actual);
     requireNonNull(requirements, "The Consumer<? super E> expressing the requirements must not be null");
 
-    long countOfSatisfactions = stream(actual)
-                                              .filter(byPassingAssertions(requirements))
-                                              .count();
+    List<? extends E> satisfiedElements = stream(actual)
+                                                        .filter(byPassingAssertions(requirements))
+                                                        .collect(toList());
 
-    if (countOfSatisfactions != 1) {
-      throw failures.failure(info, shouldSatisfyOnlyOnce(actual, Math.toIntExact(countOfSatisfactions)));
+    if (satisfiedElements.size() != 1) {
+      throw failures.failure(info, shouldSatisfyOnlyOnce(actual, satisfiedElements));
     }
 
   }

--- a/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/BDDSoftAssertionsTest.java
@@ -1199,9 +1199,12 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .as("satisfiesExactlyInAnyOrder")
           .satisfiesExactlyInAnyOrder(name -> assertThat(name).isNull(),
                                       name -> assertThat(name).isNotNull());
+    softly.then(names)
+          .as("satisfiesOnlyOnce")
+          .satisfiesOnlyOnce(name -> assertThat(name).isNull());
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(42);
+    assertThat(errorsCollected).hasSize(43);
     assertThat(errorsCollected.get(0)).hasMessageContaining("gandalf");
     assertThat(errorsCollected.get(1)).hasMessageContaining("frodo");
     assertThat(errorsCollected.get(2)).hasMessageContaining("foo")
@@ -1245,6 +1248,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(39)).hasMessageContaining("map with multiple functions");
     assertThat(errorsCollected.get(40)).hasMessageContaining("satisfiesExactly");
     assertThat(errorsCollected.get(41)).hasMessageContaining("satisfiesExactlyInAnyOrder");
+    assertThat(errorsCollected.get(42)).hasMessageContaining("satisfiesOnlyOnce");
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught
@@ -1400,9 +1404,12 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
           .as("satisfiesExactlyInAnyOrder")
           .satisfiesExactlyInAnyOrder(name -> assertThat(name).isNull(),
                                       name -> assertThat(name).isNotNull());
+    softly.then(names)
+          .as("satisfiesOnlyOnce")
+          .satisfiesOnlyOnce(name -> assertThat(name).isNull());
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(42);
+    assertThat(errorsCollected).hasSize(43);
     assertThat(errorsCollected.get(0)).hasMessageContaining("gandalf");
     assertThat(errorsCollected.get(1)).hasMessageContaining("frodo");
     assertThat(errorsCollected.get(2)).hasMessageContaining("foo")
@@ -1446,6 +1453,7 @@ class BDDSoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(39)).hasMessageContaining("map with multiple functions");
     assertThat(errorsCollected.get(40)).hasMessageContaining("satisfiesExactly");
     assertThat(errorsCollected.get(41)).hasMessageContaining("satisfiesExactlyInAnyOrder");
+    assertThat(errorsCollected.get(42)).hasMessageContaining("satisfiesOnlyOnce");
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught

--- a/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
+++ b/src/test/java/org/assertj/core/api/SoftAssertionsTest.java
@@ -1484,9 +1484,12 @@ class SoftAssertionsTest extends BaseAssertionsTest {
           .as("satisfiesExactlyInAnyOrder")
           .satisfiesExactlyInAnyOrder(name -> assertThat(name).isNull(),
                                       name -> assertThat(name).isNotNull());
+    softly.assertThat(names)
+          .as("satisfiesOnlyOnce")
+          .satisfiesOnlyOnce(name -> assertThat(name).isNull());
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(42);
+    assertThat(errorsCollected).hasSize(43);
     assertThat(errorsCollected.get(0)).hasMessage("[extracting(throwingFirstNameFunction)] error message");
     assertThat(errorsCollected.get(1)).hasMessage("[extracting(throwingFirstNameFunction)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[extracting(\"last\")] error message");
@@ -1529,6 +1532,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(39)).hasMessageContaining("map with multiple functions");
     assertThat(errorsCollected.get(40)).hasMessageContaining("satisfiesExactly");
     assertThat(errorsCollected.get(41)).hasMessageContaining("satisfiesExactlyInAnyOrder");
+    assertThat(errorsCollected.get(42)).hasMessageContaining("satisfiesOnlyOnce");
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught
@@ -1720,9 +1724,12 @@ class SoftAssertionsTest extends BaseAssertionsTest {
           .as("satisfiesExactlyInAnyOrder")
           .satisfiesExactlyInAnyOrder(name -> assertThat(name).isNull(),
                                       name -> assertThat(name).isNotNull());
+    softly.assertThat(names)
+          .as("satisfiesOnlyOnce")
+          .satisfiesOnlyOnce(name -> assertThat(name).isNull());
     // THEN
     List<Throwable> errorsCollected = softly.errorsCollected();
-    assertThat(errorsCollected).hasSize(42);
+    assertThat(errorsCollected).hasSize(43);
     assertThat(errorsCollected.get(0)).hasMessage("[extracting(throwingFirstNameFunction)] error message");
     assertThat(errorsCollected.get(1)).hasMessage("[extracting(throwingFirstNameFunction)] error message");
     assertThat(errorsCollected.get(2)).hasMessage("[extracting(\"last\")] error message");
@@ -1765,6 +1772,7 @@ class SoftAssertionsTest extends BaseAssertionsTest {
     assertThat(errorsCollected.get(39)).hasMessageContaining("map with multiple functions");
     assertThat(errorsCollected.get(40)).hasMessageContaining("satisfiesExactly");
     assertThat(errorsCollected.get(41)).hasMessageContaining("satisfiesExactlyInAnyOrder");
+    assertThat(errorsCollected.get(42)).hasMessageContaining("satisfiesOnlyOnce");
   }
 
   // the test would fail if any method was not proxyable as the assertion error would not be softly caught

--- a/src/test/java/org/assertj/core/api/assumptions/Iterable_special_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/Iterable_special_assertion_methods_in_assumptions_Test.java
@@ -243,7 +243,10 @@ class Iterable_special_assertion_methods_in_assumptions_Test extends BaseAssumpt
                                       value -> assumeThat(value).satisfiesExactlyInAnyOrder(i -> assertThat(i).isEven(),
                                                                                             i -> assertThat(i).isOdd()),
                                       value -> assumeThat(value).satisfiesExactlyInAnyOrder(i -> assertThat(i).isOdd(),
-                                                                                            i -> assertThat(i).isOdd())));
+                                                                                            i -> assertThat(i).isOdd())),
+                     assumptionRunner(iterable(1, 2),
+                                      value -> assumeThat(value).satisfiesOnlyOnce(i -> assertThat(i).isEven()),
+                                      value -> assumeThat(value).satisfiesOnlyOnce(i -> assertThat(i).isGreaterThan(0))));
   }
 
 }

--- a/src/test/java/org/assertj/core/api/assumptions/List_special_assertion_methods_in_assumptions_Test.java
+++ b/src/test/java/org/assertj/core/api/assumptions/List_special_assertion_methods_in_assumptions_Test.java
@@ -236,7 +236,11 @@ class List_special_assertion_methods_in_assumptions_Test extends BaseAssumptions
                                       value -> assumeThat(value).satisfiesExactlyInAnyOrder(i -> assertThat(i).isEven(),
                                                                                             i -> assertThat(i).isOdd()),
                                       value -> assumeThat(value).satisfiesExactlyInAnyOrder(i -> assertThat(i).isOdd(),
-                                                                                            i -> assertThat(i).isOdd())));
+                                                                                            i -> assertThat(i).isOdd())),
+                     assumptionRunner(iterable(1, 2),
+                                      value -> assumeThat(value).satisfiesOnlyOnce(i -> assertThat(i).isEven()),
+                                      value -> assumeThat(value).satisfiesOnlyOnce(i -> assertThat(i).isGreaterThan(0))));
+
   }
 
 }

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_satisfiesOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_satisfiesOnlyOnce_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+import org.assertj.core.api.ThrowingConsumer;
+
+/**
+ * Tests for <code>{@link AtomicReferenceArrayAssert#satisfiesOnlyOnce(Consumer)}</code>.
+ *
+ * @author Stefan Bratanov
+ */
+class AtomicReferenceArrayAssert_satisfiesOnlyOnce_Test extends AtomicReferenceArrayAssertBaseTest {
+
+  private ThrowingConsumer<Object> requirements = element -> assertThat(element).isNotNull();
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> create_assertions() {
+    return new AtomicReferenceArrayAssert<>(atomicArrayOf(new Object()));
+  }
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method() {
+    return assertions.satisfiesOnlyOnce(requirements);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertSatisfiesOnlyOnce(info(), list(internalArray()), requirements);
+  }
+}

--- a/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test.java
+++ b/src/test/java/org/assertj/core/api/atomic/referencearray/AtomicReferenceArrayAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.atomic.referencearray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.ThrowingConsumerFactory.throwingConsumer;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.AtomicReferenceArrayAssert;
+import org.assertj.core.api.AtomicReferenceArrayAssertBaseTest;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link AtomicReferenceArrayAssert#satisfiesOnlyOnce(Consumer)}</code>.
+ *
+ * @author Stefan Bratanov
+ */
+class AtomicReferenceArrayAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test extends AtomicReferenceArrayAssertBaseTest {
+
+  private ThrowingConsumer<Object> requirements = element -> assertThat(element).isNotNull();
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> create_assertions() {
+    return new AtomicReferenceArrayAssert<>(atomicArrayOf(new Object()));
+  }
+
+  @Override
+  protected AtomicReferenceArrayAssert<Object> invoke_api_method() {
+    return assertions.satisfiesOnlyOnce(requirements);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertSatisfiesOnlyOnce(info(), list(internalArray()), requirements);
+  }
+
+  @Test
+  void should_rethrow_throwables_as_runtime_exceptions() {
+    // GIVEN
+    Throwable exception = new Throwable("boom!");
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(atomicArrayOf("foo")).satisfiesOnlyOnce(throwingConsumer(exception)));
+    // THEN
+    then(throwable).isInstanceOf(RuntimeException.class)
+                   .hasCauseReference(exception);
+  }
+
+  @Test
+  void should_propagate_RuntimeException_as_is() {
+    // GIVEN
+    RuntimeException runtimeException = new RuntimeException("boom!");
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(atomicArrayOf("foo")).satisfiesOnlyOnce(throwingConsumer(runtimeException)));
+    // THEN
+    then(throwable).isSameAs(runtimeException);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_satisfiesOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_satisfiesOnlyOnce_Test.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+
+/**
+ * Tests for <code>{@link org.assertj.core.api.AbstractIterableAssert#satisfiesOnlyOnce(Consumer)}</code>.
+ *
+ * @author Stefan Bratanov
+ */
+class IterableAssert_satisfiesOnlyOnce_Test extends IterableAssertBaseTest {
+
+  @SuppressWarnings("unchecked")
+  private final Consumer<Object> consumer = mock(Consumer.class);
+
+  @Override
+  protected ConcreteIterableAssert<Object> create_assertions() {
+    return new ConcreteIterableAssert<>(list(new Object()));
+  }
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.satisfiesOnlyOnce(consumer);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertSatisfiesOnlyOnce(getInfo(assertions), getActual(assertions), consumer);
+  }
+}

--- a/src/test/java/org/assertj/core/api/iterable/IterableAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test.java
+++ b/src/test/java/org/assertj/core/api/iterable/IterableAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.iterable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.ThrowingConsumerFactory.throwingConsumer;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ConcreteIterableAssert;
+import org.assertj.core.api.IterableAssertBaseTest;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+
+class IterableAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test extends IterableAssertBaseTest {
+
+  private ThrowingConsumer<Object> requirements = element -> assertThat(element).isNotNull();
+
+  @Override
+  protected ConcreteIterableAssert<Object> invoke_api_method() {
+    return assertions.satisfiesOnlyOnce(requirements);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertSatisfiesOnlyOnce(getInfo(assertions), getActual(assertions), requirements);
+  }
+
+  @Test
+  void should_rethrow_throwables_as_runtime_exceptions() {
+    // GIVEN
+    Exception exception = new Exception("boom!");
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(list("foo")).satisfiesOnlyOnce(throwingConsumer(exception)));
+    // THEN
+    then(throwable).isInstanceOf(RuntimeException.class)
+                   .hasCauseReference(exception);
+  }
+
+  @Test
+  void should_propagate_RuntimeException_as_is() {
+    // GIVEN
+    RuntimeException runtimeException = new RuntimeException("boom!");
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(list("foo")).satisfiesOnlyOnce(throwingConsumer(runtimeException)));
+    // THEN
+    then(throwable).isSameAs(runtimeException);
+  }
+
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_satisfiesOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_satisfiesOnlyOnce_Test.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.Lists.list;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+
+/**
+ * Tests for <code>{@link ObjectArrayAssert#satisfiesOnlyOnce(Consumer)}</code>.
+ *
+ * @author Stefan Bratanov
+ */
+class ObjectArrayAssert_satisfiesOnlyOnce_Test extends ObjectArrayAssertBaseTest {
+
+  private final Consumer<Object> consumer = element -> assertThat(element).isNotNull();
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.satisfiesOnlyOnce(consumer);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertSatisfiesOnlyOnce(getInfo(assertions), list(getActual(assertions)), consumer);
+  }
+}

--- a/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test.java
+++ b/src/test/java/org/assertj/core/api/objectarray/ObjectArrayAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.api.objectarray;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.util.Arrays.array;
+import static org.assertj.core.util.Lists.list;
+import static org.assertj.core.util.ThrowingConsumerFactory.throwingConsumer;
+import static org.mockito.Mockito.verify;
+
+import org.assertj.core.api.ObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssertBaseTest;
+import org.assertj.core.api.ThrowingConsumer;
+import org.junit.jupiter.api.Test;
+
+class ObjectArrayAssert_satisfiesOnlyOnce_with_ThrowingConsumer_Test extends ObjectArrayAssertBaseTest {
+
+  private ThrowingConsumer<Object> requirements = element -> assertThat(element).isNotNull();
+
+  @Override
+  protected ObjectArrayAssert<Object> invoke_api_method() {
+    return assertions.satisfiesOnlyOnce(requirements);
+  }
+
+  @Override
+  protected void verify_internal_effects() {
+    verify(iterables).assertSatisfiesOnlyOnce(getInfo(assertions), list(getActual(assertions)), requirements);
+  }
+
+  @Test
+  void should_rethrow_throwables_as_runtime_exceptions() {
+    // GIVEN
+    Throwable exception = new Throwable("boom!");
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(array("foo")).satisfiesOnlyOnce(throwingConsumer(exception)));
+    // THEN
+    then(throwable).isInstanceOf(RuntimeException.class)
+                   .hasCauseReference(exception);
+  }
+
+  @Test
+  void should_propagate_RuntimeException_as_is() {
+    // GIVEN
+    RuntimeException runtimeException = new RuntimeException("boom!");
+    // WHEN
+    Throwable throwable = catchThrowable(() -> assertThat(array("foo")).satisfiesOnlyOnce(throwingConsumer(runtimeException)));
+    // THEN
+    then(throwable).isSameAs(runtimeException);
+  }
+
+}

--- a/src/test/java/org/assertj/core/error/ShouldSatisfyOnlyOnce_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldSatisfyOnlyOnce_create_Test.java
@@ -30,16 +30,30 @@ import org.junit.jupiter.api.Test;
 class ShouldSatisfyOnlyOnce_create_Test {
 
   @Test
-  void should_create_error_message_with_the_actual_count_of_satisfactions() {
+  void should_create_error_message_when_no_elements_were_satisfied() {
     // GIVEN
-    ErrorMessageFactory factory = shouldSatisfyOnlyOnce(List.of("Yoda", "Luke"), 2);
+    ErrorMessageFactory factory = shouldSatisfyOnlyOnce(List.of("Luke", "Leia", "Yoda"), List.of());
     // WHEN
     String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
     // THEN
     then(message).isEqualTo(format("[Test] %n"
-                                   + "Expecting actual:%n"
-                                   + "  [\"Yoda\", \"Luke\"]%n"
-                                   + "to satisfy the requirements only once but it did 2 times"));
+                                   + "Expecting exactly one element of actual:%n"
+                                   + " [\"Luke\", \"Leia\", \"Yoda\"]%n"
+                                   + "to satisfy the requirements but none did"));
+  }
+
+  @Test
+  void should_create_error_message_when_more_than_one_element_was_satisfied() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldSatisfyOnlyOnce(List.of("Luke", "Leia", "Yoda"), List.of("Luke", "Leia"));
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting exactly one element of actual:%n"
+                                   + " [\"Luke\", \"Leia\", \"Yoda\"]%n"
+                                   + "to satisfy the requirements but these 2 elements did:%n"
+                                   + " [\"Luke\", \"Leia\"]"));
   }
 
 }

--- a/src/test/java/org/assertj/core/error/ShouldSatisfyOnlyOnce_create_Test.java
+++ b/src/test/java/org/assertj/core/error/ShouldSatisfyOnlyOnce_create_Test.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.error;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.error.ShouldSatisfyOnlyOnce.shouldSatisfyOnlyOnce;
+import static org.assertj.core.presentation.StandardRepresentation.STANDARD_REPRESENTATION;
+
+import org.assertj.core.description.Description;
+import org.assertj.core.description.TextDescription;
+import org.assertj.core.test.jdk11.Jdk11.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link ShouldSatisfyOnlyOnce#create(Description)}</code>.
+ */
+@DisplayName("ShouldSatisfyOnlyOnce create")
+class ShouldSatisfyOnlyOnce_create_Test {
+
+  @Test
+  void should_create_error_message_with_the_actual_count_of_satisfactions() {
+    // GIVEN
+    ErrorMessageFactory factory = shouldSatisfyOnlyOnce(List.of("Yoda", "Luke"), 2);
+    // WHEN
+    String message = factory.create(new TextDescription("Test"), STANDARD_REPRESENTATION);
+    // THEN
+    then(message).isEqualTo(format("[Test] %n"
+                                   + "Expecting actual:%n"
+                                   + "  [\"Yoda\", \"Luke\"]%n"
+                                   + "to satisfy the requirements only once but it did 2 times"));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertSatisfiesOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertSatisfiesOnlyOnce_Test.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * Copyright 2012-2022 the original author or authors.
+ */
+package org.assertj.core.internal.iterables;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.error.ShouldSatisfyOnlyOnce.shouldSatisfyOnlyOnce;
+import static org.assertj.core.test.TestData.someInfo;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Consumer;
+
+import org.assertj.core.api.AssertionInfo;
+import org.assertj.core.internal.Iterables;
+import org.assertj.core.internal.IterablesBaseTest;
+import org.assertj.core.test.jdk11.Jdk11.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for <code>{@link Iterables#assertSatisfiesOnlyOnce(AssertionInfo, Iterable, Consumer)}</code>.
+ *
+ * @author Stefan Bratanov
+ */
+class Iterables_assertSatisfiesOnlyOnce_Test extends IterablesBaseTest {
+
+  private static final Consumer<String> REQUIREMENTS = value -> assertThat(value).isEqualTo("Luke");
+
+  @Test
+  void should_pass_if_actual_satisfies_requirements_only_once() {
+    iterables.assertSatisfiesOnlyOnce(someInfo(), actual, REQUIREMENTS);
+  }
+
+  @Test
+  void should_fail_if_actual_satisfies_requirements_more_than_once() {
+    actual.add("Luke");
+    Throwable error = catchThrowable(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), actual, REQUIREMENTS));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldSatisfyOnlyOnce(actual, 2));
+  }
+
+  @Test
+  void should_fail_if_actual_does_not_satisfy_requirements() {
+    Throwable error = catchThrowable(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), actual,
+                                                                             value -> assertThat(value).isEqualTo("Vader")));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldSatisfyOnlyOnce(actual, 0));
+  }
+
+  @Test
+  void should_fail_if_actual_is_empty() {
+    Throwable error = catchThrowable(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), List.of(),
+                                                                             REQUIREMENTS));
+
+    assertThat(error).isInstanceOf(AssertionError.class);
+    verify(failures).failure(info,
+                             shouldSatisfyOnlyOnce(List.of(), 0));
+  }
+
+}

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertSatisfiesOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertSatisfiesOnlyOnce_Test.java
@@ -14,13 +14,11 @@ package org.assertj.core.internal.iterables;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
-import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldSatisfyOnlyOnce.shouldSatisfyOnlyOnce;
 import static org.assertj.core.test.TestData.someInfo;
 import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
 import static org.assertj.core.util.FailureMessages.actualIsNull;
-import static org.mockito.Mockito.verify;
 
 import java.util.function.Consumer;
 
@@ -46,42 +44,43 @@ class Iterables_assertSatisfiesOnlyOnce_Test extends IterablesBaseTest {
 
   @Test
   void should_fail_if_actual_satisfies_requirements_more_than_once() {
+    // GIVEN
     actual.add("Luke");
-    Throwable error = catchThrowable(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), actual, REQUIREMENTS));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info,
-                             shouldSatisfyOnlyOnce(actual, 2));
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), actual,
+                                                                                                 REQUIREMENTS));
+    // THEN
+    then(assertionError).hasMessage(shouldSatisfyOnlyOnce(actual, List.of("Luke", "Luke")).create());
   }
 
   @Test
   void should_fail_if_actual_does_not_satisfy_requirements() {
-    Throwable error = catchThrowable(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), actual,
-                                                                             value -> assertThat(value).isEqualTo("Vader")));
-
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info,
-                             shouldSatisfyOnlyOnce(actual, 0));
+    // GIVEN
+    Consumer<String> requirements = value -> assertThat(value).isEqualTo("Vader");
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), actual,
+                                                                                                 requirements));
+    // THEN
+    then(assertionError).hasMessage(shouldSatisfyOnlyOnce(actual, List.of()).create());
   }
 
   @Test
   void should_fail_if_actual_is_empty() {
-    Throwable error = catchThrowable(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), List.of(),
-                                                                             REQUIREMENTS));
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> iterables.assertSatisfiesOnlyOnce(someInfo(), List.of(),
+                                                                                                 REQUIREMENTS));
 
-    assertThat(error).isInstanceOf(AssertionError.class);
-    verify(failures).failure(info,
-                             shouldSatisfyOnlyOnce(List.of(), 0));
+    // THEN
+    then(assertionError).hasMessage(shouldSatisfyOnlyOnce(List.of(), List.of()).create());
   }
 
   @Test
   void should_fail_if_actual_is_null() {
     // GIVEN
     actual = null;
-    Consumer<String> consumer = s -> assertThat(s).hasSize(4);
-
+    Consumer<String> requirements = s -> assertThat(s).hasSize(4);
     // WHEN
-    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).satisfiesOnlyOnce(consumer));
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).satisfiesOnlyOnce(requirements));
     // THEN
     then(assertionError).hasMessage(actualIsNull());
   }
@@ -89,9 +88,9 @@ class Iterables_assertSatisfiesOnlyOnce_Test extends IterablesBaseTest {
   @Test
   void should_throw_error_if_consumer_is_null() {
     // GIVEN
-    Consumer<String> consumer = null;
+    Consumer<String> requirements = null;
     // WHEN/THEN
-    assertThatNullPointerException().isThrownBy(() -> assertThat(actual).satisfiesOnlyOnce(consumer))
+    assertThatNullPointerException().isThrownBy(() -> assertThat(actual).satisfiesOnlyOnce(requirements))
                                     .withMessage("The Consumer<? super E> expressing the requirements must not be null");
   }
 

--- a/src/test/java/org/assertj/core/internal/iterables/Iterables_assertSatisfiesOnlyOnce_Test.java
+++ b/src/test/java/org/assertj/core/internal/iterables/Iterables_assertSatisfiesOnlyOnce_Test.java
@@ -13,9 +13,13 @@
 package org.assertj.core.internal.iterables;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.error.ShouldSatisfyOnlyOnce.shouldSatisfyOnlyOnce;
 import static org.assertj.core.test.TestData.someInfo;
+import static org.assertj.core.util.AssertionsUtil.expectAssertionError;
+import static org.assertj.core.util.FailureMessages.actualIsNull;
 import static org.mockito.Mockito.verify;
 
 import java.util.function.Consumer;
@@ -68,6 +72,27 @@ class Iterables_assertSatisfiesOnlyOnce_Test extends IterablesBaseTest {
     assertThat(error).isInstanceOf(AssertionError.class);
     verify(failures).failure(info,
                              shouldSatisfyOnlyOnce(List.of(), 0));
+  }
+
+  @Test
+  void should_fail_if_actual_is_null() {
+    // GIVEN
+    actual = null;
+    Consumer<String> consumer = s -> assertThat(s).hasSize(4);
+
+    // WHEN
+    AssertionError assertionError = expectAssertionError(() -> assertThat(actual).satisfiesOnlyOnce(consumer));
+    // THEN
+    then(assertionError).hasMessage(actualIsNull());
+  }
+
+  @Test
+  void should_throw_error_if_consumer_is_null() {
+    // GIVEN
+    Consumer<String> consumer = null;
+    // WHEN/THEN
+    assertThatNullPointerException().isThrownBy(() -> assertThat(actual).satisfiesOnlyOnce(consumer))
+                                    .withMessage("The Consumer<? super E> expressing the requirements must not be null");
   }
 
 }


### PR DESCRIPTION
#### Check List:
* Fixes #2675 
* Unit tests : YES
* Javadoc with a code example (on API only) : YES
* PR meets the [contributing guidelines](https://github.com/assertj/assertj-core/blob/main/CONTRIBUTING.md)

I wasn't sure which version to add for `@since`