### PR TITLE
Issue 2701: add withThrowableThat

### DIFF
--- a/src/main/java/org/assertj/core/api/WithThrowable.java
+++ b/src/main/java/org/assertj/core/api/WithThrowable.java
@@ -35,6 +35,7 @@ public class WithThrowable {
    * Returns a {@link ThrowableAssertAlternative} to chain assertions on the underlying throwable.
    * @return a {@link ThrowableAssertAlternative} built with underlying throwable.
    */
+  @CheckReturnValue
   public ThrowableAssertAlternative<?> withThrowableThat() {
     return new ThrowableAssertAlternative<>(throwable);
   }

--- a/src/main/java/org/assertj/core/api/WithThrowable.java
+++ b/src/main/java/org/assertj/core/api/WithThrowable.java
@@ -22,11 +22,21 @@ public class WithThrowable {
   /**
    * Checks that the underlying throwable is of the given type and returns a {@link ThrowableAssertAlternative} to chain
    * further assertions on the underlying throwable.
+   * <p>
+   * Equivalent to {@code withThrowableThat().isInstanceOf(type)}
    * @param type the expected {@link Throwable} type
    * @return a {@link ThrowableAssertAlternative} built with underlying throwable.
    */
   public ThrowableAssertAlternative<?> withThrowableOfType(Class<? extends Throwable> type) {
-    return new ThrowableAssertAlternative<>(throwable).isInstanceOf(type);
+    return withThrowableThat().isInstanceOf(type);
+  }
+
+  /**
+   * Returns a {@link ThrowableAssertAlternative} to chain assertions on the underlying throwable.
+   * @return a {@link ThrowableAssertAlternative} built with underlying throwable.
+   */
+  public ThrowableAssertAlternative<?> withThrowableThat() {
+    return new ThrowableAssertAlternative<>(throwable);
   }
 
 }

--- a/src/main/java/org/assertj/core/api/WithThrowable.java
+++ b/src/main/java/org/assertj/core/api/WithThrowable.java
@@ -12,6 +12,8 @@
  */
 package org.assertj.core.api;
 
+import org.assertj.core.util.CheckReturnValue;
+
 public class WithThrowable {
   private final Throwable throwable;
 

--- a/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_failsWithin_Test.java
+++ b/src/test/java/org/assertj/core/api/future/CompletableFutureAssert_failsWithin_Test.java
@@ -62,7 +62,8 @@ class CompletableFutureAssert_failsWithin_Test extends AbstractFutureTest {
     CompletableFuture<Void> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(50, MILLISECONDS)
-                      .withThrowableOfType(TimeoutException.class)
+                      .withThrowableThat()
+                      .isInstanceOf(TimeoutException.class)
                       .withMessage(null);
   }
 
@@ -107,7 +108,8 @@ class CompletableFutureAssert_failsWithin_Test extends AbstractFutureTest {
                 .withThrowableOfType(ExecutionException.class)
                 .withMessageContaining("boom!");
     then(future).failsWithin(Duration.ofMillis(1))
-                .withThrowableOfType(ExecutionException.class)
+                .withThrowableThat()
+                .isInstanceOf(ExecutionException.class)
                 .withMessageContaining("boom!");
   }
 

--- a/src/test/java/org/assertj/core/api/future/FutureAssert_failsWithin_Test.java
+++ b/src/test/java/org/assertj/core/api/future/FutureAssert_failsWithin_Test.java
@@ -63,7 +63,8 @@ class FutureAssert_failsWithin_Test extends AbstractFutureTest {
     Future<String> future = futureCompletingAfter(ONE_SECOND, executorService);
     // WHEN/THEN
     assertThat(future).failsWithin(50, MILLISECONDS)
-                      .withThrowableOfType(TimeoutException.class)
+                      .withThrowableThat()
+                      .isInstanceOf(TimeoutException.class)
                       .withMessage(null);
   }
 
@@ -108,7 +109,8 @@ class FutureAssert_failsWithin_Test extends AbstractFutureTest {
                 .withThrowableOfType(ExecutionException.class)
                 .withMessageContaining("boom!");
     then(future).failsWithin(Duration.ofMillis(1))
-                .withThrowableOfType(ExecutionException.class)
+                .withThrowableThat()
+                .isInstanceOf(ExecutionException.class)
                 .withMessageContaining("boom!");
   }
 


### PR DESCRIPTION
For `AbstractFutureAssertfailsWithin(...)` and `AbstractCompletableFutureAssertfailsWithin(...)`, add a method `withThrowableThat()` to the result.

Also adjust the test cases to use this new method, in the same manner as `withThrowableOfType(...)` is tested.

Fixes #2701.